### PR TITLE
Add foreign reference shorthand. close #73

### DIFF
--- a/datajoint/free_relation.py
+++ b/datajoint/free_relation.py
@@ -319,6 +319,8 @@ class FreeRelation(RelationalOperand):
         return index_info
 
     def get_base(self, module_name, class_name):
+        if not module_name:
+            module_name = r'`{dbname}`'.format(self.dbname)
         m = re.match(r'`(\w+)`', module_name)
         return FreeRelation(self.conn, m.group(1), class_name) if m else None
 
@@ -457,7 +459,12 @@ class FreeRelation(RelationalOperand):
                 in_key = False  # start parsing non-PK fields
             elif line.startswith('->'):
                 # foreign key
-                module_name, class_name = line[2:].strip().split('.')
+                if '.' in line[2:]:
+                    module_name, class_name = line[2:].strip().split('.')
+                else:
+                    # assume it's a shorthand
+                    module_name = ''
+                    class_name = line[2:].strip()
                 ref = parents if in_key else referenced
                 ref.append(self.get_base(module_name, class_name))
             elif re.match(r'^(unique\s+)?index[^:]*$', line, re.I):

--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -93,6 +93,9 @@ class Relation(FreeRelation, metaclass=abc.ABCMeta):
         :param class_name: class name
         :returns: the base relation
         """
+        if not module_name:
+            module_name = self.__module__.split('.')[-1]
+
         mod_obj = self.get_module(module_name)
         if not mod_obj:
             raise DataJointError('Module named {mod_name} was not found. Please make'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ networkx
 matplotlib
 sphinx_rtd_theme
 mock
-json

--- a/tests/schemata/schema1/test1.py
+++ b/tests/schemata/schema1/test1.py
@@ -17,6 +17,16 @@ class Subjects(dj.Relation):
     species = "mouse"           : enum('mouse', 'monkey', 'human')   # species
     """
 
+# test for shorthand
+class Animals(dj.Relation):
+    definition = """
+    test1.Animals (manual)      # Listing of all info
+
+    -> Subjects
+    ---
+    animal_dob      :date       # date of birth
+    """
+
 
 class Trials(dj.Relation):
     definition = """

--- a/tests/test_free_relation.py
+++ b/tests/test_free_relation.py
@@ -81,8 +81,6 @@ class TestRelationInstantiations(object):
         assert_equal(s.conn, self.conn)
         assert_equal(s.definition, test1.Subjects.definition)
 
-
-
     def test_packagelevel_binding(self):
         schema2.conn = self.conn
         self.conn.bind(schema2.__name__, PREFIX + '_test1')

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -56,6 +56,7 @@ class TestTableObject(object):
         self.conn.bind(test1.__name__, PREFIX + '_test1')
         self.conn.bind(test4.__name__, PREFIX + '_test4')
         self.subjects = test1.Subjects()
+        self.animals = test1.Animals()
         self.relvar_blob = test4.Matrix()
         self.trials = test1.Trials()
 
@@ -115,7 +116,8 @@ class TestTableObject(object):
     #     assert_true(len(self.subjects) == 1, 'Length does not match 1.')
     #     assert_true(len(self.trials) == 1, 'Length does not match 1.')
 
-
+    def test_short_hand_foreign_reference(self):
+        self.animals.heading;
 
 
 


### PR DESCRIPTION
* Allow for reference to a table in same module or database to omit the module name/database name
* Add a test case for the shorthand notation