### PR TITLE
Fetch object

### DIFF
--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -69,7 +69,7 @@ class AutoPopulate(metaclass=abc.ABCMeta):
         jobs = self.connection.jobs[self.target.database]
         table_name = self.target.table_name
         unpopulated = (self.populated_from - self.target) & restriction
-        for key in unpopulated.project():
+        for key in unpopulated.fetch.keys():
             if not reserve_jobs or jobs.reserve(table_name, key):
                 self.connection.start_transaction()
                 if key in self.target:  # already populated

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -6,7 +6,6 @@ This module hosts the Connection class that manages the connection to the mysql 
 from contextlib import contextmanager
 import pymysql
 import logging
-from collections import defaultdict
 from . import config
 from . import DataJointError
 from .erd import ERM

--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -1,0 +1,205 @@
+from collections import OrderedDict
+from .blob import unpack
+import numpy as np
+from datajoint import DataJointError
+from . import key as PRIMARY_KEY
+
+def prepare_attributes(relation, item):
+    if isinstance(item, str) or item is PRIMARY_KEY:
+        item = (item,)
+    elif isinstance(item, int):
+        item = (relation.heading.names[item],)
+    elif isinstance(item, slice):
+        attributes = relation.heading.names
+        start = attributes.index(item.start) if isinstance(item.start, str) else item.start
+        stop = attributes.index(item.stop) if isinstance(item.stop, str) else item.stop
+        item = attributes[slice(start, stop, item.step)]
+    try:
+        attributes = tuple(i for i in item if i is not PRIMARY_KEY)
+    except TypeError:
+        raise DataJointError("Index must be a slice, a tuple, a list, a string.")
+    return item, attributes
+
+class FetchQuery:
+
+    def __init__(self, relation):
+        """
+
+        """
+        self.behavior = dict(
+            offset=0, limit=None, order_by=None, descending=False, as_dict=False, map=None
+        )
+        self._relation = relation
+
+
+    def from_to(self, fro, to):
+        self.behavior['offset'] = fro
+        self.behavior['limit'] = to - fro
+        return self
+
+    def order_by(self, order_by):
+        self.behavior['order_by'] = order_by
+        return self
+
+    def as_dict(self):
+        self.behavior['as_dict'] = True
+
+    def ascending(self):
+        self.behavior['descending'] = False
+        return self
+
+    def descending(self):
+        self.behavior['descending'] = True
+        return self
+
+    def apply(self, f):
+        self.behavior['map'] = f
+        return self
+
+    def limit_by(self, limit):
+        self.behavior['limit'] = limit
+        return self
+
+    def set_behavior(self, **kwargs):
+        self.behavior.update(kwargs)
+        return self
+
+    def __call__(self, **kwargs):
+        """
+        Fetches the relation from the database table into an np.array and unpacks blob attributes.
+
+        :param offset: the number of tuples to skip in the returned result
+        :param limit: the maximum number of tuples to return
+        :param order_by: the list of attributes to order the results. No ordering should be assumed if order_by=None.
+        :param descending: the list of attributes to order the results
+        :param as_dict: returns a list of dictionaries instead of a record array
+        :return: the contents of the relation in the form of a structured numpy.array
+
+        """
+        behavior = dict(self.behavior, **kwargs)
+
+        cur = self._relation.cursor(offset=behavior['offset'], limit=behavior['limit'],
+                                    order_by=behavior['order_by'], descending=behavior['descending'],
+                                    as_dict=behavior['as_dict'])
+
+        heading = self._relation.heading
+        if behavior['as_dict']:
+            ret = [OrderedDict((name, unpack(d[name]) if heading[name].is_blob else d[name])
+                               for name in heading.names)
+                   for d in cur.fetchall()]
+        else:
+            ret = np.array(list(cur.fetchall()), dtype=heading.as_dtype)
+            for blob_name in heading.blobs:
+                ret[blob_name] = list(map(unpack, ret[blob_name]))
+
+        if behavior['map'] is not None:
+            f = behavior['map']
+            for i in range(len(ret)):
+                ret[i] = f(ret[i])
+
+        return ret
+
+    def __iter__(self):
+        """
+        Iterator that returns the contents of the database.
+        """
+        behavior = self.behavior
+
+        cur = self._relation.cursor(offset=behavior['offset'], limit=behavior['limit'],
+                                    order_by=behavior['order_by'], descending=behavior['descending'],
+                                    as_dict=behavior['as_dict'])
+
+        heading = self._relation.heading
+        do_unpack = tuple(h in heading.blobs for h in heading.names)
+        values = cur.fetchone()
+        while values:
+            if behavior['as_dict']:
+                yield OrderedDict(
+                    (field_name, unpack(values[field_name])) if up
+                    else (field_name, values[field_name])
+                    for field_name, up in zip(heading.names, do_unpack))
+            else:
+                yield tuple(unpack(value) if up else value for up, value in zip(do_unpack, values))
+            values = cur.fetchone()
+
+    def keys(self, **kwargs):
+        """
+        Iterator that returns primary keys.
+        """
+        if 'as_dict' not in kwargs:
+            kwargs['as_dict'] = True
+        yield from self._relation.project().fetch.set_behavior(**kwargs)
+
+
+    def __getitem__(self, item):
+        """
+        Fetch attributes as separate outputs.
+        datajoint.key is a special value that requests the entire primary key
+        :return: tuple with an entry for each element of item
+
+        Examples:
+        a, b = relation['a', 'b']
+        a, b, key = relation['a', 'b', datajoint.key]
+        results = relation['a':'z']    # return attributes a-z as a tuple
+        results = relation[:-1]   # return all but the last attribute
+        """
+        single_output = isinstance(item, str) or item is PRIMARY_KEY or isinstance(item, int)
+        item, attributes = prepare_attributes(self._relation, item)
+
+        result = self._relation.project(*attributes).fetch()
+        return_values = [
+            np.ndarray(result.shape,
+                       np.dtype({name: result.dtype.fields[name] for name in self._relation.primary_key}),
+                       result, 0, result.strides)
+            if attribute is PRIMARY_KEY
+            else result[attribute]
+            for attribute in item
+            ]
+        return return_values[0] if single_output else return_values
+
+
+class Fetch1Query:
+
+    def __init__(self, relation):
+        self._relation = relation
+
+    def __call__(self):
+        """
+        This version of fetch is called when self is expected to contain exactly one tuple.
+        :return: the one tuple in the relation in the form of a dict
+        """
+        heading = self._relation.heading
+
+        cur = self._relation.cursor(as_dict=True)
+        ret = cur.fetchone()
+        if not ret or cur.fetchone():
+            raise DataJointError('fetch1 should only be used for relations with exactly one tuple')
+
+        return OrderedDict((name, unpack(ret[name]) if heading[name].is_blob else ret[name])
+                           for name in heading.names)
+
+    def __getitem__(self, item):
+        """
+        Fetch attributes as separate outputs.
+        datajoint.key is a special value that requests the entire primary key
+        :return: tuple with an entry for each element of item
+
+        Examples:
+        a, b = relation['a', 'b']
+        a, b, key = relation['a', 'b', datajoint.key]
+        results = relation['a':'z']    # return attributes a-z as a tuple
+        results = relation[:-1]   # return all but the last attribute
+        """
+        single_output = isinstance(item, str) or item is PRIMARY_KEY or isinstance(item, int)
+        item, attributes = prepare_attributes(self._relation, item)
+
+        result = self._relation.project(*attributes).fetch()
+        return_values = tuple(
+            np.ndarray(result.shape,
+                       np.dtype({name: result.dtype.fields[name] for name in self._relation.primary_key}),
+                       result, 0, result.strides)
+            if attribute is PRIMARY_KEY
+            else result[attribute][0]
+            for attribute in item
+        )
+        return return_values[0] if single_output else return_values

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -5,14 +5,12 @@ classes for relational algebra
 import numpy as np
 import abc
 import re
