### PR TITLE
Mutation of OrderedDict iterator during the loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist/
 build/
 MANIFEST
 .vagrant/
+dj_local_conf.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
   - DJ_TEST_HOST="127.0.0.1" DJ_TEST_USER="root" DJ_TEST_PASSWORD="" DJ_HOST="127.0.0.1" DJ_USER="root" DJ_PASSWORD=""
 python:
   - "3.4"
+  - "3.5"
 services: mysql
 install:
   - pip install -r requirements.txt

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -357,7 +357,7 @@ class BaseRelation(RelationalOperand, metaclass=abc.ABCMeta):
         do_delete = False  # indicate if there is anything to delete
         if config['safemode']:
             print('The contents of the following tables are about to be deleted:')
-        for relation in list(relations.values()):
+        for relation in relations.values():
             count = len(relation)
             if count:
                 do_delete = True

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -357,7 +357,7 @@ class BaseRelation(RelationalOperand, metaclass=abc.ABCMeta):
         do_delete = False  # indicate if there is anything to delete
         if config['safemode']:
             print('The contents of the following tables are about to be deleted:')
-        for relation in relations.values():
+        for relation in list(relations.values()):
             count = len(relation)
             if count:
                 do_delete = True

--- a/tests/test_cascading_delete.py
+++ b/tests/test_cascading_delete.py
@@ -25,6 +25,15 @@ class TestDelete:
         assert_false(A() or B() or B.C() or D() or E() or E.F(), 'incomplete delete')
 
     @staticmethod
+    def test_stepwise_delete():
+        assert_false(dj.config['safemode'], 'safemode must be off for testing') #TODO: just turn it off instead of warning
+        assert_true(L() and A() and B() and B.C(), 'schema population failed as a precondition to test')
+        B.C().delete()
+        assert_false(B.C(), 'failed to delete child tables')
+        B().delete()
+        assert_false(B(), 'failed to delete the parent table following child table deletion')
+
+    @staticmethod
     def test_delete_tree_restricted():
         assert_false(dj.config['safemode'], 'safemode must be off for testing')
         assert_true(L() and A() and B() and B.C() and D() and E() and E.F(),


### PR DESCRIPTION
In `base_relation.py` `delete` method, we modify the content of the OrderedDict `relations` while traversing using its `values()` iterator, thus modifying the iterator! https://github.com/datajoint/datajoint-python/blob/master/datajoint/base_relation.py#L360-L367

It turns out that modification of the OrderedDict iterator is OK in Python 3.4 (although still not recommended) but simply fails in Python 3.5. The code has been fixed such that we are no longer using direct iterator if the OrderedDict is to be modified in the loop.

I also added Python 3.5 to the test target platform for Travis CI, addressing #198