### PR TITLE
Added `set_password` and `show_definition`

### DIFF
--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -16,8 +16,8 @@ import logging
 import os
 
 __author__ = "Dimitri Yatsenko, Edgar Walker, and Fabian Sinz at Baylor College of Medicine"
-__version__ = "0.2.8"
-__date__ = "July 1, 2016"
+__version__ = "0.3.0"
+__date__ = "July 7, 2016"
 __all__ = ['__author__', '__version__',
            'config', 'conn', 'kill', 'BaseRelation',
            'Connection', 'Heading', 'FreeRelation', 'Not', 'schema',

--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -22,7 +22,8 @@ __all__ = ['__author__', '__version__',
            'config', 'conn', 'kill', 'BaseRelation',
            'Connection', 'Heading', 'FreeRelation', 'Not', 'schema',
            'Manual', 'Lookup', 'Imported', 'Computed', 'Part',
-           'AndList', 'OrList', 'ERD', 'U']
+           'AndList', 'OrList', 'ERD', 'U',
+           'set_password']
 
 print('DataJoint', __version__, '('+__date__+')')
 
@@ -81,3 +82,4 @@ from .heading import Heading
 from .schema import Schema as schema
 from .kill import kill
 from .erd import ERD
+from .admin import set_password

--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -17,7 +17,7 @@ import os
 
 __author__ = "Dimitri Yatsenko, Edgar Walker, and Fabian Sinz at Baylor College of Medicine"
 __version__ = "0.3.0"
-__date__ = "July 7, 2016"
+__date__ = "July 14, 2016"
 __all__ = ['__author__', '__version__',
            'config', 'conn', 'kill', 'BaseRelation',
            'Connection', 'Heading', 'FreeRelation', 'Not', 'schema',

--- a/datajoint/admin.py
+++ b/datajoint/admin.py
@@ -1,0 +1,6 @@
+from . import conn
+
+
+def set_password(new_password, connection=conn()):
+    connection.query("SET PASSWORD = PASSWORD('%s')" % new_password)
+    print('done.')

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -333,10 +333,11 @@ class BaseRelation(RelationalOperand):
             attributes_thus_far.add(attr.name)
             do_include = True
             for parent, primary_key in list(parents.items()):
+                if attr.name in primary_key:
+                    do_include = False
                 if attributes_thus_far.issuperset(primary_key):
                     parents.pop(parent)
                     definition += '-> ' + self.lookup_table_name(parent) + '\n'
-                    do_include = False
             if do_include:
                 definition += '%-20s : %-28s # %s\n' % (
                     attr.name if attr.default is None else '%s=%s' % (attr.name, attr.default),

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -315,8 +315,7 @@ class BaseRelation(RelationalOperand):
                 database=self.database, table=self.table_name), as_dict=True).fetchone()
         return ret['Data_length'] + ret['Index_length']
 
-    @property
-    def real_definition(self):
+    def show_definition(self):
         """
         :return:  the definition string for the relation using DataJoint DDL.
         This does not yet work for aliased foreign keys.

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -339,7 +339,7 @@ class BaseRelation(RelationalOperand):
                     do_include = False
             if do_include:
                 definition += '%-20s : %-28s # %s\n' % (
-                    attr.name if attr.default is None else '%s="%s"' % (attr.name, attr.default),
+                    attr.name if attr.default is None else '%s=%s' % (attr.name, attr.default),
                     '%s%s' % (attr.type, 'auto_increment' if attr.autoincrement else ''), attr.comment)
         return definition
 
@@ -349,12 +349,12 @@ class BaseRelation(RelationalOperand):
         :param name: `database`.`table_name`
         :return: class name found in the context.
         """
-        def _lookup(context, name):
+        def _lookup(context, name, level=0):
             for member_name, member in context.items():
                 if inspect.isclass(member) and issubclass(member, BaseRelation) and member.full_table_name == name:
                     return member_name
-                if inspect.ismodule(member) and member.__name__ != 'datajoint':
-                    candidate_name = _lookup(dict(inspect.getmembers(member)), name)
+                if level < 5 and inspect.ismodule(member) and member.__name__ != 'datajoint':
+                    candidate_name = _lookup(dict(inspect.getmembers(member)), name, level+1)
                     if candidate_name != name:
                         return member_name + '.' + candidate_name
             return name

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -189,3 +189,6 @@ class Connection:
             raise
         else:
             self.commit_transaction()