-from collections import OrderedDict
 from copy import copy
 from . import config
-from . import key as PRIMARY_KEY
 from . import DataJointError
 import logging
 
-from .blob import unpack
+from .fetch import FetchQuery, Fetch1Query
 
 logger = logging.getLogger(__name__)
 
@@ -209,71 +207,11 @@ class RelationalOperand(metaclass=abc.ABCMeta):
         return repr_string
 
     def fetch1(self):
-        """
-        This version of fetch is called when self is expected to contain exactly one tuple.
-        :return: the one tuple in the relation in the form of a dict
-        """
-        heading = self.heading
-        cur = self.cursor(as_dict=True)
-        ret = cur.fetchone()
-        if not ret or cur.fetchone():
-            raise DataJointError('fetch1 should only be used for relations with exactly one tuple')
-        return OrderedDict((name, unpack(ret[name]) if heading[name].is_blob else ret[name])
-                           for name in self.heading.names)
+        return Fetch1Query(self)
 
-    def fetch(self, offset=0, limit=None, order_by=None, descending=False, as_dict=False):
-        """
-        fetches the relation from the database table into an np.array and unpacks blob attributes.
-        :param offset: the number of tuples to skip in the returned result
-        :param limit: the maximum number of tuples to return
-        :param order_by: the list of attributes to order the results. No ordering should be assumed if order_by=None.
-        :param descending: the list of attributes to order the results
-        :param as_dict: returns a list of dictionaries instead of a record array
-        :return: the contents of the relation in the form of a structured numpy.array
-        """
-        cur = self.cursor(offset=offset, limit=limit, order_by=order_by,
-                          descending=descending, as_dict=as_dict)
-        heading = self.heading
-        if as_dict:
-            ret = [OrderedDict((name, unpack(d[name]) if heading[name].is_blob else d[name])
-                               for name in self.heading.names)
-                   for d in cur.fetchall()]
-        else:
-            ret = np.array(list(cur.fetchall()), dtype=heading.as_dtype)
-            for blob_name in heading.blobs:
-                ret[blob_name] = list(map(unpack, ret[blob_name]))
-        return ret
-
-    def values(self, offset=0, limit=None, order_by=None, descending=False, as_dict=False):
-        """
-        Iterator that returns the contents of the database.
-        """
-        cur = self.cursor(offset=offset, limit=limit, order_by=order_by,
-                          descending=descending, as_dict=as_dict)
-        heading = self.heading
-        do_unpack = tuple(h in heading.blobs for h in heading.names)
-        values = cur.fetchone()
-        while values:
-            if as_dict:
-                yield OrderedDict(
-                    (field_name, unpack(values[field_name])) if up
-                    else (field_name, values[field_name])
-                    for field_name, up in zip(heading.names, do_unpack))
-            else:
-                yield tuple(unpack(value) if up else value for up, value in zip(do_unpack, values))
-            values = cur.fetchone()
-
-    def __iter__(self):
-        """
-        Iterator that yields individual tuples of the current table dictionaries.
-        """
-        yield from self.values(as_dict=True)
-
-    def keys(self, *args, **kwargs):
-        """
-        Iterator that returns primary keys.
-        """
-        yield from self.project().values(*args, **kwargs)
+    @property
+    def fetch(self):
+        return FetchQuery(self)
 
     @property
     def where_clause(self):
