### PR TITLE
Extended order_by and bugfixes

### DIFF
--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -56,9 +56,10 @@ class Fetch:
     def order_by(self, *args):
         if len(args) > 0:
             self.behavior['order_by'] = self.behavior['order_by'] if self.behavior['order_by'] is not None else []
+            namepat = re.compile(r"\s*(?P<name>\w+).*")
             for a in args: # remove duplicates
-                name = a.split('=')[0].strip()
-                pat = re.compile(r"%s\s*(=\s*(DESC|ASC)\s*|)?$" % (name,), re.I)
+                name = namepat.match(a).group('name')
+                pat = re.compile(r"%s(\s*$|\s+(\S*\s*)*$)" % (name,))
                 self.behavior['order_by'] = [e for e in self.behavior['order_by'] if not pat.match(e)]
             self.behavior['order_by'].extend(args)
         return self

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -181,18 +181,7 @@ class RelationalOperand(metaclass=abc.ABCMeta):
             raise DataJointError('limit is required when offset is set')
         sql = self.make_select()
         if order_by is not None:
-            order_attr, order = [], []
-            for a in order_by:
-                a = [e.strip() for e in a.split('=')]
-                if len(a) == 1:
-                    order_attr.append(a[0])
-                    order.append('ASC')
-                else:
-                    order_attr.append(a[0])
-                    order.append(a[1])
-
-            sql += ' ORDER BY ' + ', '.join(['`%s` %s' % (attr, val) for attr, val in
-                                            zip(order_attr, order)])
+            sql += ' ORDER BY ' + ', '.join(order_by)
 
         if limit is not None:
             sql += ' LIMIT %d' % limit

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -39,6 +39,26 @@ class Subject(dj.Manual):
     def prepare(self):
         self.insert(self.contents, ignore_errors=True)
 
