### PR TITLE
Fixed restrictions by empty AndLists and OrLists.

### DIFF
--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -70,7 +70,7 @@ logger.setLevel(log_levels[config['loglevel']])
 from .connection import conn, Connection
 from .base_relation import BaseRelation
 from .user_relations import Manual, Lookup, Imported, Computed, Part
-from .relational_operand import Not, AndList
+from .relational_operand import Not, AndList, OrList
 from .heading import Heading
 from .schema import Schema as schema
 from .kill import kill

--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -16,7 +16,8 @@ __version__ = "0.2"
 __all__ = ['__author__', '__version__',
            'config', 'conn', 'kill',
            'Connection', 'Heading', 'BaseRelation', 'FreeRelation', 'Not', 'schema',
-           'Manual', 'Lookup', 'Imported', 'Computed', 'Part']
+           'Manual', 'Lookup', 'Imported', 'Computed', 'Part',
+           'AndList', 'OrList']
 
 
 class key:
@@ -57,7 +58,7 @@ else:
     * modify the local copy of %s that datajoint just saved for you
     * put a file named %s with the same configuration format in your home
     * specify the environment variables DJ_USER, DJ_HOST, DJ_PASS
-          """)
+          """ % (LOCALCONFIG, GLOBALCONFIG))
     local_config_file = os.path.expanduser(LOCALCONFIG)
     logger.log(logging.INFO, "No config found. Generating {0:s}".format(local_config_file))
     config.save(local_config_file)
@@ -69,7 +70,7 @@ logger.setLevel(log_levels[config['loglevel']])
 from .connection import conn, Connection
 from .base_relation import BaseRelation
 from .user_relations import Manual, Lookup, Imported, Computed, Part
-from .relational_operand import Not
+from .relational_operand import Not, AndList
 from .heading import Heading
 from .schema import Schema as schema
 from .kill import kill

--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -190,7 +190,7 @@ class Fetch(Iterable, Callable):
         """
         Iterator that returns primary keys.
         """
-        yield from self._relation.project().fetch.set_behavior(**dict(self.behavior, as_dict=True, **kwargs))
+        yield from self._relation.proj().fetch.set_behavior(**dict(self.behavior, as_dict=True, **kwargs))
 
     def __getitem__(self, item):
         """

--- a/datajoint/heading.py
+++ b/datajoint/heading.py
@@ -184,7 +184,7 @@ class Heading:
                     attr['dtype'] = numeric_types[(t, is_unsigned)]
         self.attributes = OrderedDict([(q['name'], Attribute(**q)) for q in attributes])
 
-    def project(self, *attribute_list, **renamed_attributes):
+    def proj(self, *attribute_list, **renamed_attributes):
         """
         derive a new heading by selecting, renaming, or computing attributes.
         In relational algebra these operators are known as project, rename, and expand.

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -76,8 +76,10 @@ class RelationalOperand(metaclass=abc.ABCMeta):
             if isinstance(arg, str):
                 return arg, _negate
             elif isinstance(arg, AndList):
-                return '(' + ' AND '.join(
-                    [make_condition(element)[0] for element in arg if arg is not None]) + ')', _negate
+                if arg:
+                    return '(' + ' AND '.join([make_condition(element)[0] for element in arg]) + ')', _negate
+                else:
+                    return 'FALSE' if _negate else 'TRUE', False
 
             #  semijoin or antijoin
             elif isinstance(arg, RelationalOperand):
@@ -120,7 +122,7 @@ class RelationalOperand(metaclass=abc.ABCMeta):
             if isinstance(item, (list, tuple, set, np.ndarray)):
                 # process an OR list
                 temp = [make_condition(q)[0] for q in item if q is not is_empty_or_list(q)]
-                item = 'FALSE' if not temp else '(' + ') OR ('.join(temp) + ')'
+                item = '(' + ') OR ('.join(temp) + ')' if temp else 'FALSE'
             else:
                 item, negate = make_condition(item, negate)
             if not item:

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -118,8 +118,9 @@ class RelationalOperand(metaclass=abc.ABCMeta):
             if negate:
                 item = item.restriction  # NOT is added below
             if isinstance(item, (list, tuple, set, np.ndarray)):