@@ -314,42 +252,7 @@ class RelationalOperand(metaclass=abc.ABCMeta):
 
         return ' WHERE ' + ' AND '.join(condition_string)
 
-    def __getitem__(self, item):
-        """
-        Fetch attributes as separate outputs.
-        datajoint.key is a special value that requests the entire primary key
-        :return: tuple with an entry for each element of item
 
-        Examples:
-        a, b = relation['a', 'b']
-        a, b, key = relation['a', 'b', datajoint.key]
-        results = relation['a':'z']    # return attributes a-z as a tuple
-        results = relation[:-1]   # return all but the last attribute
-        """
-        single_output = isinstance(item, str) or item is PRIMARY_KEY or isinstance(item, int)
-        if isinstance(item, str) or item is PRIMARY_KEY:
-            item = (item,)
-        elif isinstance(item, int):
-            item = (self.heading.names[item],)
-        elif isinstance(item, slice):
-            attributes = self.heading.names
-            start = attributes.index(item.start) if isinstance(item.start, str) else item.start
-            stop = attributes.index(item.stop) if isinstance(item.stop, str) else item.stop
-            item = attributes[slice(start, stop, item.step)]
-        try:
-            attributes = tuple(i for i in item if i is not PRIMARY_KEY)
-        except TypeError:
-            raise DataJointError("Index must be a slice, a tuple, a list, a string.")
-        result = self.project(*attributes).fetch()
-        return_values = [
-            np.ndarray(result.shape,
-                       np.dtype({name: result.dtype.fields[name] for name in self.primary_key}),
-                       result, 0, result.strides)
-            if attribute is PRIMARY_KEY
-            else result[attribute]
-            for attribute in item
-            ]
-        return return_values[0] if single_output else return_values
 
 
 class Not:

--- a/tests/test_relational_operand.py
+++ b/tests/test_relational_operand.py
@@ -61,20 +61,20 @@ class TestRelationalOperand:
         """Testing RelationalOperand.__getitem__"""
 
         np.testing.assert_array_equal(sorted(self.subject.project().fetch(), key=itemgetter(0)),
-                                      sorted(self.subject[dj.key], key=itemgetter(0)),
+                                      sorted(self.subject.fetch[dj.key], key=itemgetter(0)),
                                       'Primary key is not returned correctly')
 
         tmp = self.subject.fetch(order_by=['subject_id'])
 
-        for column, field in zip(self.subject[:], [e[0] for e in tmp.dtype.descr]):
+        for column, field in zip(self.subject.fetch[:], [e[0] for e in tmp.dtype.descr]):
             np.testing.assert_array_equal(sorted(tmp[field]), sorted(column), 'slice : does not work correctly')
 
-        subject_notes, key, real_id = self.subject['subject_notes', dj.key, 'real_id']
-
+        subject_notes, key, real_id = self.subject.fetch['subject_notes', dj.key, 'real_id']
+        #
         np.testing.assert_array_equal(sorted(subject_notes), sorted(tmp['subject_notes']))
         np.testing.assert_array_equal(sorted(real_id), sorted(tmp['real_id']))
         np.testing.assert_array_equal(sorted(key, key=itemgetter(0)),
                                       sorted(self.subject.project().fetch(), key=itemgetter(0)))
 
-        for column, field in zip(self.subject['subject_id'::2], [e[0] for e in tmp.dtype.descr][::2]):
+        for column, field in zip(self.subject.fetch['subject_id'::2], [e[0] for e in tmp.dtype.descr][::2]):
             np.testing.assert_array_equal(sorted(tmp[field]), sorted(column), 'slice : does not work correctly')


### PR DESCRIPTION
- the behavior of `relation.fetch()` and `relation.fetch1()` should be reproduced
- `relation.keys()` moved to `relation.fetch.keys()`
- `relation.values()` was removed and is now `relation.fetch.__iter__()`

It probably needs more thorough testing, but I put it up so we can start using it. 