### PR TITLE
cleaned up __iter__  and fetch logic

### DIFF
--- a/datajoint/heading.py
+++ b/datajoint/heading.py
@@ -7,7 +7,7 @@ from datajoint import DataJointError
 
 class Heading:
     """
-    local class for relations' headings.
+    Local class for relations' headings.
     Heading contains the property attributes, which is an OrderedDict in which the keys are
     the attribute names and the values are AttrTuples.
     """

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -130,21 +130,26 @@ class RelationalOperand(metaclass=abc.ABCMeta):
     def __call__(self, *args, **kwargs):
         return self.fetch(*args, **kwargs)
 
-    def fetch(self, offset=0, limit=None, order_by=None, descending=False):
+    def fetch(self, offset=0, limit=None, order_by=None, descending=False, as_dict=False):
         """
         fetches the relation from the database table into an np.array and unpacks blob attributes.
         :param offset: the number of tuples to skip in the returned result
         :param limit: the maximum number of tuples to return
         :param order_by: the list of attributes to order the results. No ordering should be assumed if order_by=None.
         :param descending: the list of attributes to order the results
+        :param as_dict: returns a list of dictionaries instead of a record array
         :return: the contents of the relation in the form of a structured numpy.array
         """
-        tmp = list(self.__iter__(offset, limit, order_by, descending))
-
-        if len(tmp) > 0:
-            return np.atleast_1d(rfn.stack_arrays(tmp, usemask=False))
+        cur = self.cursor(offset, limit, order_by, descending)
+        if as_dict:
+            attr_names = self.heading.names
+            ret = [dict((n, unpack(e)) if n in self.heading.blobs else (n, e)
+                        for n, e in zip(attr_names, t)) for t in cur.fetchall()]
         else:
-            return np.empty((0,), dtype=self.heading.as_dtype)
+            ret = np.array(list(cur.fetchall()), dtype=self.heading.as_dtype)
+            for bname in self.heading.blobs:
+                ret[bname] = list(map(unpack, ret[bname]))
+        return ret
 
     def cursor(self, offset=0, limit=None, order_by=None, descending=False):
         """
@@ -168,6 +173,8 @@ class RelationalOperand(metaclass=abc.ABCMeta):
         logger.debug(sql)
         return self.conn.query(sql)
 
+
+
     def __repr__(self):
         limit = 7 #TODO: move some of these display settings into the config
         width = 14
@@ -183,9 +190,9 @@ class RelationalOperand(metaclass=abc.ABCMeta):
         repr_string += ' (%d tuples)\n' % self.count
         return repr_string
         
-    def __iter__(self, offset=0, limit=None, order_by=None, descending=False):
+    def __iter__(self):
         """
-        Iterator that yields individual tuples of the current table (as record arrays).
+        Iterator that yields individual tuples of the current table dictionaries.
 
 
         :param offset: parameter passed to the :func:`cursor`
@@ -193,12 +200,12 @@ class RelationalOperand(metaclass=abc.ABCMeta):
         :param order_by: parameter passed to the :func:`cursor`
         :param descending: parameter passed to the :func:`cursor`
         """
-        cur = self.cursor(offset, limit, order_by, descending)
+        cur = self.cursor()
         do_unpack = tuple(h in self.heading.blobs for h in self.heading.names)
         q = cur.fetchone()
         while q:
-            yield np.array([tuple(unpack(field) if up else field for up, field in zip(do_unpack, q))],
-                           dtype=self.heading.as_dtype)[0]
+            yield dict( (fieldname,unpack(field)) if up else (fieldname,field)
+                  for fieldname, up, field in zip(self.heading.names, do_unpack, q))
             q = cur.fetchone()
 
     @property

--- a/datajoint/utils.py
+++ b/datajoint/utils.py
@@ -1,5 +1,6 @@
 import re
 from . import DataJointError
+import collections
 
 
 def to_camel_case(s):


### PR DESCRIPTION
* `RelationalOperand.__iter__` doesn't take any arguments anymore
* `RelationalOperand.__iter__` yields dicts
* fetch returns a record array or a list of dicts if requested
* positional insert not supported anymore
* added check for existing attribute names in `FreeRelation.insert`
* Insert now accepts everything that is an instance of `collections.Mapping`. This is the minimum requirement we need and gives a lot of flexibility to the user. 