-                # sets of conditions that are ORed
-                item = '(' + ') OR ('.join([make_condition(q)[0] for q in item if q is not None]) + ')'
+                # process an OR list
+                temp = [make_condition(q)[0] for q in item if q is not is_empty_or_list(q)]
+                item = 'FALSE' if not temp else '(' + ') OR ('.join(temp) + ')'
             else:
                 item, negate = make_condition(item, negate)
             if not item:

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -11,45 +11,75 @@ from .fetch import Fetch, Fetch1
 logger = logging.getLogger(__name__)
 
 
-class AndList(Sequence):
+class AndList(list):
     """
     A list of restrictions to by applied to a relation.  The restrictions are ANDed.
     Each restriction can be a list or set or a relation whose elements are ORed.
-    But the elements that are lists can contain
+    But the elements that are lists can contain other AndLists.
+
+    Example:
+    rel2 = rel & dj.AndList((cond1, cond2, cond3))
+    is equivalent to
+    rel2 = rel & cond1 & cond2 & cond3
+    """
+    pass
+
+
+class OrList(list):
+    """
+    A list of restrictions to by applied to a relation.  The restrictions are ORed.
+    If any restriction is .
+    But the elements that are lists can contain other AndLists.
+
+    Example:
+    rel2 = rel & dj.ORList((cond1, cond2, cond3))
+    is equivalent to
+    rel2 = rel & [cond1, cond2, cond3]
+
+    Since ORList is just an alias for list, it is not necessary and is only provided
+    for consistency with AndList.
+    """
+    pass
+
+
+class RelationalOperand(metaclass=abc.ABCMeta):
+    """
+    RelationalOperand implements relational algebra and fetch methods.
+    RelationalOperand objects reference other relation objects linked by operators.
+    The leaves of this tree of objects are base relations.
+    When fetching data from the database, this tree of objects is compiled into an SQL expression.
+    It is a mixin class that provides relational operators, iteration, and fetch capability.
+    RelationalOperand operators are: restrict, pro, and join.
     """
 
-    def __init__(self, heading):
-        self.heading = heading
-        self._list = []
+    _restrictions = None
 
-    def __len__(self):
-        return len(self._list)
+    @property
+    def restrictions(self):
+        if self._restrictions is None:
+            self._restrictions = AndList()
+        return self._restrictions
 
-    def __getitem__(self, i):
-        return self._list[i]
+    def clear_restrictions(self):
+        self._restrictions = None
 
-    def add(self, *args):
-        # remove Nones and duplicates
-        args = [r for r in args if r is not None and r not in self]
-        if args:
-            if any(is_empty_set(r) for r in args):
-                # if any condition is an empty list, return FALSE
-                self._list = ['FALSE']
-            else:
-                self._list.extend(args)
+    @property
+    def primary_key(self):
+        return self.heading.primary_key
 
+    @property
     def where_clause(self):
         """
         convert to a WHERE clause string
         """
-
         def make_condition(arg, _negate=False):
             if isinstance(arg, str):
                 return arg, _negate
             elif isinstance(arg, AndList):
-                return '(' + ' AND '.join([make_condition(element)[0] for element in arg]) + ')', _negate
+                return '(' + ' AND '.join(
+                    [make_condition(element)[0] for element in arg if arg is not None]) + ')', _negate
 
-            # semijoin or antijoin
+            #  semijoin or antijoin
             elif isinstance(arg, RelationalOperand):
                 common_attributes = [q for q in self.heading.names if q in arg.heading.names]
                 if not common_attributes:
@@ -71,59 +101,31 @@ class AndList(Sequence):
                 # element of a record array
                 condition = ['`%s`=%s' % (k, arg[k]) for k in arg.dtype.fields if k in self.heading]
             else:
-                raise DataJointError('invalid restriction type')
+                raise DataJointError('Invalid restriction type')
             return ' AND '.join(condition) if condition else 'TRUE', _negate
 
-        if not self:
+        if len(self.restrictions) == 0:  # an empty list -> no WHERE clause
             return ''
 
+        # An empty or-list in the restrictions immediately causes an empty result
+        assert isinstance(self.restrictions, AndList)
+        if any(is_empty_or_list(r) for r in self.restrictions):
+            return ' WHERE FALSE'
+
         conditions = []
-        for item in self:
+        for item in self.restrictions:
             negate = isinstance(item, Not)
             if negate:
-                item = item.restriction
+                item = item.restriction  # NOT is added below
             if isinstance(item, (list, tuple, set, np.ndarray)):
-                # sets of conditions are ORed
-                item = '(' + ') OR ('.join([make_condition(q)[0] for q in item]) + ')'
+                # sets of conditions that are ORed
+                item = '(' + ') OR ('.join([make_condition(q)[0] for q in item if q is not None]) + ')'
             else:
                 item, negate = make_condition(item, negate)
             if not item:
                 raise DataJointError('Empty condition')
             conditions.append(('NOT (%s)' if negate else '(%s)') % item)
         return ' WHERE ' + ' AND '.join(conditions)
-
-    def __repr__(self):
-        return 'AND List: ' + repr(self._list)
-
-
-class RelationalOperand(metaclass=abc.ABCMeta):
-    """
-    RelationalOperand implements relational algebra and fetch methods.
-    RelationalOperand objects reference other relation objects linked by operators.
-    The leaves of this tree of objects are base relations.
-    When fetching data from the database, this tree of objects is compiled into an SQL expression.
-    It is a mixin class that provides relational operators, iteration, and fetch capability.
-    RelationalOperand operators are: restrict, pro, and join.
-    """
-
-    _restrictions = None
-
-    @property
-    def restrictions(self):
-        if self._restrictions is None:
-            self._restrictions = AndList(self.heading)
-        return self._restrictions
-
-    def clear_restrictions(self):
-        self._restrictions = None
-
-    @property
-    def primary_key(self):
-        return self.heading.primary_key
-
-    @property
-    def where_clause(self):
-        return self.restrictions.where_clause()
 
     # --------- abstract properties -----------
 
@@ -171,15 +173,21 @@ class RelationalOperand(metaclass=abc.ABCMeta):
         """
         relational projection operator.  See RelationalOperand.project
         """
-        return self.project(*attributes)
+        return self.proj(*attributes)
 
-    def project(self, *attributes, **renamed_attributes):
+    def project(self, *args, **kwargs):
+        """
+        alias for self.proj() for backward compatibility
+        """
+        return self.proj(*args, **kwargs)
+
+    def proj(self, *attributes, **renamed_attributes):
         """
         Relational projection operator.
         :param attributes: a list of attribute names to be included in the result.
         :return: a new relation with selected fields
         Primary key attributes are always selected and cannot be excluded.
-        Therefore obj.project() produces a relation with only the primary key attributes.
+        Therefore obj.proj() produces a relation with only the primary key attributes.
         If attributes includes the string '*', all attributes are selected.
         Each attribute can only be used once in attributes or renamed_attributes.  Therefore, the projected
         relation cannot have more attributes than the original relation.
@@ -203,43 +211,111 @@ class RelationalOperand(metaclass=abc.ABCMeta):
 
     def __iand__(self, restriction):
         """
-        in-place restriction by a single condition
+        in-place restriction
+
+        See relational_operand.restrict for more detail.
         """
         self.restrict(restriction)
+        return self
 
     def __and__(self, restriction):
         """
         relational restriction or semijoin
         :return: a restricted copy of the argument
+
+        See relational_operand.restrict for more detail.
         """
         ret = copy(self)
         ret.clear_restrictions()
-        ret.restrict(restriction, *list(self.restrictions))
+        ret.restrict(self.restrictions)
+        ret.restrict(restriction)
         return ret
 
-    def restrict(self, *restrictions):
+    def __isub__(self, restriction):
         """