+@schema
+class Language(dj.Lookup):
+
+    definition = """
+    # languages spoken by some of the developers
+
+    entry_id    : int
+    ---
+    name        : varchar(40) # name of the developer
+    language    : varchar(40) # language
+    """
+
+    contents = [
+            (0, 'Fabian', 'English'),
+            (1, 'Edgar', 'English'),
+            (2, 'Dimitri', 'English'),
+            (3, 'Dimitri', 'Ukrainian'),
+            (4, 'Fabian', 'German'),
+            (5, 'Edgar', 'Japanese'),
+        ]
 
 @schema
 class Experiment(dj.Imported):

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,121 @@
+from operator import itemgetter, attrgetter
+import itertools
+from nose.tools import assert_true
+from numpy.testing import assert_array_equal, assert_equal
+import numpy as np
+
+from . import schema
+import datajoint as dj
+
+
+class TestFetch:
+    def __init__(self):
+        self.subject = schema.Subject()
+        self.lang = schema.Language()
+
+    def test_getitem(self):
+        """Testing Fetch.__getitem__"""
+
+        np.testing.assert_array_equal(sorted(self.subject.project().fetch(), key=itemgetter(0)),
+                                      sorted(self.subject.fetch[dj.key], key=itemgetter(0)),
+                                      'Primary key is not returned correctly')
+
+        tmp = self.subject.fetch(order_by=['subject_id'])
+
+        for column, field in zip(self.subject.fetch[:], [e[0] for e in tmp.dtype.descr]):
+            np.testing.assert_array_equal(sorted(tmp[field]), sorted(column), 'slice : does not work correctly')
+
+        subject_notes, key, real_id = self.subject.fetch['subject_notes', dj.key, 'real_id']
+        #
+        np.testing.assert_array_equal(sorted(subject_notes), sorted(tmp['subject_notes']))
+        np.testing.assert_array_equal(sorted(real_id), sorted(tmp['real_id']))
+        np.testing.assert_array_equal(sorted(key, key=itemgetter(0)),
+                                      sorted(self.subject.project().fetch(), key=itemgetter(0)))
+
+        for column, field in zip(self.subject.fetch['subject_id'::2], [e[0] for e in tmp.dtype.descr][::2]):
+            np.testing.assert_array_equal(sorted(tmp[field]), sorted(column), 'slice : does not work correctly')
+
+    def test_order_by(self):
+        """Tests order_by sorting order"""
+        langs = schema.Language.contents
+
+        for ord_name, ord_lang in itertools.product(*2 * [['ASC', 'DESC']]):
+            cur = self.lang.fetch.order_by('name=' + ord_name, 'language=' + ord_lang)()
+            langs.sort(key=itemgetter(2), reverse=ord_lang == 'DESC')
+            langs.sort(key=itemgetter(1), reverse=ord_name == 'DESC')
+            for c, l in zip(cur, langs):
+                assert_true(np.all(cc == ll for cc, ll in zip(c, l)), 'Sorting order is different')
+
+    def test_order_by_default(self):
+        """Tests order_by sorting order with defaults"""
+        langs = schema.Language.contents
+
+        cur = self.lang.fetch.order_by('language', 'name=DESC')()
+        langs.sort(key=itemgetter(1), reverse=True)
+        langs.sort(key=itemgetter(2), reverse=False)
+
+        for c, l in zip(cur, langs):
+            assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
+
+    def test_order_by_direct(self):
+        """Tests order_by sorting order passing it to __call__"""
+        langs = schema.Language.contents
+
+        cur = self.lang.fetch(order_by=['language', 'name=DESC'])
+        langs.sort(key=itemgetter(1), reverse=True)
+        langs.sort(key=itemgetter(2), reverse=False)
+        for c, l in zip(cur, langs):
+            assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
+
+    def test_limit_to(self):
+        """Test the limit_to function """
+        langs = schema.Language.contents
+
+        cur = self.lang.fetch.limit_to(4)(order_by=['language', 'name=DESC'])
+        langs.sort(key=itemgetter(1), reverse=True)
+        langs.sort(key=itemgetter(2), reverse=False)
+        assert_equal(len(cur), 4, 'Length is not correct')
+        for c, l in list(zip(cur, langs))[:4]:
+            assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
+
+    def test_from_to(self):
+        """Test the from_to function """
+        langs = schema.Language.contents
+
+        cur = self.lang.fetch.from_to(2, 6)(order_by=['language', 'name=DESC'])
+        langs.sort(key=itemgetter(1), reverse=True)
+        langs.sort(key=itemgetter(2), reverse=False)
+        assert_equal(len(cur), 4, 'Length is not correct')
+        for c, l in list(zip(cur, langs[2:6])):
+            assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
+
+    def test_iter(self):
+        """Test iterator"""
+        langs = schema.Language.contents
+
+        cur = self.lang.fetch.order_by('language', 'name=DESC')
+        langs.sort(key=itemgetter(1), reverse=True)
+        langs.sort(key=itemgetter(2), reverse=False)
+        for (_, name, lang), (_, tname, tlang) in list(zip(cur, langs)):
+            assert_true(name == tname and lang == tlang, 'Values are not the same')
+
+    def test_keys(self):
+        """test key iterator"""
+        langs = schema.Language.contents
+        langs.sort(key=itemgetter(1), reverse=True)
+        langs.sort(key=itemgetter(2), reverse=False)
+
+        cur = self.lang.fetch.order_by('language', 'name=DESC')['entry_id']
+        cur2 = [e['entry_id'] for e in self.lang.fetch.order_by('language', 'name=DESC').keys()]
+
+        keys, _, _ = list(zip(*langs))
+        for k, c, c2 in zip(keys, cur, cur2):
+            assert_true(k == c == c2, 'Values are not the same')
+
+    def test_fetch1(self):
+        key = {'entry_id': 0}
+        true = schema.Language.contents[0]
+
+        dat = (self.lang & key).fetch1()
+        for k, (ke, c) in zip(true, dat.items()):
+            assert_true(k == c == (self.lang & key).fetch1[ke], 'Values are not the same')

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -119,3 +119,15 @@ class TestFetch:
         dat = (self.lang & key).fetch1()
         for k, (ke, c) in zip(true, dat.items()):
             assert_true(k == c == (self.lang & key).fetch1[ke], 'Values are not the same')
+
+    def test_copy(self):
+        """Test whether modifications copy the object"""
+        f = self.lang.fetch
+        f2 = f.order_by('name')
+        assert_true(f.behavior['order_by'] is None and len(f2.behavior['order_by']) == 1, 'Object was not copied')
+
+    def test_overwrite(self):
+        """Test whether order_by overwrites duplicates"""
+        f = self.lang.fetch.order_by('name =   DeSc ')
+        f2 = f.order_by('name')
+        assert_true(f2.behavior['order_by'] == ['name'], 'order_by attribute was not overwritten')

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -40,7 +40,7 @@ class TestFetch:
         langs = schema.Language.contents
 
         for ord_name, ord_lang in itertools.product(*2 * [['ASC', 'DESC']]):
-            cur = self.lang.fetch.order_by('name=' + ord_name, 'language=' + ord_lang)()
+            cur = self.lang.fetch.order_by('name ' + ord_name, 'language ' + ord_lang)()
             langs.sort(key=itemgetter(2), reverse=ord_lang == 'DESC')
             langs.sort(key=itemgetter(1), reverse=ord_name == 'DESC')
             for c, l in zip(cur, langs):
@@ -50,7 +50,7 @@ class TestFetch:
         """Tests order_by sorting order with defaults"""
         langs = schema.Language.contents
 
-        cur = self.lang.fetch.order_by('language', 'name=DESC')()
+        cur = self.lang.fetch.order_by('language', 'name DESC')()
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
 
@@ -61,7 +61,7 @@ class TestFetch:
         """Tests order_by sorting order passing it to __call__"""
         langs = schema.Language.contents
 
