### PR TITLE
Cascading Delete Implementation

### DIFF
--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from collections import defaultdict
 import numpy as np
 import logging
 import abc
@@ -82,10 +83,16 @@ class Relation(RelationalOperand, metaclass=abc.ABCMeta):
 
     @property
     def references(self):
+        """
+        :return: list of tables that this tables refers to
+        """
         return self.connection.erm.references[self.full_table_name]
 
     @property
     def referenced(self):
+        """
+        :return: list of tables for which this table is referenced by
+        """
         return self.connection.erm.referenced[self.full_table_name]
 
     @property
@@ -187,8 +194,22 @@ class Relation(RelationalOperand, metaclass=abc.ABCMeta):
         User is prompted for confirmation if config['safemode']
         """
         relations = self.descendants
-        if self.restrictions and len(relations)>1:
-            raise NotImplementedError('Restricted cascading deletes are not yet implemented')
+        #if self.restrictions and len(relations)>1:
+        #    raise NotImplementedError('Restricted cascading deletes are not yet implemented')
+        restrict_by_me = defaultdict(lambda: False)
+        rel_by_name = {r.full_table_name:r for r in relations}
+        for r in relations:
+            for ref in r.references:
+                restrict_by_me[ref] = True
+
+        if self.restrictions is not None:
+            restrict_by_me[self.full_table_name] = True
+            rel_by_name[self.full_table_name]._restrict(self.restrictions)
+
+        for r in relations:
+            for dep in (r.children + r.references):
+                rel_by_name[dep]._restrict(r.project() if restrict_by_me[r.full_table_name] else r.restrictions)
+
         do_delete = True
         if config['safemode']:
             do_delete = False

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -113,7 +113,10 @@ class RelationalOperand(metaclass=abc.ABCMeta):
         if restriction is not None:
             if self._restrictions is None:
                 self._restrictions = []
-            self._restrictions.append(restriction)
+            if isinstance(restriction, list):
+                self._restrictions.extend(restriction)
+            else:
+                self._restrictions.append(restriction)
         return self
 
     def __iand__(self, restriction):

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -414,12 +414,14 @@ class Projection(RelationalOperand):
             self._arg = Subquery(arg)
         else:
             self._group = None
-            if arg.heading.computed:
-                self._arg = Subquery(arg)
-            else:
-                # project without subquery
+            if arg.heading.computed or\
+                    (isinstance(arg.restrictions, RelationalOperand) and \
+                    all(attr in self._attributes for attr in arg.restrictions.heading.names)) :
+                # can simply the expression because all restrictions attrs are projected out anyway!
                 self._arg = arg
                 self._restrictions = self._arg.restrictions
+            else:
+                self._arg = Subquery(arg)
 
     @property
     def connection(self):

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -61,6 +61,7 @@ class Experiment(dj.Imported):
         """
         from datetime import date, timedelta
         users = User().fetch()['username']
+        random.seed('Amazing Seed')
         for experiment_id in range(self.fake_experiments_per_subject):
             self.insert1(
                 dict(key,
@@ -82,6 +83,7 @@ class Trial(dj.Imported):
         """
         populate with random data (pretend reading from raw files)
         """
+        random.seed('Amazing Seed')
         for trial_id in range(10):
             self.insert1(
                 dict(key,
@@ -103,6 +105,7 @@ class Ephys(dj.Imported):
         """
         populate with random data
         """
+        random.seed('Amazing seed')
         row = dict(key,
                    sampling_frequency=6000,
                    duration=np.minimum(2, random.expovariate(1)))
@@ -124,6 +127,7 @@ class EphysChannel(dj.Subordinate, dj.Imported):
         """
         populate random trace of specified length
         """
+        random.seed('Amazing seed')
         for channel in range(2):
             self.insert1(
                 dict(key,


### PR DESCRIPTION
* Implemented cascading delete with proper restriction handling, addressing #15
* Fix bug pertaining to projection operation on relation already restricted by another relation. For details, please refer to #129
* Added seed to random number generation in tests, addressing #128
* Expanded the implementation of `_restrict` in `RelationalOperand` to accept a list of restrictions. This done for implementing cascading delete. However, it's very likely that a cleaner solution exists.

It passes all existing tests after the modification, and I have run a number of checks locally, but haven't got to write tests covering new operations.