-        In-place restriction. Primarily intended for datajoint's internal use.
-        Users are encouraged to use self & restriction to apply a restriction.
-        Each condition in restrictions is applied and the conditions are combined with AND.
-        However, each member of restrictions can be a list of conditions, which are combined with OR.
-        :param restrictions: list of restrictions.
+        in-place inverted restriction
+
+        See relational_operand.restrict for more detail.
         """
-        self.restrictions.add(*restrictions)
+        self.restrict(Not(restriction))
+        return self
+
+    def __sub__(self, restriction):
+        """
+        inverse restriction aka antijoin
+        :return: a restricted copy of the argument
+
+        See relational_operand.restrict for more detail.
+        """
+        return self & Not(restriction)
+
+    def restrict(self, restriction):
+        """
+        In-place restriction.  Restricts the relation to a subset of its original tuples.
+        rel.restrict(restriction)  is equivalent to  rel = rel & restriction  or  rel &= restriction
+        rel.restrict(Not(restriction))  is equivalent to  rel = rel - restriction  or  rel -= restriction
+        The primary key of the result is unaffected.
+        Successive restrictions are combined using the logical AND.
+        The AndList class is provided to play the role of successive restrictions.
+        Any relation, collection, or sequence other than an AndList are treated as OrLists.
+        However, the class OrList is still provided for cases when explicitness is required.
+        Inverse restriction is accomplished by either using the subtraction operator or the Not class.
+
+        The expressions in each row equivalent:
+        rel & 'TRUE'                        rel
+        rel & 'FALSE'                       the empty relation
+        rel - cond                          rel & Not(cond)
+        rel - 'TRUE'                        rel & 'FALSE'
+        rel - 'FALSE'                       rel
+        rel & AndList((cond1,cond2))        rel & cond1 & cond2
+        rel & AndList()                     rel
+        rel & [cond1, cond2]                rel & OrList((cond1, cond2))
+        rel & []                            rel & 'FALSE'
+        rel & None                          rel & 'FALSE'
+        rel & any_empty_relation            rel & 'FALSE'
+        rel - AndList((cond1,cond2))        rel & [Not(cond1), Not(cond2)]
+        rel - [cond1, cond2]                rel & Not(cond1) & Not(cond2)
+        rel - AndList()                     rel & 'FALSE'
+        rel - []                            rel
+        rel - None                          rel
+        rel - any_empty_relation            rel
+
+        When arg is another relation, the restrictions  rel & arg  and  rel - arg  become the relational semijoin and
+        antijoin operators, respectively.
+        Then,  rel & arg  restricts rel to tuples that match at least one tuple in arg (hence arg is treated as an OrList).
+        Conversely,  rel - arg  restricts rel to tuples that do not match any tuples in arg.
+        Two tuples match when their common attributes have equal values or when they have no common attributes.
+        All shared attributes must be in the primary key of either rel or arg or both or an error will be raised.
+
+        relational_operand.restrict is the only access point that modifies restrictions. All other operators must
+        ultimately call restrict()
+
+        :param restriction: a sequence or an array (treated as OR list), another relation, an SQL condition string, or
+        an AndList.
+        """
+        if isinstance(restriction, AndList):
+            self.restrictions.extend(restriction)
+        elif is_empty_or_list(restriction):
+            self.clear_restrictions()
+            self.restrictions.append('FALSE')
+        else:
+            self.restrictions.append(restriction)
+
+    @property
+    def fetch1(self):
+        return Fetch1(self)
+
+    @property
+    def fetch(self):
+        return Fetch(self)
 
     def attributes_in_restrictions(self):
         """
         :return: list of attributes that are probably used in the restrictions.
         This is used internally for optimizing SQL statements
         """
-        s = self.restrictions.where_clause()  # avoid calling multiple times
+        s = self.where_clause
         return set(name for name in self.heading.names if name in s)
-
-    def __sub__(self, restriction):
-        """
-        inverted restriction aka antijoin
-        """
-        return self & (None if is_empty_set(restriction) else Not(restriction))
 
     @abc.abstractmethod
     def _repr_helper(self):
@@ -253,7 +329,7 @@ class RelationalOperand(metaclass=abc.ABCMeta):
             if self._restrictions:
                 ret += ' & %r' % self._restrictions
         else:
-            rel = self.project(*self.heading.non_blobs)  # project out blobs
+            rel = self.proj(*self.heading.non_blobs)  # project out blobs
             limit = config['display.limit']
             width = config['display.width']
 
@@ -262,7 +338,7 @@ class RelationalOperand(metaclass=abc.ABCMeta):
 
             widths = {f: min(max([len(f)] + [len(str(e)) for e in tups[f]])+4,width) for f in columns}
 
-            templates = {f:'%%-%d.%ds' % (widths[f], widths[f]) for f in columns}
+            templates = {f: '%%-%d.%ds' % (widths[f], widths[f]) for f in columns}
             repr_string = ' '.join([templates[column] % column for column in columns]) + '\n'
             repr_string += ' '.join(['+' + '-' * (widths[column] - 2) + '+' for column in columns]) + '\n'
             for tup in tups:
@@ -276,7 +352,7 @@ class RelationalOperand(metaclass=abc.ABCMeta):
 
     def _repr_html_(self):
         limit = config['display.limit']
-        rel = self.project(*self.heading.non_blobs)  # project out blobs
+        rel = self.proj(*self.heading.non_blobs)  # project out blobs
         columns = rel.heading.names
         content = dict(
             head='</th><th>'.join(columns),
@@ -303,7 +379,7 @@ class RelationalOperand(metaclass=abc.ABCMeta):
         return 'SELECT {fields} FROM {from_}{where}{group}'.format(
             fields=select_fields if select_fields else self.select_fields,
             from_=self.from_clause,
-            where=self.restrictions.where_clause(),
+            where=self.where_clause,
             group=' GROUP BY `%s`' % '`,`'.join(self.primary_key) if self._grouped else '')
 
     def __len__(self):
@@ -341,14 +417,6 @@ class RelationalOperand(metaclass=abc.ABCMeta):
         logger.debug(sql)
         return self.connection.query(sql, as_dict=as_dict)
 
-    @property
-    def fetch1(self):
-        return Fetch1(self)
-
-    @property
-    def fetch(self):
-        return Fetch(self)
-
 
 class Not:
     """
