### PR TITLE
Configure Travis to work with `scipy` installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ addons:
     packages:
       - libblas-dev
       - liblapack-dev
+      - libatlas-dev
+      - gfortran
 install:
   - pip install -r requirements.txt
   - pip install nose nose-cov python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libblas-dev liblapack-dev libatlas-dev gfortran
 install:
-  - pip install -r requirements.txt
+  - travis_wait 30 pip install -r requirements.txt
   - pip install nose nose-cov python-coveralls
 # command to run tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 language: python
 env:
   - DJ_TEST_HOST="127.0.0.1" DJ_TEST_USER="root" DJ_TEST_PASSWORD="" DJ_HOST="127.0.0.1" DJ_USER="root" DJ_PASSWORD=""
@@ -6,13 +6,9 @@ python:
   - "3.4"
   - "3.5"
 services: mysql
-addons:
-  apt:
-    packages:
-      - libblas-dev
-      - liblapack-dev
-      - libatlas-dev
-      - gfortran
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libblas-dev liblapack-dev libatlas-dev gfortran
 install:
   - pip install -r requirements.txt
   - pip install nose nose-cov python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
   apt:
     packages:
       - libblas-dev
+      - liblapack-dev
 install:
   - pip install -r requirements.txt
   - pip install nose nose-cov python-coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy
+scipy
 pymysql
 pyparsing
 networkx


### PR DESCRIPTION
Introduction of `scipy` as part of requirements required a number of changes to Travis configuration, including:
* explicit installation of dependencies: BLAS, LAPACK, ATLAS, and Fortran
* extension of Travis time delay to cope with long build time for `scipy`. Travis times out after 10 min of non-response and this was preventing successful build under Python 3.5. Extended this to 30 min.

These modifications allow for `scipy` to be built and the rest of the test to be run. However, building of `scipy` alone extends the test time by nearly 10min, and we might want to look into other methods to speed up the test run time. 