### PR TITLE
Refactored Relation, Table and Base

### DIFF
--- a/datajoint/Relation.py
+++ b/datajoint/Relation.py
@@ -2,14 +2,14 @@ import importlib
 import abc
 from types import ModuleType
 from . import DataJointError
-from .table import Table
+from .free_relation import FreeRelation
 import logging
 
 
 logger = logging.getLogger(__name__)
 
 
-class Base(Table, metaclass=abc.ABCMeta):
+class Base(FreeRelation, metaclass=abc.ABCMeta):
     """
     Base is a Table that implements data definition functions.
     It is an abstract class with the abstract property 'definition'.
@@ -104,7 +104,7 @@ class Base(Table, metaclass=abc.ABCMeta):
         try:
             ret = getattr(mod_obj, class_name)()
         except AttributeError:
-            ret = Table(conn=self.conn,
+            ret = FreeRelation(conn=self.conn,
                         dbname=self.conn.mod_to_db[mod_obj.__name__],
                         class_name=class_name)
         return ret

--- a/datajoint/Relation.py
+++ b/datajoint/Relation.py
@@ -9,17 +9,17 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class Base(FreeRelation, metaclass=abc.ABCMeta):
+class Relation(FreeRelation, metaclass=abc.ABCMeta):
     """
-    Base is a Table that implements data definition functions.
+    Relation is a Table that implements data definition functions.
     It is an abstract class with the abstract property 'definition'.
 
-    Example for a usage of Base::
+    Example for a usage of Relation::
 
         import datajoint as dj
 
 