+
+
+

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -161,7 +161,11 @@ def compile_attribute(line, in_key=False):
     :returns: (name, sql) -- attribute name and sql code for its declaration
     """
 
-    match = attribute_parser.parseString(line+'#', parseAll=True)
+    try:
+        match = attribute_parser.parseString(line+'#', parseAll=True)
+    except pp.ParseException:
+        logger.error('Declaration error in line: ', line)
+        raise
     match['comment'] = match['comment'].rstrip('#')
     if 'default' not in match:
         match['default'] = ''

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -141,15 +141,12 @@ def declare(full_table_name, definition, context):
     # compile SQL
     if not primary_key:
         raise DataJointError('Table must have a primary key')
-    sql = 'CREATE TABLE IF NOT EXISTS %s (\n  ' % full_table_name
-    sql += ',\n  '.join(attribute_sql)
-    sql += ',\n  PRIMARY KEY (`' + '`,`'.join(primary_key) + '`)'
-    if foreign_key_sql:
-        sql += ',  \n' + ',  \n'.join(foreign_key_sql)
-    if index_sql:
-        sql += ',  \n' + ',  \n'.join(index_sql)
-    sql += '\n) ENGINE = InnoDB, COMMENT "%s"' % table_comment
-    return sql
+    return ('CREATE TABLE IF NOT EXISTS %s (\n' % full_table_name +
+            ',\n'.join(attribute_sql +
+                       ['PRIMARY KEY (`' + '`,`'.join(primary_key) + '`)'] +
+                       foreign_key_sql +
+                       index_sql) +
+            '\n) ENGINE=InnoDB, COMMENT "%s"' % table_comment)
 
 
 def compile_attribute(line, in_key=False):

--- a/datajoint/heading.py
+++ b/datajoint/heading.py
@@ -166,7 +166,6 @@ class Heading:
             ('int', True): np.uint32,
             ('bigint', False): np.int64,
             ('bigint', True): np.uint64
-            # TODO: include types DECIMAL and NUMERIC
             }
 
         sql_literals = ['CURRENT_TIMESTAMP']

--- a/datajoint/heading.py
+++ b/datajoint/heading.py
@@ -19,22 +19,13 @@ class Attribute(namedtuple('_Attribute', default_attribute_properties.keys())):
     @property
     def sql(self):
         """
-        Convert attribute tuple into its SQL CREATE TABLE clause.
+        Convert primary key attribute tuple into its SQL CREATE TABLE clause.
+        Default values are not reflected.
         :return: SQL code
         """
-        sql_literals = ['CURRENT_TIMESTAMP']    # SQL literals that can be used as default values
-        if self.nullable:
-            default = 'DEFAULT NULL'
-        else:
-            default = 'NOT NULL'
-            if self.default:
-                # enclose value in quotes except special SQL values or already enclosed
-                quote = self.default.upper() not in sql_literals and self.default[0] not in '"\''
-                default += ' DEFAULT ' + ('"%s"' if quote else "%s") % self.default
-        if any(c in r'\"' for c in self.comment):
-            raise DataJointError('Illegal characters in attribute comment "%s"' % self.comment)
-        return '`{name}` {type} {default} COMMENT "{comment}"'.format(
-            name=self.name, type=self.type, default=default, comment=self.comment)
+        assert self.in_key and not self.nullable   # primary key attributes are never nullable
+        return '`{name}` {type} NOT NULL COMMENT "{comment}"'.format(
+            name=self.name, type=self.type, comment=self.comment)
 
 
 class Heading:
@@ -99,7 +90,7 @@ class Heading:
                 ret += '---\n'
                 in_key = False
             ret += '%-20s : %-28s # %s\n' % (
-                v.name if v.default is None else '%s="%s"' % (v.name, v.default),
+                v.name if v.default is None else '%s=%s' % (v.name, v.default),
                 '%s%s' % (v.type, 'auto_increment' if v.autoincrement else ''), v.comment)
         return ret
 
@@ -178,14 +169,20 @@ class Heading:
             # TODO: include types DECIMAL and NUMERIC
             }
 
+        sql_literals = ['CURRENT_TIMESTAMP']
+
         # additional attribute properties
         for attr in attributes:
             attr['nullable'] = (attr['nullable'] == 'YES')
             attr['in_key'] = (attr['in_key'] == 'PRI')
             attr['autoincrement'] = bool(re.search(r'auto_increment', attr['Extra'], flags=re.IGNORECASE))
+            attr['type'] = re.sub(r'int\(\d+\)', 'int', attr['type'], count=1)   # strip size off integers
             attr['numeric'] = bool(re.match(r'(tiny|small|medium|big)?int|decimal|double|float', attr['type']))
             attr['string'] = bool(re.match(r'(var)?char|enum|date|time|timestamp', attr['type']))
             attr['is_blob'] = bool(re.match(r'(tiny|medium|long)?blob', attr['type']))
+
+            if attr['string'] and attr['default'] is not None and attr['default'] not in sql_literals:
+                attr['default'] = '"%s"' % attr['default']
 
             attr['sql_expression'] = None
             if not (attr['numeric'] or attr['string'] or attr['is_blob']):

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -2,13 +2,12 @@ import warnings
 
 import pymysql
 import logging
+import inspect
 import re
 from . import conn, DataJointError, config
-from datajoint.utils import to_camel_case
 from .heading import Heading
-from .utils import user_choice
-from .user_relations import Part, Computed, Imported, Manual, Lookup
-import inspect
+from .utils import user_choice, to_camel_case
+from .user_relations import UserRelation, Part, Computed, Imported, Manual, Lookup
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +118,7 @@ class Schema:
         cur = self.connection.query("SHOW DATABASES LIKE '{database}'".format(database=self.database))
         return cur.rowcount > 0
 
+
     def process_relation_class(self, relation_class, context, assert_declared=False):
         """
         assign schema properties to the relation class and declare the table