-        cur = self.lang.fetch(order_by=['language', 'name=DESC'])
+        cur = self.lang.fetch(order_by=['language', 'name DESC'])
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
         for c, l in zip(cur, langs):
@@ -71,7 +71,7 @@ class TestFetch:
         """Test the limit_to function """
         langs = schema.Language.contents
 
-        cur = self.lang.fetch.limit_to(4)(order_by=['language', 'name=DESC'])
+        cur = self.lang.fetch.limit_to(4)(order_by=['language', 'name DESC'])
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
         assert_equal(len(cur), 4, 'Length is not correct')
@@ -82,7 +82,7 @@ class TestFetch:
         """Test the from_to function """
         langs = schema.Language.contents
 
-        cur = self.lang.fetch.from_to(2, 6)(order_by=['language', 'name=DESC'])
+        cur = self.lang.fetch.from_to(2, 6)(order_by=['language', 'name DESC'])
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
         assert_equal(len(cur), 4, 'Length is not correct')
@@ -93,7 +93,7 @@ class TestFetch:
         """Test iterator"""
         langs = schema.Language.contents
 
-        cur = self.lang.fetch.order_by('language', 'name=DESC')
+        cur = self.lang.fetch.order_by('language', 'name DESC')
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
         for (_, name, lang), (_, tname, tlang) in list(zip(cur, langs)):
@@ -105,8 +105,8 @@ class TestFetch:
         langs.sort(key=itemgetter(1), reverse=True)
         langs.sort(key=itemgetter(2), reverse=False)
 
-        cur = self.lang.fetch.order_by('language', 'name=DESC')['entry_id']
-        cur2 = [e['entry_id'] for e in self.lang.fetch.order_by('language', 'name=DESC').keys()]
+        cur = self.lang.fetch.order_by('language', 'name DESC')['entry_id']
+        cur2 = [e['entry_id'] for e in self.lang.fetch.order_by('language', 'name DESC').keys()]
 
         keys, _, _ = list(zip(*langs))
         for k, c, c2 in zip(keys, cur, cur2):
@@ -128,6 +128,6 @@ class TestFetch:
 
     def test_overwrite(self):
         """Test whether order_by overwrites duplicates"""
-        f = self.lang.fetch.order_by('name =   DeSc ')
+        f = self.lang.fetch.order_by('name    DeSc ')
         f2 = f.order_by('name')
         assert_true(f2.behavior['order_by'] == ['name'], 'order_by attribute was not overwritten')

--- a/tests/test_relational_operand.py
+++ b/tests/test_relational_operand.py
@@ -53,28 +53,3 @@ import datajoint as dj
 #     def test_not(self):
 #         pass
 
-class TestRelationalOperand:
-    def __init__(self):
-        self.subject = schema.Subject()
-
-    def test_getitem(self):
-        """Testing RelationalOperand.__getitem__"""
-
-        np.testing.assert_array_equal(sorted(self.subject.project().fetch(), key=itemgetter(0)),
-                                      sorted(self.subject.fetch[dj.key], key=itemgetter(0)),
-                                      'Primary key is not returned correctly')
-
-        tmp = self.subject.fetch(order_by=['subject_id'])
-
-        for column, field in zip(self.subject.fetch[:], [e[0] for e in tmp.dtype.descr]):
-            np.testing.assert_array_equal(sorted(tmp[field]), sorted(column), 'slice : does not work correctly')
-
-        subject_notes, key, real_id = self.subject.fetch['subject_notes', dj.key, 'real_id']
-        #
-        np.testing.assert_array_equal(sorted(subject_notes), sorted(tmp['subject_notes']))
-        np.testing.assert_array_equal(sorted(real_id), sorted(tmp['real_id']))
-        np.testing.assert_array_equal(sorted(key, key=itemgetter(0)),
-                                      sorted(self.subject.project().fetch(), key=itemgetter(0)))
-
-        for column, field in zip(self.subject.fetch['subject_id'::2], [e[0] for e in tmp.dtype.descr][::2]):
-            np.testing.assert_array_equal(sorted(tmp[field]), sorted(column), 'slice : does not work correctly')


### PR DESCRIPTION
- `relation.fetch.order_by` allows for individual sorting arguments now. I removed the kwarg `descending`. The new syntax is `relation.fetch.order_by('name DESC', 'trial', 'stimulus DESC')`. If the sorting argument is omitted, ASC is set by default. 

- I removed the `relation.fetch.apply` function. It is not needed at the moment and simplified the syntax substantially. Additionally, it might cause confusion, since something like `relation.fetch.apply(myfunc).order_by('stimulus')['name']` suggests that the function is applied in the beginning, but it would have been applied at the end. 

- I renamed `FetchQuery` to `Fetch` and `Fetch1Query` to `Fetch1`

- I renamed `limit_by` to `limit_to`. Dimitri actually prefers `limit`, but I think `limit_to` is more consistent with `order_by`. 

- Wrote quite a few more tests. 