### PR TITLE
added RetlationalOperand.fetch1()

### DIFF
--- a/datajoint/free_relation.py
+++ b/datajoint/free_relation.py
@@ -149,7 +149,7 @@ class FreeRelation(RelationalOperand):
 
         if isinstance(tup, np.void):
             for fieldname in tup.dtype.fields:
-                if not fieldname in self.heading.names:
+                if fieldname not in self.heading.names:
                     raise KeyError(u'{0:s} is not in the attribute list'.format(fieldname, ))
             value_list = ','.join([repr(tup[name]) if name not in self.heading.blobs else '%s'
                                    for name in self.heading.names if name in tup.dtype.fields])
@@ -160,7 +160,7 @@ class FreeRelation(RelationalOperand):
                 [q for q in self.heading.names if q in tup.dtype.fields]) + '`'
         elif isinstance(tup, Mapping):
             for fieldname in tup.keys():
-                if not fieldname in self.heading.names:
+                if fieldname not in self.heading.names:
                     raise KeyError(u'{0:s} is not in the attribute list'.format(fieldname, ))
             value_list = ','.join([repr(tup[name]) if name not in self.heading.blobs else '%s'
                                    for name in self.heading.names if name in tup])

--- a/demos/rundemo1.py
+++ b/demos/rundemo1.py
@@ -6,6 +6,7 @@ Created on Thu Aug 28 00:46:11 2014
 """
 import logging
 import demo1
+from collections import namedtuple
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -32,22 +33,26 @@ subject.insert(dict(subject_id=2,
                     date_of_birth="2014-08-01",
                     caretaker="Joe"))
 
-subject.insert((3, 'Alice', 'monkey', '2012-09-01'))
-subject.insert((4, 'Dennis', 'monkey', '2012-09-01'))
-subject.insert((5, 'Warren', 'monkey', '2012-09-01'))
-subject.insert((6, 'Franky', 'monkey', '2012-09-01'))
-subject.insert((7, 'Simon', 'monkey', '2012-09-01', 'F'))
-subject.insert((8, 'Ferocious', 'monkey', '2012-09-01', 'M'))
-subject.insert((9, 'Simon', 'monkey', '2012-09-01', 'm'))
-subject.insert((10, 'Ferocious', 'monkey', '2012-09-01', 'F'))
-subject.insert((11, 'Simon', 'monkey', '2012-09-01', 'm'))
-subject.insert((12, 'Ferocious', 'monkey', '2012-09-01', 'M'))
-subject.insert((13, 'Dauntless', 'monkey', '2012-09-01', 'F'))
-subject.insert((14, 'Dawn', 'monkey', '2012-09-01', 'F'))
 
-subject.insert((12430, 'C0430', 'mouse', '2012-09-01', 'M'))
-subject.insert((12431, 'C0431', 'mouse', '2012-09-01', 'F'))
+def tup(*arg):
+    return dict(zip(subject.heading.names, arg))
 
+subject.insert(tup(3, 'Alice', 'monkey', '2012-09-01', 'M', 'Joe', ''))
+subject.insert(tup(4, 'Dennis', 'monkey', '2012-09-01', 'M', 'Joe', ''))
+subject.insert(tup(5, 'Warren', 'monkey', '2012-09-01', 'M', 'Joe', ''))
+subject.insert(tup(6, 'Franky', 'monkey', '2012-09-01', 'M', 'Joe', ''))
+subject.insert(tup(7, 'Simon', 'monkey', '2012-09-01', 'F', 'Joe', ''))
+subject.insert(tup(8, 'Ferocious', 'monkey', '2012-09-01', 'M', 'Joe', ''))
+subject.insert(tup(9, 'Simon', 'monkey', '2012-09-01', 'm', 'Joe', ''))
+subject.insert(tup(10, 'Ferocious', 'monkey', '2012-09-01', 'F', 'Joe', ''))
+subject.insert(tup(11, 'Simon', 'monkey', '2012-09-01', 'm', 'Joe', ''))
+subject.insert(tup(12, 'Ferocious', 'monkey', '2012-09-01', 'M', 'Joe', ''))
+subject.insert(tup(13, 'Dauntless', 'monkey', '2012-09-01', 'F', 'Joe', ''))
+subject.insert(tup(14, 'Dawn', 'monkey', '2012-09-01', 'F', 'Joe', ''))
+subject.insert(tup(12430, 'C0430', 'mouse', '2012-09-01', 'M', 'Joe', ''))
+subject.insert(tup(12431, 'C0431', 'mouse', '2012-09-01', 'F', 'Joe', ''))
+
+(subject & 'subject_id=1').fetch1()
 print(subject)
 print(subject.project())
 print(subject.project(name='real_id', dob='date_of_birth', sex='sex') & 'sex="M"')

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -66,8 +66,8 @@ class TestTableObject(object):
         s = self.subjects
         t = self.trials
 
-        s.insert(dict(subject_id=1, real_id='M' ))
-        s.insert(dict(subject_id=2, real_id='F' ))
+        s.insert(dict(subject_id=1, real_id='M'))
+        s.insert(dict(subject_id=2, real_id='F'))
         t.iter_insert(trial_faker(20))
 
         tM = t & (s & "real_id = 'M'")


### PR DESCRIPTION
In many cases, especially from within `_make_tuples`, queries must return exactly one tuple.  This is communicated by calling `fetch1` in place of `fetch`.   The return result is a single dict.  An error is thrown if the number of tuples is not 1.