### PR TITLE
safemode=True by default and configchange logging

### DIFF
--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -36,7 +36,7 @@ default = OrderedDict({
     #
     'loglevel': 'DEBUG',
     #
-    'safemode': False,
+    'safemode': True,
     #
     'display.limit': 7,
     'display.width': 14
@@ -78,6 +78,7 @@ class Config(Borg, collections.MutableMapping):
         return self._conf[key]
 
     def __setitem__(self, key, value):
+        logger.log(logging.INFO, u"Setting {0:s} to {1:s}".format(str(key), str(value)))
         if isinstance(value, collections.Mapping):
             raise ValueError("Nested settings are not supported!")
         if validators[key](value):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,6 +8,7 @@ after the test.
 import pymysql
 import logging
 from os import environ
+import datajoint as dj
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -26,7 +27,7 @@ BASE_CONN.autocommit(True)
 
 def setup():
     cleanup()
-
+    dj.config['safemode'] = False
 
 def teardown():
     cleanup()

--- a/tests/schemata/schema1/test1.py
+++ b/tests/schemata/schema1/test1.py
@@ -38,7 +38,7 @@ class Trials(dj.Relation):
     outcome                    : int           # result of experiment
 
     notes=""                   : varchar(4096) # other comments
-    trial_ts=CURRENT_TIMESTAMP : timestamp    # automatic
+    trial_ts=CURRENT_TIMESTAMP : timestamp     # automatic
     """
 
 
@@ -47,7 +47,7 @@ class Experiments(dj.Relation):
     definition = """
     test1.Experiments (imported)   # Experiment info
     -> test1.Subjects
-    exp_id     : int            # unique id for experiment
+    exp_id     : int               # unique id for experiment
     ---
     exp_data_file   : varchar(255) # data file
     """
@@ -59,7 +59,7 @@ class Sessions(dj.Relation):
     test1.Sessions (manual)     # Experiment sessions
     -> test1.Subjects
     -> test2.Experimenter
-    session_id     : int       # unique session id
+    session_id     : int        # unique session id
     ---
     session_comment        : varchar(255)    # comment about the session
     """


### PR DESCRIPTION
* the default for safemode in settings is now True
* safemode is set to false in `__init__` of tests
* changes in config are logged on level INFO via `__getitem__`