### PR TITLE
Optimized relational operators

### DIFF
--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -16,8 +16,8 @@ import logging
 import os
 
 __author__ = "Dimitri Yatsenko, Edgar Walker, and Fabian Sinz at Baylor College of Medicine"
-__version__ = "0.2.1"
-__date__ = "June 1, 2016"
+__version__ = "0.2.2"
+__date__ = "June 15, 2016"
 __all__ = ['__author__', '__version__',
            'config', 'conn', 'kill',
            'Connection', 'Heading', 'BaseRelation', 'FreeRelation', 'Not', 'schema',

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -1,5 +1,4 @@
 """autopopulate containing the dj.AutoPopulate class. See `dj.AutoPopulate` for more info."""
-import abc
 import logging
 import datetime
 import random
@@ -131,9 +130,8 @@ class AutoPopulate:
         total = len(todo)
         remaining = len(todo - self.target.proj())
         if display:
-            print('%-20s' % self.__class__.__name__, flush=True, end=': ')
-            print('Completed %d of %d (%2.1f%%)   %s' %
-                  (total - remaining, total, 100 - 100 * remaining / (total+1e-12),
-                   datetime.datetime.strftime(datetime.datetime.now(), '%Y-%m-%d %H:%M:%S')
-                   ), flush=True)
+            print('%-20s' % self.__class__.__name__,
+                  'Completed %d of %d (%2.1f%%)   %s' % (
+                      total - remaining, total, 100 - 100 * remaining / (total+1e-12),
+                      datetime.datetime.strftime(datetime.datetime.now(), '%Y-%m-%d %H:%M:%S')), flush=True)
         return remaining, total

--- a/datajoint/jobs.py
+++ b/datajoint/jobs.py
@@ -51,19 +51,15 @@ class JobRelation(BaseRelation):
         return self._definition
 
     @property
-    def connection(self):
-        return self._connection
-
-    @property
     def table_name(self):
         return self._table_name
 
     def delete(self):
-        """ bypass interactive prompts"""
+        """bypass interactive prompts and dependencies"""
         self.delete_quick()
 
     def drop(self):
-        """ bypass interactive prompts"""
+        """bypass interactive prompts and dependencies"""
         self.drop_quick()
 
     def reserve(self, table_name, key):
@@ -74,12 +70,11 @@ class JobRelation(BaseRelation):
         :param key: the dict of the job's primary key
         :return: True if reserved job successfully. False = the jobs is already taken
         """
-
         try:
             job_key = dict(table_name=table_name, key_hash=key_hash(key),
                            status='reserved', host=os.uname().nodename, pid=os.getpid())
             self.insert1(job_key)
-        except pymysql.err.IntegrityError: #TODO check for other exceptions!
+        except pymysql.err.IntegrityError:
             return False
         else:
             return True

--- a/datajoint/kill.py
+++ b/datajoint/kill.py
@@ -19,9 +19,8 @@ def kill(restriction=None, connection=None):
     if connection is None:
         connection = conn()
 
-    query = 'SELECT * FROM information_schema.processlist WHERE id <> CONNECTION_ID()';
-    if restriction is not None:
-        query += ' AND (%s)' % restriction
+    query = 'SELECT * FROM information_schema.processlist WHERE id <> CONNECTION_ID()' + (
+        "" if restriction is None else ' AND (%s)' % restriction)
 
     while True:
         print('  ID USER         STATE         TIME  INFO')
@@ -29,9 +28,8 @@ def kill(restriction=None, connection=None):
         for process in connection.query(query, as_dict=True).fetchall():
             try:
                 print('{ID:>4d} {USER:<12s} {STATE:<12s} {TIME:>5d}  {INFO}'.format(**process))
-            except TypeError as err:
+            except TypeError:
                 print(process)
-
         response = input('process to kill or "q" to quit > ')
         if response == 'q':
             break
@@ -40,7 +38,6 @@ def kill(restriction=None, connection=None):
                 pid = int(response)
             except ValueError:
                 pass  # ignore non-numeric input
-            #TODO: check behavior when invalid input given
             else:
                 try:
                     connection.query('kill %d' % pid)

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -9,13 +9,28 @@ from .fetch import Fetch, Fetch1
 logger = logging.getLogger(__name__)
 
 
+def equal_ignore_case(str1, str2):
+    try:
+        return str1.upper() == str2.upper()
+    except AttributeError:
+        return str1 == str2
+
+
+def restricts_to_same(arg):
+    """
+    returns True if restriction with arg produces the same result as not restricting at all
+    """
+    return isinstance(arg, U) or arg is True and not equal_ignore_case(arg, "TRUE")
+
+
 def restricts_to_empty(arg):
     """
-    returns true if restriction to arg will produce the empty relation.
+    returns True if restriction with arg must produce the empty relation.
     """
-    return not isinstance(arg, AndList) and (
-        arg is None or arg is False or isinstance(arg, str) and arg.upper() == "FALSE" or
-        isinstance(arg, (list, set, tuple, np.ndarray, RelationalOperand)) and len(arg) == 0)
+    or_lists = (list, set, tuple, np.ndarray, RelationalOperand)
+    return arg is None or (isinstance(arg, AndList) and any(restricts_to_empty(r) for r in arg)) or (
+        arg is None or arg is False or equal_ignore_case(arg, "FALSE") or
+        isinstance(arg, or_lists) and len(arg) == 0)  # empty OR-list equals FALSE
 
 
 class AndList(list):
@@ -59,39 +74,62 @@ class RelationalOperand:
     """
 
     def __init__(self, arg=None):
-        assert arg is None or isinstance(arg, RelationalOperand), \
-            'Cannot construct RelationalOperand from %s' % arg.__class__.__name__
-        self._restrictions = AndList(() if arg is None else arg._restrictions)
+        if arg is not None:  # copy
+            assert isinstance(arg, RelationalOperand), 'Cannot make RelationalOperand from %s' % arg.__class__.__name__
+            self._restrictions = AndList(arg._restrictions)
+            self._distinct = arg.distinct
+        else:  # initialize
+            self._restrictions = AndList()
+            self._distinct = False
 
     # --------- abstract properties -----------
 
     @property
     def connection(self):
         """
-        :return: a datajoint.Connection object
+        :return:  the dj.Connection object
         """
-        raise NotImplementedError('Subclasses of RelationOperand must implement the property "connection"')
+        try:
+            return self._connection
+        except:
+            raise DataJointError('Subclasses of RelationOperand must define self._connection or self.connection.')
 
     @property
     def from_clause(self):
         """
-        :return: a string containing the FROM clause of the SQL SELECT statement
+        :return: string with the FROM clause of the SQL SELECT statement (not including the word "FROM")
+        It is the core of the SELECT statement but lacks the field specification and the WHERE clause (restriction)
         """
-        raise NotImplementedError('Subclasses of RelationOperand must implement the property "from_clause"')
+        raise NotImplementedError('Missing property `from_clause` in class %s' % self.__class__.__name__)
 
     @property
     def heading(self):
         """
-        :return: all RelationalOperands must supply a valid datajoint.Heading object
+        :return: the dj.Heading object of the relation
         """
-        raise NotImplementedError('Subclasses of RelationOperand must implement the property "from_clause"')
+        try:
+            return self._heading
+        except:
+            raise DataJointError('Subclasses of RelationOperand must define self._heading or self.heading.')
 
     # ---------- derived properties --------
 
     @property
+    def distinct(self):
+        """True if the DISTINCT modifier is required to turn the query into a relation"""
+        return self._distinct
+
+    @property
     def restrictions(self):
+        """
+        :return:  The AndList of restrictions applied to the relation.
+        """
         assert isinstance(self._restrictions, AndList)
         return self._restrictions
+
+    @property
+    def is_restricted(self):
+        return len(self.restrictions) > 0
 
     @property
     def primary_key(self):
@@ -100,7 +138,7 @@ class RelationalOperand:
     @property
     def where_clause(self):
         """
-        convert to a WHERE clause string
+        convert self.restrictions to the SQL WHERE clause
         """
         def make_condition(arg, _negate=False):
             if isinstance(arg, str):
@@ -136,12 +174,11 @@ class RelationalOperand:
                 raise DataJointError('Invalid restriction type')
             return ' AND '.join(condition) if condition else 'TRUE', _negate
 
-        if len(self.restrictions) == 0:  # an empty list -> no WHERE clause
+        if not self.is_restricted:
             return ''
 
         # An empty or-list in the restrictions immediately causes an empty result
-        assert isinstance(self.restrictions, AndList)
-        if any(restricts_to_empty(r) for r in self.restrictions):
+        if restricts_to_empty(self.restrictions):
             return ' WHERE FALSE'
 
         conditions = []
@@ -150,9 +187,8 @@ class RelationalOperand:
             if negate:
                 item = item.restriction  # NOT is added below
             if isinstance(item, (list, tuple, set, np.ndarray)):
-                # process an OR list
-                temp = [make_condition(q)[0] for q in item if q is not restricts_to_empty(q)]
-                item = '(' + ') OR ('.join(temp) + ')' if temp else 'FALSE'
+                item = '(' + ') OR ('.join(
+                    [make_condition(q)[0] for q in item if q is not restricts_to_empty(q)]) + ')'
             else:
                 item, negate = make_condition(item, negate)
             if not item:
@@ -167,48 +203,40 @@ class RelationalOperand:
         """
         return self.heading.as_sql
 
-    def _grouped(self):
-        """
-        If grouped, then GROUP BY the primary key.  Used for aggregation.
-        :return: True for aggregation, False otherwise
-        """
-        return False
-
     # --------- relational operators -----------
 
     def __mul__(self, other):
         """
-        relational join
+        natural join of relations self and other
         """
         return other*self if isinstance(other, U) else Join(self, other)
 
-    def proj(self, *attributes, **renamed_attributes):
+    def proj(self, *attributes, **named_attributes):
         """
         Relational projection operator.
-        :param attributes: a list of attribute names to be included in the result.
-        :return: a new relation with selected fields
-        Primary key attributes are always selected and cannot be excluded.
-        Therefore obj.proj() produces a relation with only the primary key attributes.
-        If attributes includes the string '*', all attributes are selected.
-        Each attribute can only be used once in attributes or renamed_attributes.  Therefore, the projected
-        relation cannot have more attributes than the original relation.
+        :param attributes:  attributes to be included in the result. (The primary key is already included).
+        :param named_attributes: new attributes computed or renamed from existing attributes.
+        :return: the projected relation.
+        Primary key attributes are always cannot be excluded but may be renamed.
+        Thus self.proj() produces the relation with only the primary key of self.
+        self.proj(a='id') renames the attribute 'id' into 'a' and includes 'a' in the projection.
+        self.proj(a='expr') adds a new field a with the value computed with SQL expression.
+        self.proj(a='(id)') adds a new computed field named 'a' that has the same value as id
+        Each attribute can only be used once in attributes or named_attributes.
         """
-        return Projection(self, attributes, renamed_attributes)
+        return Projection(self, attributes, named_attributes)
 
-    def aggregate(self, group, *attributes, keep_all_rows=False, **renamed_attributes):
+    def aggregate(self, group, *attributes, keep_all_rows=False, **named_attributes):
         """
-        Relational aggregation operator
-
+        Relational aggregation/projection operator
         :param group:  relation whose tuples can be used in aggregation operators
-        :param attributes:
+        :param attributes: attributes of self to include in the resulting relation
         :param keep_all_rows: True = preserve the number of tuples in the result (equivalent of LEFT JOIN in SQL)
-        :param renamed_attributes: a dict of renamings and computations
-        :return: a relation representing the aggregation/projection operator result
+        :param named_attributes: renamings and computations on attributes of self and group
+        :return: a relation representing the result of the aggregation/projection operator
         """
-        if not isinstance(group, RelationalOperand):
-            raise DataJointError('The second argument must be a relation')
-        return Aggregation(self, group, keep_all_rows=keep_all_rows,
-                           attributes=attributes, renamed_attributes=renamed_attributes)
+        return GroupBy(self, group, keep_all_rows=keep_all_rows,
+                       attributes=attributes, named_attributes=named_attributes)
 
     def __iand__(self, restriction):
         """
@@ -290,16 +318,11 @@ class RelationalOperand:
         :param restriction: a sequence or an array (treated as OR list), another relation, an SQL condition string, or
         an AndList.
         """
-        # ineffective restrictions
-        if isinstance(restriction, U) or restriction is True or \
-                isinstance(restriction, str) and restriction.upper() == "TRUE":
-            return self
-        if isinstance(restriction, AndList):
-            self.restrictions.extend(restriction)
-        elif restricts_to_empty(restriction):
-            self._restrictions = AndList(['FALSE'])
-        else:
-            self.restrictions.append(restriction)
+        if not restricts_to_same(restriction):
+            if isinstance(restriction, AndList):
+                self.restrictions.extend(restriction)
+            else:
+                self.restrictions.append(restriction)
         return self
 
     @property
@@ -310,99 +333,95 @@ class RelationalOperand:
     def fetch(self):
         return Fetch(self)
 
-    def attributes_in_restrictions(self):
+    def attributes_in_restriction(self):
         """
         :return: list of attributes that are probably used in the restrictions.
-        This is used internally for optimizing SQL statements
+        The function errs on the side of false positives.
+        For example, if the restriction is "val='id'", then the attribute 'id' would be flagged.
+        This is used internally for optimizing SQL statements.
         """
-        s = self.where_clause
-        return set(name for name in self.heading.names if name in s)
-
-    def _repr_helper(self):
-        """
-        :return: (string) basic representation of the relation
-        """
-        raise NotImplementedError('Subclasses of RelationOperand must implement the method "_repr_helper"')
+        return set(name for name in self.heading.names
+                   if re.search(r'\b' + name + r'\b', self.where_clause))
 
     def __repr__(self):
-        if config['loglevel'].lower() == 'debug':
-            ret = self._repr_helper()
-            if self.restrictions:
-                ret += ' & %r' % self.restrictions
-            return ret
+        return super().__repr__() if config['loglevel'].lower() == 'debug' else self.preview()
+
+    def preview(self):
+        """
+        returns a preview of the contents of the relation.
+        """
         rel = self.proj(*self.heading.non_blobs)  # project out blobs
         limit = config['display.limit']
         width = config['display.width']
-        tups = rel.fetch(limit=limit)
+        tuples = rel.fetch(limit=limit)
         columns = rel.heading.names
-        widths = {f: min(max([len(f)] + [len(str(e)) for e in tups[f]])+4, width) for f in columns}
+        widths = {f: min(max([len(f)] + [len(str(e)) for e in tuples[f]])+4, width) for f in columns}
         templates = {f: '%%-%d.%ds' % (widths[f], widths[f]) for f in columns}
         return (
             ' '.join([templates[f] % ('*'+f if f in rel.primary_key else f) for f in columns]) + '\n' +
             ' '.join(['+' + '-' * (widths[column] - 2) + '+' for column in columns]) + '\n' +
-            '\n'.join(' '.join(templates[f] % tup[f] for f in columns) for tup in tups) +
+            '\n'.join(' '.join(templates[f] % tup[f] for f in columns) for tup in tuples) +
             ('\n...\n' if len(rel) > limit else '\n') +
             ' (%d tuples)\n' % len(rel))
 
     def _repr_html_(self):
-        limit = config['display.limit']
         rel = self.proj(*self.heading.non_blobs)  # project out blobs
-        columns = rel.heading.names
         info = self.heading.table_info
-        content = dict(
-            title="" if info is None else "<h3>%s</h3>" % info['comment'],
-            head='</th><th>'.join("<em>" + c + "</em>" if c in self.primary_key else c for c in columns),
-            body='</tr><tr>'.join(
-                ['\n'.join(['<td>%s</td>' % column for column in tup]) for tup in rel.fetch(limit=limit)]),
-            tuples=len(rel))
-        return """ %(title)s
+        return """ {title}
             <div style="max-height:1000px;max-width:1500px;overflow:auto;">
             <table border="1" class="dataframe">
-                <thead> <tr style="text-align: right;"> <th> %(head)s </th> </tr> </thead>
-                <tbody> <tr> %(body)s </tr> </tbody>
+                <thead> <tr style="text-align: right;"> <th> {head} </th> </tr> </thead>
+                <tbody> <tr> {body} </tr> </tbody>
             </table>
-            <p>%(tuples)i tuples</p></div>
-            """ % content
+            <p>{count} tuples</p></div>
+            """.format(
+            title="" if info is None else "<h3>%s</h3>" % info['comment'],
+            head='</th><th>'.join("<em>" + c + "</em>" if c in self.primary_key else c
+                                  for c in rel.heading.names),
+            body='</tr><tr>'.join(
+                ['\n'.join(['<td>%s</td>' % column for column in tup])
+                 for tup in rel.fetch(limit=config['display.limit'])]),
+            count=len(rel))
 
     def make_sql(self, select_fields=None):
-        return 'SELECT {fields} FROM {from_}{where}{group}'.format(
-            fields=select_fields if select_fields else self.select_fields,
+        return 'SELECT {fields} FROM {from_}{where}'.format(
+            fields=(select_fields if select_fields else ("DISTINCT " if self.distinct else "") + self.select_fields),
             from_=self.from_clause,
-            where=self.where_clause,
-            group=' GROUP BY `%s`' % '`,`'.join(self.primary_key) if self._grouped() else '')
+            where=self.where_clause)
 
     def __len__(self):
         """
-        number of tuples in the relation.  This also takes care of the truth value
+        number of tuples in the relation.
         """
-        if self._grouped():
-            return len(Subquery(self))
+        return self.connection.query(self.make_sql('count(%s)' % (
+            ("DISTINCT `%s`" % '`,`'.join(self.primary_key)) if self.distinct else "*"))).fetchone()[0]
 
-        cur = self.connection.query(self.make_sql('count(*)'))
-        return cur.fetchone()[0]
+    def __bool__(self):
+        """
+        :return:  True if the relation is not empty. Equivalent to len(rel)>0 but may be more efficient.
+        """
+        return len(self) > 0
 
     def __contains__(self, item):
         """
-        "item in relation" is equivalent to "len(relation & item)>0"
+        returns True if item is found in the relation.
+        :param item: any restriction
+        (item in relation) is equivalent to bool(self & item) but may be executed more efficiently.
         """
-        return len(self & item) > 0
+        return bool(self & item)   # May be optimized using as an EXISTS query
 
     def cursor(self, offset=0, limit=None, order_by=None, as_dict=False):
         """
-        Return query cursor.
         See Relation.fetch() for input description.
-        :return: cursor to the query
+        :return: query cursor
         """
         if offset and limit is None:
             raise DataJointError('limit is required when offset is set')
         sql = self.make_sql()
         if order_by is not None:
             sql += ' ORDER BY ' + ', '.join(order_by)
-
         if limit is not None:
-            sql += ' LIMIT %d' % limit
-            if offset:
-                sql += ' OFFSET %d' % offset
+            sql += ' LIMIT %d' % limit + (' OFFSET %d' % offset if offset else "")
         logger.debug(sql)
         return self.connection.query(sql, as_dict=as_dict)
 
@@ -418,143 +437,156 @@ class Not:
 
 class Join(RelationalOperand):
     """
-    Relational join
+    Relational join.
+    Join is a private DataJoint class not exposed to users.
     """
 
-    def __init__(self, arg1, arg2=None, aggregated=False, keep_all_rows=None):
-        if arg2 is None and isinstance(arg1, Join):
+    def __init__(self, arg, arg2=None, keep_all_rows=False):
+        if arg2 is None and isinstance(arg, Join):
             # copy constructor
-            super().__init__(arg1)
-            self._arg1 = arg1._arg1
-            self._arg2 = arg1._arg2
-            self._heading = arg1._heading
-            self._left = arg1._left
+            super().__init__(arg)
+            self._connection = arg.connection
+            self._heading = arg.heading
+            self._arg = arg._arg
+            self._arg2 = arg._arg2
+            self._left = arg._left
         else:
             super().__init__()
-            assert aggregated or keep_all_rows is None     # keep_all_rows should be set only for aggregation
-            assert not any(isinstance(arg, U) for arg in (arg1, arg2)), 'Cannot join with Relation U'
             if not isinstance(arg2, RelationalOperand):
                 raise DataJointError('a relation can only be joined with another relation')
-            if arg1.connection != arg2.connection:
-                raise DataJointError('Cannot join relations with different database connections')
-            self._arg1 = Subquery(arg1) if isinstance(arg1, Projection) else arg1
-            self._arg2 = Subquery(arg2) if isinstance(arg2, Projection) else arg2
-            self._heading = self._arg1.heading.join(self._arg2.heading, aggregated=aggregated)
-            self.restrict(self._arg1.restrictions)
-            self.restrict(self._arg2.restrictions)
+            if arg.connection != arg2.connection:
+                raise DataJointError("Cannot join relations from different connections.")
+            self._connection = arg.connection
+            self._arg = self.make_argument_subquery(arg)
+            self._arg2 = self.make_argument_subquery(arg2)
+            self._distinct = self._arg.distinct or self._arg2.distinct
             self._left = keep_all_rows
+            try:
+                DataJointError("Cannot join relations on dependent attribute %s" % next(r for r in set(
+                    self._arg.heading.dependent_attributes).intersection(self._arg2.heading.dependent_attributes)))
+            except StopIteration:
+                self._heading = self._arg.heading.join(self._arg2.heading)
+                self.restrict(self._arg.restrictions)
+                self.restrict(self._arg2.restrictions)
 
-    def _repr_helper(self):
-        return "(%r) * (%r)" % (self._arg1, self._arg2)
-
-    @property
-    def connection(self):
-        return self._arg1.connection
-
-    @property
-    def heading(self):
-        return self._heading
+    @staticmethod
+    def make_argument_subquery(arg):
+        """
+        Decide when a Join argument needs to be wrapped in a subquery
+        """
+        return (Subquery(arg)
+                if isinstance(arg, GroupBy) or (isinstance(arg, Projection) and arg.heading.expressions)
+                else arg)
 
     @property
     def from_clause(self):
-        return '{from1} NATURAL {left}JOIN {from2}'.format(
-            from1=self._arg1.from_clause,
-            left="LEFT " if self._left else "",
+        return '{from1} NATURAL{left} JOIN {from2}'.format(
+            from1=self._arg.from_clause,
+            left=" LEFT" if self._left else "",
             from2=self._arg2.from_clause)
 
     @property
     def select_fields(self):
-        return self.heading.as_sql
-
-
-attribute_alias_parser = re.compile('^\s*(?P<sql_expression>\S(.*\S)?)\s*->\s*(?P<alias>[a-z][a-z_0-9]*)\s*$')
+        return '*' if all(a.select_fields == '*' for a in (self._arg, self._arg2)) else self.heading.as_sql
 
 
 class Projection(RelationalOperand):
+    """
+    Projection is an private DataJoint class that implements relational projection.
+    See RelationalOperand.proj() for user interface.
+    """
 
-    def __init__(self, arg, attributes=None, renamed_attributes=None, include_primary_key=True):
-        """
-        See RelationalOperand.proj()
-        """
-        if attributes is None:
+    def __init__(self, arg, attributes=None, named_attributes=None, include_primary_key=True):
+        if attributes is None and isinstance(arg, Projection):
             # copy constructor
-            assert isinstance(arg, Projection), 'Projection can only be copied from another projection.'
-            super().__init__(arg)   # copy restrictions
+            super().__init__(arg)
+            self._connection = arg.connection
+            self._heading = arg.heading
             self._arg = arg._arg
-            self._renamed_attributes = arg._renamed_attributes   # ok not to copy
-            self._attributes = arg._attributes  # ok not to copy
-            self._include_primary_key = arg._include_primary_key
             return
 
         super().__init__()
-        # parse attributes in the form 'sql_expression -> new_attribute'
-        self._attributes = []
-        self._renamed_attributes = renamed_attributes
-        self._include_primary_key = include_primary_key
-        for attribute in attributes:
-            alias_match = attribute_alias_parser.match(attribute)
-            if alias_match:
-                d = alias_match.groupdict()
-                self._renamed_attributes.update({d['alias']: d['sql_expression']})
-            else:
-                self._attributes.append(attribute)
-        self._arg = arg
-        restricting_on_removed_attributes = bool(
-            arg.attributes_in_restrictions() - set(self.heading.names))
-        use_subquery = restricting_on_removed_attributes or arg.heading.computed
-        if use_subquery:
+        self._connection = arg.connection
+        named_attributes = {k: v.strip() for k, v in named_attributes.items()}  # clean up values
+        if include_primary_key:   # include primary key of arg
+            attributes = (list(a for a in arg.primary_key if a not in named_attributes.values()) +
+                          list(a for a in attributes if a not in arg.primary_key))
+        else:
+            self._distinct = (self.distinct or not set(arg.primary_key).issubset(
+                set(attributes) | set(named_attributes.values())))
+        if self._need_subquery(arg, attributes, named_attributes):
             self._arg = Subquery(arg)
         else:
-            self.restrict(arg.restrictions)
+            self._arg = arg
+            self.restrict(arg.restrictions)  # transfer restrictions when no subquery
+        self._heading = self._arg.heading.project(attributes, named_attributes)
 
-    def _repr_helper(self):
-        return "(%r).proj(%r)" % (self._arg, self._attributes)
-
-    @property
-    def connection(self):
-        return self._arg.connection
-
-    @property
-    def heading(self):
-        return self._arg.heading.proj(
-            self._attributes, self._renamed_attributes, include_primary_key=self._include_primary_key)
-
-    def _grouped(self):
-        return self._arg._grouped()
+    @staticmethod
+    def _need_subquery(arg, attributes, named_attributes):
+        """
+        Decide whether the projection argument needs to be wrapped in a subquery
+        """
+        if arg.heading.expressions:  # argument has any renamed (computed) attributes
+            return True
+        restricting_attributes = arg.attributes_in_restriction()
+        return (not restricting_attributes.issubset(attributes) or # if any restricting attribute is projected out or
+                any(v.strip() in restricting_attributes for v in named_attributes.values()))  # or renamed
 
     @property
     def from_clause(self):
         return self._arg.from_clause
 
-    def __and__(self, restriction):
-        has_restriction = isinstance(restriction, RelationalOperand) or bool(restriction)
-        do_subquery = has_restriction and self.heading.computed
-        return (Subquery(self) if do_subquery else self).restrict(restriction)
 
+class GroupBy(RelationalOperand):
+    """
+    GroupBy(rel, comp1='expr1', ..., compn='exprn')  produces a relation with the primary key specified by rel.heading.
+    The computed arguments comp1, ..., compn use aggregation operators on the attributes of rel.
+    GroupBy is used RelationalOperand.aggregate and U.aggregate.
+    GroupBy is a private class in DataJoint, not exposed to users.
+    """
 
-class Aggregation(Projection):
-
-    def __init__(self, arg, group=None, attributes=None, renamed_attributes=None, keep_all_rows=None):
-        """
-        See: RelationalOperand.aggregate
-        """
-        if group is None and isinstance(arg, Aggregation):
+    def __init__(self, arg, group=None, attributes=None, named_attributes=None, keep_all_rows=False):
+        if group is None and isinstance(arg, GroupBy):
             # copy constructor
             super().__init__(arg)
-            self._left_arg = arg._left_arg
-            self._group = arg._group
+            self._connection = arg.connection
+            self._heading = arg.heading
+            self._arg = arg._arg
+            self._keep_all_rows = arg._keep_all_rows
+            return
+
+        super().__init__()
+        if not isinstance(group, RelationalOperand):
+            raise DataJointError('a relation can only be joined with another relation')
+        self._keep_all_rows = keep_all_rows
+        if not (set(group.primary_key) - set(arg.primary_key)):
+            raise DataJointError(
+                'The aggregated relation should have additional fields in its primary key for aggregation to work')
+        if isinstance(arg, U):
+            self._arg = Join.make_argument_subquery(group)
         else:
-            super().__init__(
-                Join(arg, group, aggregated=True, keep_all_rows=keep_all_rows),
-                attributes=attributes, renamed_attributes=renamed_attributes)
-            self._left_arg = arg
-            self._group = group
+            self._arg = Join(arg, group, keep_all_rows=keep_all_rows)
+        self._connection = self._arg.connection
+        # always include primary key of arg
+        attributes = (list(a for a in arg.primary_key if a not in named_attributes.values()) +
+                      list(a for a in attributes if a not in arg.primary_key))
+        self._heading = self._arg.heading.project(
+            attributes, named_attributes, force_primary_key=arg.primary_key)
 
-    def _grouped(self):
-        return True
+    @property
+    def from_clause(self):
+        raise DataJointError('Internal DataJointError: Aggregated relation must be wrapped in a subquery.')
 
-    def _repr_helper(self):
-        return "(%r).aggregate(%r, %r, **%s)" % (self._arg, self._group, self._attributes)
+    def make_sql(self):
+        return 'SELECT {fields} FROM {from_}{where} GROUP  BY `{group_by}`{having}'.format(
+            fields=self.select_fields,
+            from_=self._arg.from_clause,
+            where=self._arg.where_clause,
+            group_by='`,`'.join(self.primary_key),
+            having=re.sub(r'^ WHERE', ' HAVING', self.where_clause))
+
+    def __len__(self):
+        return len(Subquery(self) if self.restrictions else self._arg)
 
 
 class Subquery(RelationalOperand):
@@ -569,14 +601,14 @@ class Subquery(RelationalOperand):
         if isinstance(arg, Subquery):
             # copy constructor
             super().__init__(arg)
+            self._connection = arg.connection
+            self._heading = arg.heading
             self._arg = arg._arg
         else:
             super().__init__()
+            self._connection = arg.connection
+            self._heading = arg.heading.make_subquery_heading()
             self._arg = arg
-
-    @property
-    def connection(self):
-        return self._arg.connection
 
     @property
     def counter(self):
@@ -591,15 +623,8 @@ class Subquery(RelationalOperand):
     def select_fields(self):
         return '*'
 
-    @property
-    def heading(self):
-        return self._arg.heading.resolve()
 
-    def _repr_helper(self):
-        return "%r" % self._arg
-
-
-class U(RelationalOperand):
+class U:
     """
     dj.U objects are special relations representing all possible values their attributes.
     dj.U objects cannot be queried on their own but are useful for forming some relational queries.
@@ -649,44 +674,37 @@ class U(RelationalOperand):
     """
 
     def __init__(self, *primary_key):
-        super().__init__()
-        if len(primary_key) == 1 and isinstance(primary_key[0], U):
-            # copy constructor
-            self._primary_key = primary_key[0]._primary_key  # ok not to copy
-        else:
-            # regular constructor
-            self._primary_key = primary_key
-
-    # ----------- prohibited operations ------------- #
-    @property
-    def connection(self):
-        raise DataJointError('Relation U does not support this operation')
-
-    @property
-    def from_clause(self):
-        raise DataJointError('Relation U does not support this operation')
-
-    # ------------- overriden operations ---------------- #
-
-    def _repr_helper(self):
-        return 'U(%s)' % (','.join(self.primary_key))
-
-    @property
-    def heading(self):
-        raise DataJointError('Relation U does not support this operation')
+        self._primary_key = primary_key
 
     @property
     def primary_key(self):
         return self._primary_key
 
-    def restrict(self, relation):
+    def __and__(self, relation):
         if not isinstance(relation, RelationalOperand):
             raise DataJointError('Relation U can only be restricted with another relation.')
-        return Projection(relation, attributes=self.primary_key, renamed_attributes=dict(), include_primary_key=False)
+        return Projection(relation, attributes=self.primary_key,
+                          named_attributes=dict(), include_primary_key=False)
 
     def __mul__(self, relation):
+        """
+        Joining relation U * relation has the effect of adding the attributes of U to the primary key of
+        the other relation.
+        :param relation: other relation
+        :return: a copy of the other relation with the primary key extended.
+        """
         if not isinstance(relation, RelationalOperand):
             raise DataJointError('Relation U can only be joined with another relation.')
         copy = relation.__class__(relation)
         copy._heading = copy.heading.extend_primary_key(self.primary_key)
         return copy
+
+    def aggregate(self, group, **named_attributes):
+        """
+        Aggregation of the type U('attr1','attr2').aggregate(rel, computation="expression")
+        has the primary key ('attr1','attr2') and performs aggregation computations for all matching tuples of relation.
+        :param group:  The other relation which will be aggregated
+        :param named_attributes: computations of the form new_attribute="sql expression on attributes of group"
+        :return: The new relation
+        """
+        return GroupBy(self, group=group, keep_all_rows=False, attributes=(), named_attributes=named_attributes)

--- a/tests/test_relation_u.py
+++ b/tests/test_relation_u.py
@@ -20,9 +20,11 @@ class TestU:
         self.trash = schema.UberTrash()
 
     def test_restriction(self):
+        language_set = {s[1] for s in self.language.contents}
         rel = dj.U('language') & self.language
         assert_list_equal(rel.heading.names, ['language'])
-        languages = rel.fetch()
+        assert_true(len(rel) == len(language_set))
+        assert_true(set(rel.fetch['language']) == language_set)
 
     def test_ineffective_restriction(self):
         rel = self.language & dj.U('language')

--- a/tests/test_relational_operand.py
+++ b/tests/test_relational_operand.py
@@ -95,7 +95,7 @@ class TestRelational:
         y = A().proj(a2='id_a', c2='cond_in_a')
         rel = x*y & 'c1=0' & 'c2=1'
         lenx = len(x & 'c1=0')
-        leny = len(y & 'c2=0')
+        leny = len(y & 'c2=1')
         assert_equal(lenx + leny, len(A()),
                      'incorrect restriction')
         assert_equal(len(rel), len(x & 'c1=0')*len(y & 'c2=1'),
@@ -180,7 +180,6 @@ class TestRelational:
     def test_datetime():
         """Test date retrieval"""
         date = Experiment().fetch['experiment_date'][0]
-
         e1 = Experiment() & dict(experiment_date=str(date))
         e2 = Experiment() & dict(experiment_date=date)
         assert_true(len(e1) == len(e2) > 0, 'Two date restriction do not yield the same result')
@@ -188,7 +187,5 @@ class TestRelational:
     @staticmethod
     def test_join_project_optimization():
         """Test optimization for join of projected relations with matching non-primary key"""
-        print(DataA().proj() * DataB().proj())
-        print(DataA())
         assert_true(len(DataA().proj() * DataB().proj()) == len(DataA()) == len(DataB()),
                     "Join of projected relations does not work")

--- a/tests/test_relational_operand.py
+++ b/tests/test_relational_operand.py
@@ -79,8 +79,7 @@ class TestRelational:
         assert_equal(set(x.primary_key).union(y.primary_key), set(rel.primary_key),
                      'incorrect join primary_key')
 
-        # test the -> notation
-        x = B().proj('id_a->a')
+        x = B().proj(a='id_a')
         y = D()
         rel = x*y
         assert_equal(len(rel), len(x)*len(y),
@@ -95,7 +94,9 @@ class TestRelational:
         x = A().proj(a1='id_a', c1='cond_in_a')
         y = A().proj(a2='id_a', c2='cond_in_a')
         rel = x*y & 'c1=0' & 'c2=1'
-        assert_equal(len(x & 'c1=0')+len(y & 'c2=1'), len(A()),
+        lenx = len(x & 'c1=0')
+        leny = len(y & 'c2=0')
+        assert_equal(lenx + leny, len(A()),
                      'incorrect restriction')
         assert_equal(len(rel), len(x & 'c1=0')*len(y & 'c2=1'),
                      'incorrect pairing')
@@ -123,6 +124,7 @@ class TestRelational:
     @staticmethod
     def test_aggregate():
         x = B().aggregate(B.C(), 'n', count='count(id_c)', mean='avg(value)', max='max(value)', keep_all_rows=True)
+        sql = x.make_sql()
         assert_equal(len(x), len(B()))
         for n, count, mean, max_, key in zip(*x.fetch['n', 'count', 'mean', 'max', dj.key]):
             assert_equal(n, count, 'aggregation failed (count)')


### PR DESCRIPTION
- `dj.U` is no longer a `RelationalOperand` -- it only supports a limited number of operations, which produce relational operands. 
- `GroupBy` now uses a `HAVING` clause for restrictions, avoiding an extra subquery. 
- Added `__repr__` to `Schema`. 
- Closing issues #163, #136, #214, #177, #112 -- these should all be fixed. 