### PR TITLE
Improved ERD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,6 @@
 * Fixed issue #223:  `insert` can insert relations without fetching
 * ERD() now takes the `context` argument, which specifies in which context to look for classes. The default is taken from the argument (schema or relation).
 * ERD.draw() no longer has the `prefix` argument: class names are shown as found in the context.
+
+### 0.3.3
+* Suppressed warnings (redirected them to logging).  Previoiusly, scipy would throw warnings in ERD, for example.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,6 @@
 
 ### 0.3.3
 * Suppressed warnings (redirected them to logging).  Previoiusly, scipy would throw warnings in ERD, for example.
+* Added ERD.from_sequence as a shortcut to combining the ERDs of multiple sources
+* ERD() no longer text the context argument.
+* ERD.draw() now takes an optional context argument.  By default uses the caller's locals.

--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -16,7 +16,7 @@ import logging
 import os
 
 __author__ = "Dimitri Yatsenko, Edgar Walker, and Fabian Sinz at Baylor College of Medicine"
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 __date__ = "July 18, 2016"
 __all__ = ['__author__', '__version__',
            'config', 'conn', 'kill', 'BaseRelation',
@@ -26,6 +26,8 @@ __all__ = ['__author__', '__version__',
            'set_password']
 
 print('DataJoint', __version__, '('+__date__+')')
+
+logging.captureWarnings(True)
 
 
 class key:

--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -17,7 +17,7 @@ import os
 
 __author__ = "Dimitri Yatsenko, Edgar Walker, and Fabian Sinz at Baylor College of Medicine"
 __version__ = "0.3.3"
-__date__ = "July 18, 2016"
+__date__ = "July 20, 2016"
 __all__ = ['__author__', '__version__',
            'config', 'conn', 'kill', 'BaseRelation',
            'Connection', 'Heading', 'FreeRelation', 'Not', 'schema',

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -387,9 +387,13 @@ def lookup_class_name(context, name, levels=4):
                     if inspect.isclass(part) and issubclass(part, BaseRelation) and part.full_table_name == name:
                         return member_name + '.' + part.__name__
         elif levels and inspect.ismodule(member) and member.__name__ != 'datajoint':
-            candidate_name = lookup_class_name(dict(inspect.getmembers(member)), name, levels-1)
-            if candidate_name != name:
-                return member_name + '.' + candidate_name
+            try:
+                candidate_name = lookup_class_name(dict(inspect.getmembers(member)), name, levels-1)
+            except ImportError:
+                pass
+            else:
+                if candidate_name != name:
+                    return member_name + '.' + candidate_name
     return name
 
 

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -62,6 +62,7 @@ class Connection:
             port = config['database.port']
         self.conn_info = dict(host=host, port=port, user=user, passwd=passwd)
         self.init_fun = init_fun
+        print("Connecting {user}@{host}:{port}".format(**self.conn_info))
         self.connect()
         if self.is_connected:
             logger.info("Connected {user}@{host}:{port}".format(**self.conn_info))

--- a/datajoint/erd.py
+++ b/datajoint/erd.py
@@ -1,6 +1,7 @@
 import networkx as nx
 import re
 import numpy as np
+import functools
 from scipy.optimize import basinhopping
 import itertools
 from . import Manual, Imported, Computed, Lookup, Part, DataJointError
@@ -73,6 +74,15 @@ class ERD(nx.DiGraph):
             for node in self:
                 if node.startswith('`%s`' % database):
                     self.nodes_to_show.add(node)
+
+    @classmethod
+    def from_sequence(cls, sequence):
+        """
+        The join ERD for all objects in sequence
+        :param sequence: a sequence (e.g. list, tuple)
+        :return: ERD(arg1) + ... + ERD(argn)
+        """
+        return functools.reduce(lambda x, y: x+y, map(ERD, sequence))
 
     def __add__(self, arg):
         """

--- a/datajoint/erd.py
+++ b/datajoint/erd.py
@@ -3,9 +3,9 @@ import re
 import numpy as np
 from scipy.optimize import basinhopping
 import itertools
-import inspect
 from . import Manual, Imported, Computed, Lookup, Part, DataJointError
 from .base_relation import lookup_class_name
+
 
 user_relation_classes = (Manual, Lookup, Computed, Imported, Part)
 

--- a/tests/test_erd.py
+++ b/tests/test_erd.py
@@ -32,7 +32,7 @@ class TestERD:
     @staticmethod
     def test_erd():
         erd = dj.ERD(schema)
-        graph = erd._make_graph()
+        graph = erd._make_graph(schema.context)
         assert_true(set(cls.__name__ for cls in (A, B, D, E, L)).issubset(graph.nodes()))
         pos = erd._layout(graph)
         assert_true(set(cls.__name__ for cls in (A, B, D, E, L)).issubset(pos.keys()))


### PR DESCRIPTION
(Copied from CHANGELOG)
* Suppressed warnings (redirected them to logging).  Previoiusly, scipy would throw warnings in ERD, for example.
* Added ERD.from_sequence as a shortcut to combining the ERDs of multiple sources
* ERD() no longer text the context argument.
* ERD.draw() now takes an optional context argument.  By default uses the caller's locals.
