### PR TITLE
Fixed issue #15

### DIFF
--- a/datajoint/relation.py
+++ b/datajoint/relation.py
@@ -264,7 +264,7 @@ class Relation(RelationalOperand, metaclass=abc.ABCMeta):
 
         # construct restrictions for each relation
         restrict_by_me = set()
-        restrictions = defaultdict(lambda: list())
+        restrictions = defaultdict(list)
         if self.restrictions:
             restrict_by_me.add(self.full_table_name)
             restrictions[self.full_table_name] = self.restrictions  # copy own restrictions
@@ -279,9 +279,9 @@ class Relation(RelationalOperand, metaclass=abc.ABCMeta):
 
         # apply restrictions
         for name, r in relations.items():
-            if restrictions[name]:
+            if restrictions[name]:  # do not restrict by an empty list
                 r.restrict([r.project() if isinstance(r, RelationalOperand) else r
-                            for r in restrictions[name]])
+                            for r in restrictions[name]])  # project 
 
         # execute
         do_delete = False  # indicate if there is anything to delete

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -33,6 +33,6 @@ def test_reserve_job():
         assert_false(schema.schema.jobs.reserve(table_name, key),
                      'failed to ignore error jobs')
     # clear error jobs
-    (schema.schema.jobs & dict(status="error")).delete()
+    (schema.schema.jobs & dict(status="error")).delete_quick()
     assert_false(schema.schema.jobs,
                  'failed to clear error jobs')


### PR DESCRIPTION
Converging dependencies are now handled correctly in deletes.
Also, `rel & [cond1, cond2, ...]` now works for any type of conditions, including relations and strings. The conditioned are ORed in this case.