### PR TITLE
Avoid implicit commits

### DIFF
--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -15,6 +15,13 @@ class DataJointError(Exception):
     pass
 
 
+class TransactionError(DataJointError):
+    """
+    Base class for errors specific to DataJoint internal operation.
+    """
+    pass
+
+
 # ----------- loads local configuration from file ----------------
 from .settings import Config, CONFIGVAR, LOCALCONFIG, logger, log_levels
 config = Config()

--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -19,7 +19,18 @@ class TransactionError(DataJointError):
     """
     Base class for errors specific to DataJoint internal operation.
     """
-    pass
+    def __init__(self, msg, f, args, kwargs):
+        super(TransactionError, self).__init__(msg)
+        self.operations = (f, args, kwargs)
+
+    def resolve(self):
+        f, args, kwargs = self.operations
+        return f(*args, **kwargs)
+
+    @property
+    def culprit(self):
+        return self.operations[0].__name__
+
 
 
 # ----------- loads local configuration from file ----------------

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -41,6 +41,7 @@ def conn_container():
             init_fun = init_fun if init_fun is not None else config['connection.init_function']
             _connObj = Connection(host, user, passwd, init_fun)
         return _connObj
+
     return conn_function
 
 # The function conn is used by others to obtain the package wide persistent connection object
@@ -51,11 +52,16 @@ class Transaction(object):
     """
     Class that defines a transaction. Mainly for use in a with statement.
 
+    :param ignore_errors=False: if True, all errors are not passed on. However, the transaction is still
+                          rolled back if an error is raised.
+
     :param conn: connection object that opens the transaction.
     """
 
-    def __init__(self, conn):
+    def __init__(self, conn, ignore_errors=False):
         self.conn = conn
+        self._do_not_raise_error_again = False
+        self.ignore_errors = ignore_errors
 
     def __enter__(self):
         assert self.conn.is_connected, "Connection is not connected"
@@ -74,8 +80,19 @@ class Transaction(object):
         """
         return self.conn.is_connected and self.conn.in_transaction
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if exc_type is None and exc_val is None and exc_tb is None:
+    def cancel(self):
+        """
+        Cancels an ongoing transaction and rolls back.
+
+        """
+        self._do_not_raise_error_again = True
+        raise DataJointError("Transaction cancelled by user.")
+
+    def __exit__(self, exc_type, exc_val, exc_tb):  # TODO: assert XOR and only exc_type is None
+
+        if exc_type is None:
+            assert exc_type is None and exc_val is None and exc_tb is None, \
+                "Either all of exc_type, exc_val, exc_tb should be None, or neither of them"
             self.conn._commit_transaction()
             self.conn._in_transaction = False
             return True
@@ -83,7 +100,7 @@ class Transaction(object):
             self.conn._cancel_transaction()
             self.conn._in_transaction = False
             logger.debug("Transaction cancled because of an error.", exc_info=(exc_type, exc_val, exc_tb))
-            return False
+            return self._do_not_raise_error_again or self.ignore_errors # if True is returned, errors are not raised again
 
 
 class Connection(object):
@@ -300,7 +317,7 @@ class Connection(object):
                 if key in self.referenced:
                     self.referenced.pop(key)
 
-    def parents_of(self, child_table): #TODO: this function is not clear to me after reading the docu
+    def parents_of(self, child_table):  # TODO: this function is not clear to me after reading the docu
         """
         Returns a list of tables that are parents for the childTable based on
         primary foreign keys.
@@ -309,7 +326,7 @@ class Connection(object):
         """
         return self.parents.get(child_table, []).copy()
 
-    def children_of(self, parent_table):#TODO: this function is not clear to me after reading the docu
+    def children_of(self, parent_table):  # TODO: this function is not clear to me after reading the docu
         """
         Returns a list of tables for which parent_table is a parent (primary foreign key)
 
@@ -385,10 +402,12 @@ class Connection(object):
         cur.execute(query, args)
         return cur
 
-    def transaction(self):
+    def transaction(self, ignore_errors=False):
         """
         Context manager to be used with python's with statement.
 
+        :param ignore_errors=False: if True, all errors are not passed on. However, the transaction is still
+                              rolled back if an error is raised.
         :return: a :class:`Transaction` object
 
         :Example:
@@ -397,7 +416,7 @@ class Connection(object):
         >>> with conn.transaction() as tr:
                 ... # do magic
         """
-        return Transaction(self)
+        return Transaction(self, ignore_errors)
 
     @property
     def in_transaction(self):

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -78,10 +78,12 @@ class Transaction(object):
         if exc_type is None and exc_val is None and exc_tb is None:
             self.conn._commit_transaction()
             self.conn._in_transaction = False
+            return True
         else:
             self.conn._cancel_transaction()
             self.conn._in_transaction = False
             logger.debug("Transaction cancled because of an error.", exc_info=(exc_type, exc_val, exc_tb))
+            return False
 
 
 class Connection(object):

--- a/datajoint/decorators.py
+++ b/datajoint/decorators.py
@@ -11,7 +11,7 @@ def _not_in_transaction(f, *args, **kwargs):
     if args[0]._conn.in_transaction:
         raise TransactionError(
             u"{0:s} is currently in transaction. Operation not allowed to avoid implicit commits.".format(
-                args[0].__class__.__name__))
+                args[0].__class__.__name__), f, args, kwargs)
     return f(*args, **kwargs)
 
 

