### PR TITLE
Rearrange `__repr__`

### DIFF
--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -174,11 +174,13 @@ class Fetch:
         repr_string += ' '.join(['+' + '-' * (width - 2) + '+' for _ in columns]) + '\n'
         for tup in rel.fetch(limit=limit):
             repr_string += ' '.join([template % column for column in tup]) + '\n'
-        if len(self._relation) > limit:
+        if len(rel) > limit:
             repr_string += '...\n'
-        repr_string += ' (%d tuples)\n' % len(self._relation)
+        repr_string += ' (%d tuples)\n' % len(rel)
         return repr_string
 
+    def __len__(self):
+        return len(self._relation)
 
 class Fetch1:
     def __init__(self, relation):

--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -8,6 +8,7 @@ import numpy as np
 from datajoint import DataJointError
 from . import key as PRIMARY_KEY
 from collections import abc
+from . import config
 
 
 def prepare_attributes(relation, item):
@@ -35,7 +36,9 @@ def copy_first(f):
 
     return ret
 
+
 class Fetch:
+
     def __init__(self, relation):
         if isinstance(relation, Fetch): # copy constructor
             self.behavior = dict(relation.behavior)
@@ -45,7 +48,6 @@ class Fetch:
                 offset=None, limit=None, order_by=None, as_dict=False
             )
             self._relation = relation
-
 
     @copy_first
     def order_by(self, *args):
@@ -161,6 +163,21 @@ class Fetch:
             for attribute in item
             ]
         return return_values[0] if single_output else return_values
+
+    def __repr__(self):
+        limit = config['display.limit']
+        width = config['display.width']
+        rel = self._relation.project(*self._relation.heading.non_blobs)  # project out blobs
+        template = '%%-%d.%ds' % (width, width)
+        columns = rel.heading.names
+        repr_string = ' '.join([template % column for column in columns]) + '\n'
+        repr_string += ' '.join(['+' + '-' * (width - 2) + '+' for _ in columns]) + '\n'
+        for tup in rel.fetch(limit=limit):
+            repr_string += ' '.join([template % column for column in tup]) + '\n'
+        if len(self._relation) > limit:
+            repr_string += '...\n'
+        repr_string += ' (%d tuples)\n' % len(self._relation)
+        return repr_string
 
 
 class Fetch1:

--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -107,7 +107,7 @@ class Relation(RelationalOperand, metaclass=abc.ABCMeta):
         return [relation for relation in relations if relation.is_declared]
 
     def _repr_helper(self):
-        return self.full_table_name
+        return "%s.%s()" % (self.__module__, self.__class__.__name__)
 
     # --------- SQL functionality --------- #
     @property

--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -285,6 +285,9 @@ class FreeRelation(Relation):
         self._definition = definition
         self._context = context
 
+    def __repr__(self):
+        return "FreeRelation(`%s`.`%s`)" % (self.database, self._table_name)
+
     @property
     def definition(self):
         return self._definition

--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -106,6 +106,9 @@ class Relation(RelationalOperand, metaclass=abc.ABCMeta):
                      for table in self.connection.erm.get_descendants(self.full_table_name))
         return [relation for relation in relations if relation.is_declared]
 
+    def _repr_helper(self):
+        return self.full_table_name
+
     # --------- SQL functionality --------- #
     @property
     def is_declared(self):

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -125,3 +125,11 @@ class TestFetch:
         f2 = f.order_by('name')
         assert_true(f.behavior['order_by'] is None and len(f2.behavior['order_by']) == 1, 'Object was not copied')
 
+    def test_repr(self):
+        """Test string representation of fetch, returning table preview"""
+        repr = self.subject.fetch.__repr__()
+        n = len(repr.strip().split('\n'))
+        limit = dj.config['display.limit']
+        # 3 lines are used for headers (2) and summary statement (1)
+        assert_true(n - 3 <= limit)
+


### PR DESCRIPTION
* Moved table preview into `Fetch` object's `__repr__`
* Modify 'RelationalOperand`'s `__repr__` to represent the constituent relational operation 
* Add `__len__` onto `Fetch` object

`Fetch1` object's `__repr__` was not touched as it didn't quite make sense for this to be previewable (should only be one row, and fetching it for display costs about the same as just grabbing it).