@@ -372,8 +440,8 @@ class Join(RelationalOperand):
         self._arg1 = Subquery(arg1) if isinstance(arg1, Projection) else arg1
         self._arg2 = Subquery(arg2) if isinstance(arg2, Projection) else arg2
         self._heading = self._arg1.heading.join(self._arg2.heading, left=left)
-        self.restrict(*list(self._arg1.restrictions))
-        self.restrict(*list(self._arg2.restrictions))
+        self.restrict(self._arg1.restrictions)
+        self.restrict(self._arg2.restrictions)
         self._left = left
 
     def _repr_helper(self):
@@ -402,7 +470,7 @@ class Join(RelationalOperand):
 class Projection(RelationalOperand):
     def __init__(self, arg, *attributes, **renamed_attributes):
         """
-        See RelationalOperand.project()
+        See RelationalOperand.proj()
         """
         # parse attributes in the form 'sql_expression -> new_attribute'
         alias_parser = re.compile(
@@ -424,10 +492,10 @@ class Projection(RelationalOperand):
         if use_subquery:
             self._arg = Subquery(arg)
         else:
-            self.restrict(*list(arg.restrictions))
+            self.restrict(arg.restrictions)
 
     def _repr_helper(self):
-        return "(%r).project(%r)" % (self._arg, self._attributes)
+        return "(%r).proj(%r)" % (self._arg, self._attributes)
 
     @property
     def connection(self):
@@ -435,7 +503,7 @@ class Projection(RelationalOperand):
 
     @property
     def heading(self):
-        return self._arg.heading.project(*self._attributes, **self._renamed_attributes)
+        return self._arg.heading.proj(*self._attributes, **self._renamed_attributes)
 
     @property
     def _grouped(self):
@@ -451,17 +519,6 @@ class Projection(RelationalOperand):
         ret = Subquery(self) if do_subquery else self
         ret.restrict(restriction)
         return ret
-
-    def restrict(self, *restrictions):
-        """
-        Override restrict: when restricting on renamed attributes, enclose in subquery
-        """
-        has_restriction = any(isinstance(r, RelationalOperand) or r for r in restrictions)
-        do_subquery = has_restriction and self.heading.computed
-        if do_subquery:
-            # TODO fix this for the case (r & key).aggregate(m='compute')
-            raise DataJointError('In-place restriction on renamed attributes is not allowed')
-        super().restrict(*restrictions)
 
 
 class Aggregation(Projection):
@@ -506,5 +563,10 @@ class Subquery(RelationalOperand):
         return "%r" % self._arg
 
 
-def is_empty_set(arg):
-    return isinstance(arg, (list, set, tuple, np.ndarray, RelationalOperand)) and len(arg) == 0
+def is_empty_or_list(arg):
+    """
+    returns true if the argument is equivalent to an empty OR list.
+    """
+    return not isinstance(arg, AndList) and (
+        arg is None or
+        isinstance(arg, (list, set, tuple, np.ndarray, RelationalOperand)) and len(arg) == 0)

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -5,12 +5,10 @@ import re
 from . import conn, DataJointError
 from datajoint.utils import to_camel_case
 from .heading import Heading
-from .base_relation import BaseRelation
 from .user_relations import Part, Computed, Imported, Manual, Lookup
 import inspect
 
 logger = logging.getLogger(__name__)
-from warnings import warn
 
 
 class Schema:

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -12,7 +12,7 @@ import collections
 from enum import Enum
 
 LOCALCONFIG = 'dj_local_conf.json'
-GLOBALCONFIG = '._datajoint_config.json'
+GLOBALCONFIG = '.datajoint_config.json'
 
 validators = collections.defaultdict(lambda: lambda value: True)
 validators['database.port'] = lambda a: isinstance(a, int)

--- a/datajoint/user_relations.py
+++ b/datajoint/user_relations.py
@@ -5,8 +5,6 @@ Hosts the table tiers, user relations should be derived from.
 from .base_relation import BaseRelation
 from .autopopulate import AutoPopulate
 from .utils import from_camel_case
-from . import DataJointError
-import re
 
 _base_regexp = r'[a-z]+[a-z0-9]*(_[a-z]+[a-z0-9]*)*'
 

--- a/datajoint/user_relations.py
+++ b/datajoint/user_relations.py
@@ -45,17 +45,10 @@ class Manual(UserRelation):
     _prefix = r''
     _regexp = r'(?P<manual>' + _prefix + _base_regexp + ')'
 
-    @property
-    def table_name(self):
-        """
-        :returns: the table name of the table formatted for mysql.
-        """
-        return self._prefix + from_camel_case(self.__class__.__name__)
-
     @classproperty
     def table_name(cls):
         """
-        :returns: the table name of the table formatted for mysql.
+        :returns: the table name of the table formatted for SQL.
         """
         return from_camel_case(cls.__name__)
 
@@ -94,13 +87,6 @@ class Imported(UserRelation, AutoPopulate):
     _prefix = '_'
     _regexp = r'(?P<imported>' + _prefix + _base_regexp + ')'
 
-    @property
-    def table_name(self):
-        """
-        :returns: the table name of the table formatted for mysql.
-        """
-        return self._prefix + from_camel_case(self.__class__.__name__)
-
     @classproperty
     def table_name(cls):
         """
@@ -118,17 +104,10 @@ class Computed(UserRelation, AutoPopulate):
     _prefix = '__'
     _regexp = r'(?P<computed>' + _prefix + _base_regexp + ')'
 
-    @property
-    def table_name(self):
-        """
-        :returns: the table name of the table formatted for mysql.
-        """
-        return self._prefix + from_camel_case(self.__class__.__name__)
-
     @classproperty
     def table_name(cls):
         """
-        :returns: the table name of the table formatted for mysql.
+        :returns: the table name of the table formatted for SQL.
         """
         return cls._prefix + from_camel_case(cls.__name__)
 
@@ -141,8 +120,9 @@ class Part(BaseRelation):
     Part relations are implemented as classes inside classes.
     """
 
-    _regexp = r'(?P<master>' + '|'.join([c._regexp for c in [Manual, Imported, Computed, Lookup]]) + r'){1,1}' \
-              + '__' + r'(?P<part>' + _base_regexp + ')'
+    _regexp = r'(?P<master>' + '|'.join(
+        [c._regexp for c in [Manual, Imported, Computed, Lookup]]
+    ) + r'){1,1}' + '__' + r'(?P<part>' + _base_regexp + ')'
 
     _master = None
 

--- a/tests/test_autopopulate.py
+++ b/tests/test_autopopulate.py
@@ -35,7 +35,7 @@ class TestPopulate:
         # test restricted populate
         assert_false(self.trial, 'table already filled?')
         restriction = dict(subject_id=self.subject.project().fetch()['subject_id'][0])
-        self.trial.populate(restriction=restriction)
+        self.trial.populate(restriction)
         assert_true(self.trial, 'table was not populated')
         poprel = self.trial.populated_from
         assert_equal(len(poprel & self.trial), len(poprel & restriction))

--- a/tests/test_relational_operand.py
+++ b/tests/test_relational_operand.py
@@ -92,16 +92,16 @@ class TestRelational:
 
         # test pairing
         # Approach 1: join then restrict
-        x = A().project(a1='id_a', c1='cond_in_a')
-        y = A().project(a2='id_a', c2='cond_in_a')
+        x = A().proj(a1='id_a', c1='cond_in_a')
+        y = A().proj(a2='id_a', c2='cond_in_a')
         rel = x*y & 'c1=0' & 'c2=1'
         assert_equal(len(x & 'c1=0')+len(y & 'c2=1'), len(A()),
                      'incorrect restriction')
         assert_equal(len(rel), len(x & 'c1=0')*len(y & 'c2=1'),
                      'incorrect pairing')
         # Approach 2: restrict then join
-        x = (A() & 'cond_in_a=0').project(a1='id_a')
-        y = (A() & 'cond_in_a=1').project(a2='id_a')
+        x = (A() & 'cond_in_a=0').proj(a1='id_a')
+        y = (A() & 'cond_in_a=1').proj(a2='id_a')
         assert_equal(len(rel), len(x*y))
 
     @staticmethod
@@ -186,7 +186,7 @@ class TestRelational:
     @staticmethod
     def test_join_project_optimization():
         """Test optimization for join of projected relations with matching non-primary key"""
-        print(DataA().project() * DataB().project())
+        print(DataA().project() * DataB().proj())
         print(DataA())
-        assert_true(len(DataA().project() * DataB().project()) == len(DataA()) == len(DataB()),
+        assert_true(len(DataA().project() * DataB().proj()) == len(DataA()) == len(DataB()),
                     "Join of projected relations does not work")


### PR DESCRIPTION
Restrictions by AndLists and OrLists now work correctly
- `rel & []`  is equivalent to `rel & dj.OrList()`
- `rel & []` produces  the empty relation
- `rel - []` has no effect
- `rel & dj.AndList((cond1, cond2))` is equivalent to `rel & cond1 & cond2`
- `rel & dj.AndList()` has no effect
- `rel - dj.AndList()` produces the empty relation

Also, `rel.restriction` is now of type `dj.AndList`.

Also, `RelationalOperand.project` has been renamed to  `RelationalOperand.proj`  (issue #202) with `project` aliased to `proj` for backward compatibility.