@@ -141,6 +141,7 @@ class Schema:
                             table=instance.__class__.__name__))
                 else:
                     instance.insert(contents, skip_duplicates=True)
+
 
     def __call__(self, cls):
         """
@@ -170,3 +171,4 @@ class Schema:
         :return: jobs relation
         """
         return self.connection.jobs[self.database]
+

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -171,4 +171,3 @@ class Schema:
         :return: jobs relation
         """
         return self.connection.jobs[self.database]
-

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -1,5 +1,4 @@
 import warnings
-
 import pymysql
 import logging
 import inspect

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1,7 +1,7 @@
-import re
 from nose.tools import assert_true, assert_false, assert_equal, assert_list_equal, raises
 from . import schema
 import datajoint as dj
+from datajoint.declare import declare
 
 auto = schema.Auto()
 auto.fill()
@@ -24,8 +24,9 @@ class TestDeclare:
     def test_real_definition():
         """real_definition should match original definition"""
         rel = schema.Experiment()
-        s1 = re.sub('r\s+', rel.definition, '')
-        s2 = re.sub('r\s+', rel.real_definition, '')
+        context = rel._context
+        s1 = declare(rel.full_table_name, rel.definition, context)
+        s2 = declare(rel.full_table_name, rel.real_definition, context)
         assert_equal(s1, s2)
 
     @staticmethod

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -21,12 +21,12 @@ class TestDeclare:
         assert_true(not issubclass(schema.Subject, dj.Part))
 
     @staticmethod
-    def test_real_definition():
+    def test_show_definition():
         """real_definition should match original definition"""
         rel = schema.Experiment()
         context = rel._context
         s1 = declare(rel.full_table_name, rel.definition, context)
-        s2 = declare(rel.full_table_name, rel.real_definition, context)
+        s2 = declare(rel.full_table_name, rel.show_definition(), context)
         assert_equal(s1, s2)
 
     @staticmethod

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1,3 +1,4 @@
+import re
 from nose.tools import assert_true, assert_false, assert_equal, assert_list_equal, raises
 from . import schema
 import datajoint as dj
@@ -18,6 +19,14 @@ class TestDeclare:
     def test_schema_decorator():
         assert_true(issubclass(schema.Subject, dj.Manual))
         assert_true(not issubclass(schema.Subject, dj.Part))
+
+    @staticmethod
+    def test_real_definition():
+        """real_definition should match original definition"""
+        rel = schema.Experiment()
+        s1 = re.sub('r\s+', rel.definition, '')
+        s2 = re.sub('r\s+', rel.real_definition, '')
+        assert_equal(s1, s2)
 
     @staticmethod
     def test_attributes():


### PR DESCRIPTION
The property `real_definition` contains the reversed engineered table definition.  This is useful for updating the definition when changes are made elsewhere.