### PR TITLE
Work on fetch objects and rename `_prepare`

### DIFF
--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -55,20 +55,13 @@ class Fetch:
     @copy_first
     def order_by(self, *args):
         if len(args) > 0:
-            self.behavior['order_by'] = self.behavior['order_by'] if self.behavior['order_by'] is not None else []
-            namepat = re.compile(r"\s*(?P<name>\w+).*")
-            for a in args: # remove duplicates
-                name = namepat.match(a).group('name')
-                pat = re.compile(r"%s(\s*$|\s+(\S*\s*)*$)" % (name,))
-                self.behavior['order_by'] = [e for e in self.behavior['order_by'] if not pat.match(e)]
-            self.behavior['order_by'].extend(args)
+            self.behavior['order_by'] = args
         return self
 
     @copy_first
     def as_dict(self):
         self.behavior['as_dict'] = True
         return self
-
 
     @copy_first
     def limit_to(self, limit):

--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -264,7 +264,7 @@ class Relation(RelationalOperand, metaclass=abc.ABCMeta):
         return ret['Data_length'] + ret['Index_length']
 
     # --------- functionality used by the decorator ---------
-    def prepare(self):
+    def _prepare(self):
         """
         This method is overridden by the user_relations subclasses. It is called on an instance
         once when the class is declared.

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -53,7 +53,7 @@ class schema:
         # trigger table declaration by requesting the heading from an instance
         instance = cls()
         instance.heading
-        instance.prepare()
+        instance._prepare()
         return cls
 
     @property

--- a/datajoint/user_relations.py
+++ b/datajoint/user_relations.py
@@ -34,7 +34,7 @@ class Lookup(Relation):
         """
         return '#' + from_camel_case(self.__class__.__name__)
 
-    def prepare(self):
+    def _prepare(self):
         """
         Checks whether the instance has a property called `contents` and inserts its elements.
         """

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -36,7 +36,7 @@ class Subject(dj.Manual):
         [1552, '1552', 'mouse', '2015-06-15', ''],
         [1553, '1553', 'mouse', '2016-07-01', '']]
 
-    def prepare(self):
+    def _prepare(self):
         self.insert(self.contents, ignore_errors=True)
 
 @schema
@@ -45,19 +45,18 @@ class Language(dj.Lookup):
     definition = """
     # languages spoken by some of the developers
 
-    entry_id    : int
-    ---
     name        : varchar(40) # name of the developer
     language    : varchar(40) # language
+    ---
     """
 
     contents = [
-            (0, 'Fabian', 'English'),
-            (1, 'Edgar', 'English'),
-            (2, 'Dimitri', 'English'),
-            (3, 'Dimitri', 'Ukrainian'),
-            (4, 'Fabian', 'German'),
-            (5, 'Edgar', 'Japanese'),
+            ('Fabian', 'English'),
+            ('Edgar', 'English'),
+            ('Dimitri', 'English'),
+            ('Dimitri', 'Ukrainian'),
+            ('Fabian', 'German'),
+            ('Edgar', 'Japanese'),
         ]
 
 @schema

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -41,8 +41,8 @@ class TestFetch:
 
         for ord_name, ord_lang in itertools.product(*2 * [['ASC', 'DESC']]):
             cur = self.lang.fetch.order_by('name ' + ord_name, 'language ' + ord_lang)()
-            langs.sort(key=itemgetter(2), reverse=ord_lang == 'DESC')
-            langs.sort(key=itemgetter(1), reverse=ord_name == 'DESC')
+            langs.sort(key=itemgetter(1), reverse=ord_lang == 'DESC')
+            langs.sort(key=itemgetter(0), reverse=ord_name == 'DESC')
             for c, l in zip(cur, langs):
                 assert_true(np.all(cc == ll for cc, ll in zip(c, l)), 'Sorting order is different')
 
@@ -51,8 +51,8 @@ class TestFetch:
         langs = schema.Language.contents
 
         cur = self.lang.fetch.order_by('language', 'name DESC')()
-        langs.sort(key=itemgetter(1), reverse=True)
-        langs.sort(key=itemgetter(2), reverse=False)
+        langs.sort(key=itemgetter(0), reverse=True)
+        langs.sort(key=itemgetter(1), reverse=False)
 
         for c, l in zip(cur, langs):
             assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