-        class Subjects(dj.Base):
+        class Subjects(dj.Relation):
             definition = '''
             test1.Subjects (manual)                                    # Basic subject info
             subject_id            : int                                # unique subject id
@@ -91,7 +91,7 @@ class Base(FreeRelation, metaclass=abc.ABCMeta):
     def get_base(self, module_name, class_name):
         """
         Loads the base relation from the module.  If the base relation is not defined in
-        the module, then construct it using Base constructor.
+        the module, then construct it using Relation constructor.
 
         :param module_name: module name
         :param class_name: class name
@@ -119,9 +119,9 @@ class Base(FreeRelation, metaclass=abc.ABCMeta):
 
         The module_name resolution steps in the following order:
 
-        1. Global reference to a module of the same name defined in the module that contains this Base derivative.
+        1. Global reference to a module of the same name defined in the module that contains this Relation derivative.
            This is the recommended use case.
-        2. Module of the same name defined in the package containing this Base derivative. This will only look for the
+        2. Module of the same name defined in the package containing this Relation derivative. This will only look for the
            most immediate containing package (e.g. if this class is contained in package.subpackage.module, it will
            check within `package.subpackage` but not inside `package`).
         3. Globally accessible module with the same name.

--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -4,7 +4,7 @@ import os
 __author__ = "Dimitri Yatsenko, Edgar Walker, and Fabian Sinz at Baylor College of Medicine"
 __version__ = "0.2"
 __all__ = ['__author__', '__version__',
-           'Connection', 'Heading', 'Base', 'Not',
+           'Connection', 'Heading', 'Relation', 'Not',
            'AutoPopulate', 'conn', 'DataJointError', 'blob']
 
 
@@ -34,7 +34,7 @@ except FileNotFoundError:
 
 # ------------- flatten import hierarchy -------------------------
 from .connection import conn, Connection
-from .base import Base
+from .relation import Relation
 from .autopopulate import AutoPopulate
 from . import blob
-from .relational import Not
+from .relational_operand import Not

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -1,4 +1,4 @@
-from .relational import Relation
+from .relational_operand import RelationalOperand
 from . import DataJointError
 import pprint
 import abc
@@ -10,8 +10,8 @@ logger = logging.getLogger(__name__)
 
 class AutoPopulate(metaclass=abc.ABCMeta):
     """
-    AutoPopulate is a mixin class that adds the method populate() to a Base class.
-    Auto-populated relations must inherit from both Base and AutoPopulate,
+    AutoPopulate is a mixin class that adds the method populate() to a Relation class.
+    Auto-populated relations must inherit from both Relation and AutoPopulate,
     must define the property pop_rel, and must define the callback method make_tuples.
     """
 
@@ -40,7 +40,7 @@ class AutoPopulate(metaclass=abc.ABCMeta):
         rel.populate() will call rel.make_tuples(key) for every primary key in self.pop_rel
         for which there is not already a tuple in rel.
         """
-        if not isinstance(self.pop_rel, Relation):
+        if not isinstance(self.pop_rel, RelationalOperand):
             raise DataJointError('')
         self.conn.cancel_transaction()
 

--- a/datajoint/free_relation.py
+++ b/datajoint/free_relation.py
@@ -11,20 +11,20 @@ from .utils import from_camel_case
 logger = logging.getLogger(__name__)
 
 
-class Table(RelationalOperand):
+class FreeRelation(RelationalOperand):
     """
-    A Table object is a relation associated with a table.
-    A Table object provides insert and delete methods.
-    Table objects are only used internally and for debugging.
-    The table must already exist in the schema for its Table object to work.
+    A FreeRelation object is a relation associated with a table.
+    A FreeRelation object provides insert and delete methods.
+    FreeRelation objects are only used internally and for debugging.
+    The table must already exist in the schema for its FreeRelation object to work.
 
-    The table associated with an instance of Base is identified by its 'class name'.
+    The table associated with an instance of Relation is identified by its 'class name'.
     property, which is a string in CamelCase. The actual table name is obtained
     by converting className from CamelCase to underscore_separated_words and
     prefixing according to the table's role.
 
-    Base instances obtain their table's heading by looking it up in the connection
-    object. This ensures that Base instances contain the current table definition
+    Relation instances obtain their table's heading by looking it up in the connection
+    object. This ensures that Relation instances contain the current table definition
     even after tables are modified after the instance is created.
     """
 
@@ -62,7 +62,7 @@ class Table(RelationalOperand):
             self._declare()
             if not self.is_declared:
                 raise DataJointError(
-                    'Table could not be declared for %s' % self.class_name)
+                    'FreeRelation could not be declared for %s' % self.class_name)
 
     @staticmethod
     def _field_to_sql(field): #TODO move this into Attribute Tuple
@@ -360,7 +360,7 @@ class Table(RelationalOperand):
         m = re.match(r'`(\w+)`', module_name)
         if m:
             dbname = m.group(1)
-            return Table(self.conn, dbname, class_name)
+            return FreeRelation(self.conn, dbname, class_name)
         else:
             return None
 

--- a/datajoint/free_relation.py
+++ b/datajoint/free_relation.py
@@ -1,7 +1,7 @@
 import numpy as np
 import logging
 from . import DataJointError
-from .relational import Relation
+from .relational_operand import RelationalOperand
 from .blob import pack
 from .heading import Heading
 import re
@@ -11,7 +11,7 @@ from .utils import from_camel_case
 logger = logging.getLogger(__name__)
 
 
-class Table(Relation):
+class Table(RelationalOperand):
     """
     A Table object is a relation associated with a table.
     A Table object provides insert and delete methods.

--- a/demos/demo1.py
+++ b/demos/demo1.py
@@ -14,7 +14,7 @@ conn = dj.conn()   # connect to database; conn must be defined in module namespa
 conn.bind(module=__name__, dbname='dj_test')  # bind this module to the database
 
 
-class Subject(dj.Base):
+class Subject(dj.Relation):
     definition = """
     demo1.Subject (manual)     # Basic subject info
     subject_id       : int     # internal subject id
@@ -28,7 +28,7 @@ class Subject(dj.Base):
     """
 
 
-class Experiment(dj.Base):
+class Experiment(dj.Relation):
     definition = """
     demo1.Experiment (manual)     # Basic subject info
     -> demo1.Subject
@@ -41,7 +41,7 @@ class Experiment(dj.Base):
     """
 
 
-class Session(dj.Base):
+class Session(dj.Relation):
     definition = """
     demo1.Session (manual)   # a two-photon imaging session
     -> demo1.Experiment
@@ -52,7 +52,7 @@ class Session(dj.Base):
     """
 
 
-class Scan(dj.Base):
+class Scan(dj.Relation):
     definition = """
     demo1.Scan (manual)   # a two-photon imaging session
     -> demo1.Session

--- a/doc/source/Getting started.rst
+++ b/doc/source/Getting started.rst
@@ -16,7 +16,7 @@ This tests some latex :math:`x \mapsto y`.
     environ.get('DJ_PASSW', 'datajoint')
     import datajoint as dj
     
-    class Subjects(dj.Base):
+    class Subjects(dj.Relation):
         _table_def = """
         Subjects (manual)     # Basic subject info
     

--- a/doc/source/base.rst
+++ b/doc/source/base.rst
@@ -1,4 +1,4 @@
-Base
+Relation
 ====
 
 .. automodule:: datajoint.base

--- a/tests/schemata/schema1/test1.py
+++ b/tests/schemata/schema1/test1.py
@@ -6,7 +6,7 @@ __author__ = 'eywalker'
 import datajoint as dj
 from .. import schema2
 
-class Subjects(dj.Base):
+class Subjects(dj.Relation):
     definition = """
     test1.Subjects (manual)     # Basic subject info
 
@@ -17,7 +17,7 @@ class Subjects(dj.Base):
     """
 
 # test reference to another table in same schema
-class Experiments(dj.Base):
+class Experiments(dj.Relation):
     definition = """
     test1.Experiments (imported)   # Experiment info
     -> test1.Subjects
@@ -27,7 +27,7 @@ class Experiments(dj.Base):
     """
 
 # refers to a table in dj_test2 (bound to test2) but without a class
-class Sessions(dj.Base):
+class Sessions(dj.Relation):
     definition = """
     test1.Sessions (manual)     # Experiment sessions
     -> test1.Subjects
@@ -37,7 +37,7 @@ class Sessions(dj.Base):
     session_comment        : varchar(255)    # comment about the session
     """
 
-class Match(dj.Base):
+class Match(dj.Relation):
     definition = """
     test1.Match (manual)     # Match between subject and color
     -> schema2.Subjects
@@ -46,12 +46,12 @@ class Match(dj.Base):
     """
 
 # this tries to reference a table in database directly without ORM
-class TrainingSession(dj.Base):
+class TrainingSession(dj.Relation):
     definition = """
     test1.TrainingSession (manual)  # training sessions
     -> `dj_test2`.Experimenter
     session_id    : int      # training session id
     """
 
-class Empty(dj.Base):
+class Empty(dj.Relation):
     pass

--- a/tests/schemata/schema1/test2.py
+++ b/tests/schemata/schema1/test2.py
@@ -9,7 +9,7 @@ from . import test1 as alias
 
 
 # references to another schema
-class Experiments(dj.Base):
+class Experiments(dj.Relation):
     definition = """
     test2.Experiments (manual)     # Basic subject info
     -> test1.Subjects
@@ -20,21 +20,21 @@ class Experiments(dj.Base):
     """
 
 # references to another schema
-class Conditions(dj.Base):
+class Conditions(dj.Relation):
     definition = """
     test2.Conditions (manual)     # Subject conditions
     -> alias.Subjects
     condition_name              : varchar(255)    # description of the condition
     """
 
-class FoodPreference(dj.Base):
+class FoodPreference(dj.Relation):
     definition = """
     test2.FoodPreference (manual)   # Food preference of each subject
     -> animals.Subjects
     preferred_food           : enum('banana', 'apple', 'oranges')
     """
 
-class Session(dj.Base):
+class Session(dj.Relation):
     definition = """
     test2.Session (manual)     # Experiment sessions
     -> test1.Subjects

--- a/tests/schemata/schema1/test3.py
+++ b/tests/schemata/schema1/test3.py
@@ -8,7 +8,7 @@ __author__ = 'eywalker'
 import datajoint as dj
 
 
-class Subjects(dj.Base):
+class Subjects(dj.Relation):
     definition = """
     schema1.Subjects (manual)     # Basic subject info
 

--- a/tests/schemata/schema1/test4.py
+++ b/tests/schemata/schema1/test4.py
@@ -6,7 +6,7 @@ __author__ = 'fabee'
 import datajoint as dj
 
 
-class Matrix(dj.Base):
+class Matrix(dj.Relation):
     definition = """
     test4.Matrix (manual)        # Some numpy array
 

--- a/tests/schemata/schema2/test1.py
+++ b/tests/schemata/schema2/test1.py
@@ -7,7 +7,7 @@ import datajoint as dj
 
 
 
-class Subjects(dj.Base):
+class Subjects(dj.Relation):
     definition = """
     schema2.Subjects (manual)     # Basic subject info
     pop_id       : int      # unique experiment id

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -23,7 +23,7 @@ def setup():
 
 class TestBaseInstantiations(object):
     """
-    Test cases for instantiating Base objects
+    Test cases for instantiating Relation objects
     """
     def __init__(self):
         self.conn = None
@@ -52,7 +52,7 @@ class TestBaseInstantiations(object):
 
     def test_instantiation_from_unbound_module_should_fail(self):
         """
-        Attempting to instantiate a Base derivative from a module with
+        Attempting to instantiate a Relation derivative from a module with
         connection defined but not bound to a database should raise error
         """
         test1.conn = self.conn
@@ -62,7 +62,7 @@ class TestBaseInstantiations(object):
 
     def test_instantiation_from_module_without_conn_should_fail(self):
         """
-        Attempting to instantiate a Base derivative from a module that lacks
+        Attempting to instantiate a Relation derivative from a module that lacks
         `conn` object should raise error
         """
         with assert_raises(DataJointError) as e:
@@ -72,7 +72,7 @@ class TestBaseInstantiations(object):
     def test_instantiation_of_base_derivatives(self):
         """
         Test instantiation and initialization of objects derived from
-        Base class
+        Relation class
         """
         test1.conn = self.conn
         self.conn.bind(test1.__name__, PREFIX + '_test1')
@@ -92,7 +92,7 @@ class TestBaseInstantiations(object):
 class TestBaseDeclaration(object):
     """
     Test declaration (creation of table) from
-    definition in Base under various circumstances
+    definition in Relation under various circumstances
     """
 
     def setup(self):
@@ -171,7 +171,7 @@ class TestBaseWithExistingTables(object):
 
     def test_detection_of_existing_table(self):
         """
-        The Base instance should be able to detect if the
+        The Relation instance should be able to detect if the
         corresponding table already exists in the database
         """
         s = test1.Subjects()
@@ -191,7 +191,7 @@ class TestBaseWithExistingTables(object):
 
     def test_direct_reference_to_existing_table_should_fail(self):
         """
-        When deriving from Base, definition should not contain direct reference
+        When deriving from Relation, definition should not contain direct reference
         to a database name
         """
         s = test1.TrainingSession()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -8,7 +8,7 @@ from nose.tools import assert_raises, assert_equal, assert_regexp_matches, asser
 from datajoint import DataJointError
 import numpy as np
 from numpy.testing import assert_array_equal
-from datajoint.table import Table
+from datajoint.free_relation import FreeRelation
 
 def setup():
     """
@@ -23,7 +23,7 @@ class TestTableObject(object):
         self.setup()
 
     """
-    Test cases for Table objects
+    Test cases for FreeRelation objects
     """
 
     def setup(self):
@@ -126,7 +126,7 @@ class TestTableObject(object):
 
 class TestUnboundTables(object):
     """
-    Test usages of Table objects not connected to a module.
+    Test usages of FreeRelation objects not connected to a module.
     """
     def setup(self):
         cleanup()
@@ -139,7 +139,7 @@ class TestUnboundTables(object):
         ---
         animal_name : varchar(128)  # name of the animal
         """
-        table = Table(self.conn, 'dj_free', 'Animals', definition)
+        table = FreeRelation(self.conn, 'dj_free', 'Animals', definition)
         table.declare()
         assert_true('animal_id' in table.primary_key)
 
@@ -149,7 +149,7 @@ class TestUnboundTables(object):
         -> `dj_free`.Animals
         rec_session_id : int     # recording session identifier
         """
-        table = Table(self.conn, 'dj_free', 'Recordings', definition)
+        table = FreeRelation(self.conn, 'dj_free', 'Recordings', definition)
         assert_raises(DataJointError, table.declare)
 
     def test_reference_to_existing_table(self):
@@ -159,7 +159,7 @@ class TestUnboundTables(object):
         ---
         animal_name : varchar(128)  # name of the animal
         """
-        table1 = Table(self.conn, 'dj_free', 'Animals', definition1)
+        table1 = FreeRelation(self.conn, 'dj_free', 'Animals', definition1)
         table1.declare()
 
         definition2 = """
@@ -167,7 +167,7 @@ class TestUnboundTables(object):
         -> `dj_free`.Animals
         rec_session_id : int     # recording session identifier
         """
-        table2 = Table(self.conn, 'dj_free', 'Recordings', definition2)
+        table2 = FreeRelation(self.conn, 'dj_free', 'Recordings', definition2)
         table2.declare()
         assert_true('animal_id' in table2.primary_key)
 


### PR DESCRIPTION
Three classes and its respective module names have been refactors as following:

* `Relation` -> `RelationalOperand`
* `relation.py` -> `relational_operand.py`
* `Table` -> `FreeRelation`
* `table.py` -> `free_relation.py`
* `Base` -> `Relation`
* `base.py` -> `relation.py`

These are major name changes, so please make sure to base any future work off of this.