### PR TITLE
Update Dockerfile to use datajoint/pydev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eywalker/pydev
+FROM datajoint/pydev
 
 MAINTAINER Edgar Y. Walker <edgar.walker@gmail.com>
 


### PR DESCRIPTION
Update `Dockerfile` to base the `datajoint` image off of the `datajoint/pydev` instead of the original `eywalker/pydev`. This reflects planned changes and deviations of `eywalker/pydev` content from it's current version. Namely, `eywalker/pydev` will be switched to build up on Ubuntu image rather than the current standard `python:3.5` which is ultimately based on a Debian image. `datajoint/pydev` has been created to be a drop-in replacement of the current `eywalker/pydev` and will continue to be based on `python:3.5` image to maintain compatibility.