@@ -62,8 +62,8 @@ class TestFetch:
         langs = schema.Language.contents
 
         cur = self.lang.fetch(order_by=['language', 'name DESC'])
-        langs.sort(key=itemgetter(1), reverse=True)
-        langs.sort(key=itemgetter(2), reverse=False)
+        langs.sort(key=itemgetter(0), reverse=True)
+        langs.sort(key=itemgetter(1), reverse=False)
         for c, l in zip(cur, langs):
             assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
 
@@ -72,8 +72,8 @@ class TestFetch:
         langs = schema.Language.contents
 
         cur = self.lang.fetch.limit_to(4)(order_by=['language', 'name DESC'])
-        langs.sort(key=itemgetter(1), reverse=True)
-        langs.sort(key=itemgetter(2), reverse=False)
+        langs.sort(key=itemgetter(0), reverse=True)
+        langs.sort(key=itemgetter(1), reverse=False)
         assert_equal(len(cur), 4, 'Length is not correct')
         for c, l in list(zip(cur, langs))[:4]:
             assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
@@ -83,8 +83,8 @@ class TestFetch:
         langs = schema.Language.contents
 
         cur = self.lang.fetch.from_to(2, 6)(order_by=['language', 'name DESC'])
-        langs.sort(key=itemgetter(1), reverse=True)
-        langs.sort(key=itemgetter(2), reverse=False)
+        langs.sort(key=itemgetter(0), reverse=True)
+        langs.sort(key=itemgetter(1), reverse=False)
         assert_equal(len(cur), 4, 'Length is not correct')
         for c, l in list(zip(cur, langs[2:6])):
             assert_true(np.all([cc == ll for cc, ll in zip(c, l)]), 'Sorting order is different')
@@ -94,27 +94,26 @@ class TestFetch:
         langs = schema.Language.contents
 
         cur = self.lang.fetch.order_by('language', 'name DESC')
-        langs.sort(key=itemgetter(1), reverse=True)
-        langs.sort(key=itemgetter(2), reverse=False)
-        for (_, name, lang), (_, tname, tlang) in list(zip(cur, langs)):
+        langs.sort(key=itemgetter(0), reverse=True)
+        langs.sort(key=itemgetter(1), reverse=False)
+        for (name, lang), (tname, tlang) in list(zip(cur, langs)):
             assert_true(name == tname and lang == tlang, 'Values are not the same')
 
     def test_keys(self):
         """test key iterator"""
         langs = schema.Language.contents
-        langs.sort(key=itemgetter(1), reverse=True)
-        langs.sort(key=itemgetter(2), reverse=False)
+        langs.sort(key=itemgetter(0), reverse=True)
+        langs.sort(key=itemgetter(1), reverse=False)
 
-        cur = self.lang.fetch.order_by('language', 'name DESC')['entry_id']
-        cur2 = [e['entry_id'] for e in self.lang.fetch.order_by('language', 'name DESC').keys()]
+        cur = self.lang.fetch.order_by('language', 'name DESC')['name','language']
+        cur2 = list(self.lang.fetch.order_by('language', 'name DESC').keys())
 
-        keys, _, _ = list(zip(*langs))
-        for k, c, c2 in zip(keys, cur, cur2):
-            assert_true(k == c == c2, 'Values are not the same')
+        for c, c2 in zip(zip(*cur), cur2):
+            assert_true(c == tuple(c2.values()), 'Values are not the same')
 
     def test_fetch1(self):
-        key = {'entry_id': 0}
-        true = schema.Language.contents[0]
+        key = {'name': 'Edgar', 'language':'Japanese'}
+        true = schema.Language.contents[-1]
 
         dat = (self.lang & key).fetch1()
         for k, (ke, c) in zip(true, dat.items()):
@@ -126,8 +125,3 @@ class TestFetch:
         f2 = f.order_by('name')
         assert_true(f.behavior['order_by'] is None and len(f2.behavior['order_by']) == 1, 'Object was not copied')
 
-    def test_overwrite(self):
-        """Test whether order_by overwrites duplicates"""
-        f = self.lang.fetch.order_by('name    DeSc ')
-        f2 = f.order_by('name')
-        assert_true(f2.behavior['order_by'] == ['name'], 'order_by attribute was not overwritten')


### PR DESCRIPTION
- Test fetch table normal form
- `prepare` renamed to `_prepare`
- `order_by` overwrites **all** previous ordering settings