--- a/datajoint/decorators.py
+++ b/datajoint/decorators.py
@@ -1,0 +1,22 @@
+from decorator import decorator
+from . import DataJointError, TransactionError
+
+
+def _not_in_transaction(f, *args, **kwargs):
+    if not hasattr(args[0], '_conn'):
+        raise DataJointError(u"{0:s} does not have a member called _conn".format(args[0].__class__.__name__, ))
+    if not hasattr(args[0]._conn, 'in_transaction'):
+        raise DataJointError(
+            u"{0:s}._conn does not have a property in_transaction".format(args[0].__class__.__name__, ))
+    if args[0]._conn.in_transaction:
+        raise TransactionError(
+            u"{0:s} is currently in transaction. Operation not allowed to avoid implicit commits.".format(
+                args[0].__class__.__name__))
+    return f(*args, **kwargs)
+
+
+def not_in_transaction(f):
+    """
+    This decorator raises an error if the function is called during a transaction.
+    """
+    return decorator(_not_in_transaction, f)

--- a/datajoint/free_relation.py
+++ b/datajoint/free_relation.py
@@ -2,6 +2,7 @@ from _collections_abc import MutableMapping, Mapping
 import numpy as np
 import logging
 from . import DataJointError, config
+from .decorators import not_in_transaction
 from .relational_operand import RelationalOperand
 from .blob import pack
 from .heading import Heading
@@ -296,6 +297,7 @@ class FreeRelation(RelationalOperand):
         plt.show()
         """
 
+    @not_in_transaction
     def _alter(self, alter_statement):
         """
         Execute ALTER TABLE statement for this table. The schema
@@ -343,6 +345,7 @@ class FreeRelation(RelationalOperand):
         """
         return '`{0}`'.format(self.dbname) + '.' + self.class_name
 
+    @not_in_transaction
     def _declare(self):
         """
         Declares the table in the database if no table in the database matches this object.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ networkx
 matplotlib
 sphinx_rtd_theme
 mock
+decorator

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(
     description='An object-relational mapping and relational algebra to facilitate data definition and data manipulation in MySQL databases.',
     url='https://github.com/datajoint/datajoint-python',
     packages=['datajoint'],
-    requires=['numpy', 'pymysql', 'networkx', 'matplotlib', 'sphinx_rtd_theme', 'mock', 'json'],
+    requires=['numpy', 'pymysql', 'networkx', 'matplotlib', 'sphinx_rtd_theme', 'mock', 'json', 'decorator'],
     license = "MIT",
 )

--- a/tests/schemata/schema1/test1.py
+++ b/tests/schemata/schema1/test1.py
@@ -42,6 +42,43 @@ class Trials(dj.Relation):
     """
 
 
+
+class SquaredScore(dj.Relation, dj.AutoPopulate):
+    definition = """
+    test1.SquaredScore (computed)         # cumulative outcome of trials
+
+    -> test1.Subjects
+    -> test1.Trials
+    ---
+    squared                    : int         # squared result of Trials outcome
+    """
+
+    @property
+    def populate_relation(self):
+        return Subjects() * Trials()
+
+    def _make_tuples(self, key):
+        tmp = (Trials() & key).fetch1()
+        tmp2 = SquaredSubtable() & key
+
+        self.insert(dict(key, squared=tmp['outcome']**2))
+
+        ss = SquaredSubtable()
+
+        for i in range(10):
+            key['dummy'] = i
+            ss.insert(key)
+
+class SquaredSubtable(dj.Relation):
+    definition = """
+    test1.SquaredSubtable (computed)         # cumulative outcome of trials
+
+    -> test1.SquaredScore
+    dummy                      : int         # dummy primary attribute
+    ---
+    """
+
+
 # test reference to another table in same schema
 class Experiments(dj.Relation):
     definition = """

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -223,6 +223,19 @@ class TestContextManager(object):
         testt2 = (self.relvar & 'subject_id = 2').fetch()
         assert_equal(len(testt2), 0, "Length is not 0. Expected because rollback should have happened.")
 
+    def test_cancel(self):
+        """Tests cancelling a transaction"""
+        tmp = np.array([(1,'Peter','mouse'),(2, 'Klara', 'monkey')],
+                       dtype=[('subject_id', '>i4'), ('real_id', 'O'), ('species', 'O')])
+
+        self.relvar.insert(tmp[0])
+        with self.conn.transaction() as transaction:
+            self.relvar.insert(tmp[1])
+            transaction.cancel()
+
+        testt2 = (self.relvar & 'subject_id = 2').fetch()
+        assert_equal(len(testt2), 0, "Length is not 0. Expected because rollback should have happened.")
+
 
 
 # class TestConnectionWithBindings(object):


### PR DESCRIPTION
* created a decorator `@not_in_transaction` that throws a TransactionError if the decorated function is called during a transaction
* If an error is thrown, the Transaction object rolls back the current transaction and hands the error to the next level
* `populate` explicitly catches the TransactionError. The TransactionError object holds the function and the parameters that caused the error. It uses that to provide a function `resolve` which just calls the function again with the same arguments. So if `populate` catches a TransactionError, it can just call `resolve` (because it is not in a transaction anymore), resolve the error, and restart the transaction. 
