### PR TITLE
tables are not declare if definition is None or Ellipsis

### DIFF
--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -32,6 +32,12 @@ class DataJointError(Exception):
     """
     pass
 
+class NoDefinitionError(DataJointError):
+    """
+    Error raised if table definition is not there.
+    """
+    pass
+
 # ----------- loads local configuration from file ----------------
 from .settings import Config, LOCALCONFIG, GLOBALCONFIG, logger, log_levels
 config = Config()

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -5,14 +5,13 @@ import logging
 import abc
 import binascii
 
-from . import config
+from . import config, NoDefinitionError
 from . import DataJointError
 from .declare import declare
 from .relational_operand import RelationalOperand
 from .blob import pack
 from .utils import user_choice
 from .heading import Heading
-from warnings import warn
 
 logger = logging.getLogger(__name__)
 
@@ -76,9 +75,8 @@ class BaseRelation(RelationalOperand, metaclass=abc.ABCMeta):
                     declare(self.full_table_name, self.definition, self._context))
             else:
                 name = self.__class__.__name__
-                warn("""Table for %s is not declared and definition is not defined.
-                        This table is probably defined but not yet declared in Matlab.""" % (name, ))
-                logger.info("Table for %s is not declared and definition is not defined." % (name, ))
+                raise NoDefinitionError("%s.definition is not defined and table is not in the database." % (name,))
+
 
     @property
     def from_clause(self):

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -12,6 +12,7 @@ from .relational_operand import RelationalOperand
 from .blob import pack
 from .utils import user_choice
 from .heading import Heading
+from warnings import warn
 
 logger = logging.getLogger(__name__)
 
@@ -70,8 +71,14 @@ class BaseRelation(RelationalOperand, metaclass=abc.ABCMeta):
         Loads the table heading. If the table is not declared, use self.definition to declare
         """
         if not self.is_declared:
-            self.connection.query(
-                declare(self.full_table_name, self.definition, self._context))
+            if self.definition is not None and self.definition is not Ellipsis:
+                self.connection.query(
+                    declare(self.full_table_name, self.definition, self._context))
+            else:
+                name = self.__class__.__name__
+                warn("""Table for %s is not declared and definition is not defined.
+                        This table is probably defined but not yet declared in Matlab.""" % (name, ))
+                logger.info("Table for %s is not declared and definition is not defined." % (name, ))
 
     @property
     def from_clause(self):

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -70,12 +70,8 @@ class BaseRelation(RelationalOperand, metaclass=abc.ABCMeta):
         Loads the table heading. If the table is not declared, use self.definition to declare
         """
         if not self.is_declared:
-            if self.definition is not None and self.definition is not Ellipsis:
-                self.connection.query(
-                    declare(self.full_table_name, self.definition, self._context))
-            else:
-                name = self.__class__.__name__
-                raise NoDefinitionError("%s.definition is not defined and table is not in the database." % (name,))
+            self.connection.query(
+                declare(self.full_table_name, self.definition, self._context))
 
 
     @property

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1,5 +1,5 @@
 import warnings
-from nose.tools import assert_true, assert_false, assert_equal, assert_list_equal
+from nose.tools import assert_true, assert_false, assert_equal, assert_list_equal, raises
 from . import schema
 import datajoint as dj
 
@@ -67,7 +67,8 @@ class TestDeclare:
         assert_equal(channel.parents, [ephys.full_table_name])
 
     @staticmethod
-    def test_defined_in_matlab():
+    def test_definition_defined():
+        """Test whether a warning is raised if the definition is not defined."""
         with warnings.catch_warnings(record=True) as warning_list:
             warnings.simplefilter('always')
 
@@ -78,5 +79,18 @@ class TestDeclare:
             @schema
             class FromMatlab(dj.Manual):
                 definition = ...
-            assert_true(any(["Table for FromMatlab is not declared and definition is not defined." in str(w.message)
+            assert_true(any(["Table FromMatlab will not be declared because definition is not defined." in str(w.message)
                              for w in warning_list]))
+
+    @raises(dj.NoDefinitionError)
+    def test_no_definition_error(self):
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter('always')
+            from . import PREFIX, CONN_INFO
+
+            schema = dj.schema(PREFIX + '_test1', locals(), connection=dj.conn(**CONN_INFO))
+
+            @schema
+            class FromMatlab(dj.Manual):
+                definition = ...
+        FromMatlab().declare()

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -66,21 +66,6 @@ class TestDeclare:
         assert_equal(ephys.children, [channel.full_table_name])
         assert_equal(channel.parents, [ephys.full_table_name])
 
-    @staticmethod
-    def test_definition_defined():
-        """Test whether a warning is raised if the definition is not defined."""
-        with warnings.catch_warnings(record=True) as warning_list:
-            warnings.simplefilter('always')
-
-            from . import PREFIX, CONN_INFO
-
-            schema = dj.schema(PREFIX + '_test1', locals(), connection=dj.conn(**CONN_INFO))
-
-            @schema
-            class FromMatlab(dj.Manual):
-                definition = ...
-            assert_true(any(["Table FromMatlab will not be declared because definition is not defined." in str(w.message)
-                             for w in warning_list]))
 
     @raises(dj.NoDefinitionError)
     def test_no_definition_error(self):


### PR DESCRIPTION
So far, if a schema is defined in matlab, the corresponding class in python does not define a definition (for consistency). The syntax is 

```python
class MyMatlabTable(dj.Tier):
   definition = None
```


```python
class MyMatlabTable(dj.Tier):
   definition = ...
```

The problem is that this will raise an error if the matlab table has not yet been defined in the database. This pull request solves that by checking whether `definition=None` or `definition=...` in `BaseRelation.declare`. If that is the case, then the table is not declared and a warning is raised. 

I refrained from overriding the constructor because the user might have defined a constructor and I didn't want to mess with that. 