### PR TITLE
Added the option to randomize AutoPopulate order.  Improved the timing of prepare calls for Part relations.

### DIFF
--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -14,18 +14,16 @@ import os
 __author__ = "Dimitri Yatsenko, Edgar Walker, and Fabian Sinz at Baylor College of Medicine"
 __version__ = "0.2"
 __all__ = ['__author__', '__version__',
-           'config',
-           'Connection', 'Heading', 'Relation', 'FreeRelation', 'Not',
-           'Relation', 'schema',
-           'Manual', 'Lookup', 'Imported', 'Computed', 'Part',
-           'conn', 'kill']
+           'config', 'conn', 'kill',
+           'Connection', 'Heading', 'Relation', 'FreeRelation', 'Not', 'schema',
+           'Manual', 'Lookup', 'Imported', 'Computed', 'Part']
 
 
-# define an object that identifies the primary key in RelationalOperand.__getitem__
-class PrimaryKey:
+class key:
+    """
+    object that allows requesting the primary key in Fetch.__getitem__
+    """
     pass
-
-key = PrimaryKey
 
 
 class DataJointError(Exception):

--- a/datajoint/kill.py
+++ b/datajoint/kill.py
@@ -32,7 +32,7 @@ def kill(restriction=None, connection=None):
             except TypeError as err:
                 print(process)
 
-        response = input('process to kill or "q" to quit)')
+        response = input('process to kill or "q" to quit > ')
         if response == 'q':
             break
         if response:

--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -274,8 +274,7 @@ class Relation(RelationalOperand, metaclass=abc.ABCMeta):
         """
         ret = self.connection.query(
             'SHOW TABLE STATUS FROM `{database}` WHERE NAME="{table}"'.format(
-                database=self.database, table=self.table_name), as_dict=True
-        ).fetchone()
+                database=self.database, table=self.table_name), as_dict=True).fetchone()
         return ret['Data_length'] + ret['Index_length']
 
     # --------- functionality used by the decorator ---------

--- a/datajoint/user_relations.py
+++ b/datajoint/user_relations.py
@@ -2,13 +2,14 @@
 Hosts the table tiers, user relations should be derived from.
 """
 
-from datajoint.relation import Relation
+import abc
+from .relation import Relation
 from .autopopulate import AutoPopulate
 from .utils import from_camel_case
 from . import DataJointError
 
 
-class Part(Relation):
+class Part(Relation, metaclass=abc.ABCMeta):
 
     @property
     def master(self):
@@ -22,7 +23,7 @@ class Part(Relation):
         return self.master().table_name + '__' + from_camel_case(self.__class__.__name__)
 
 
-class Manual(Relation):
+class Manual(Relation, metaclass=abc.ABCMeta):
     """
     Inherit from this class if the table's values are entered manually.
     """
@@ -35,7 +36,7 @@ class Manual(Relation):
         return from_camel_case(self.__class__.__name__)
 
 
-class Lookup(Relation):
+class Lookup(Relation, metaclass=abc.ABCMeta):
     """
     Inherit from this class if the table's values are for lookup. This is
     currently equivalent to defining the table as Manual and serves semantic
@@ -54,10 +55,10 @@ class Lookup(Relation):
         Checks whether the instance has a property called `contents` and inserts its elements.
         """
         if hasattr(self, 'contents'):
-            self.insert(self.contents, ignore_errors=False, skip_duplicates=True)
+            self.insert(self.contents, skip_duplicates=True)
 
 
-class Imported(Relation, AutoPopulate):
+class Imported(Relation, AutoPopulate, metaclass=abc.ABCMeta):
     """
     Inherit from this class if the table's values are imported from external data sources.
     The inherited class must at least provide the function `_make_tuples`.
@@ -71,7 +72,7 @@ class Imported(Relation, AutoPopulate):
         return "_" + from_camel_case(self.__class__.__name__)
 
 
-class Computed(Relation, AutoPopulate):
+class Computed(Relation, AutoPopulate, metaclass=abc.ABCMeta):
     """
     Inherit from this class if the table's values are computed from other relations in the schema.
     The inherited class must at least provide the function `_make_tuples`.


### PR DESCRIPTION
- Minor cleanup
- Added the `order` parameter to AutoPopulate.populate()
- For Part relations, prepare is now called after their tables are declared.  