### PR TITLE
Docker related enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM eywalker/pydev
 
-MAINTAINER Fabian Sinz <sinz@bcm.edu>
+MAINTAINER Edgar Y. Walker <edgar.walker@gmail.com>
 
-RUN pip install git+https://github.com/datajoint/datajoint-python.git &&  \
-    pip install git+https://github.com/datajoint/datajoint-addons.git
+ADD . /src
+RUN pip install /src && \
+    rm -rf /src
+    
 
 

--- a/JupyterDockerfile
+++ b/JupyterDockerfile
@@ -1,0 +1,7 @@
+FROM eywalker/jupyter
+
+MAINTAINER Edgar Y. Walker <edgar.walker@gmail.com>
+
+ADD . /src
+RUN pip install /src && \
+    rm -rf /src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '2'
+services:
+  datajoint:
+    build:
+      context: .
+      dockerfile: JupyterDockerfile
+    environment:
+      - DJ_HOST=db
+      - DJ_USER=root
+      - DJ_PASS=simple
+    links:
+      - db
+    ports:
+      - "8888:8888"
+  db:
+    image: mysql:5.7
+    environment:
+      - MYSQL_ROOT_PASSWORD=simple
+
+


### PR DESCRIPTION
* Updated `Dockerfile` to creating DataJoint container by using locally available code rather than the indirect reference to GitHub content
* Added `docker-compose.yml` so that you can run `docker-compose up` to launch a Jupyter notebook server along with a MySQL server to have a complete working environment for DataJoint. Will be ideal for just testing/playing with DataJoint.