### PR TITLE
ERD.add_parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@
 * Added ERD.from_sequence as a shortcut to combining the ERDs of multiple sources
 * ERD() no longer text the context argument.
 * ERD.draw() now takes an optional context argument.  By default uses the caller's locals.
+
+### 0.3.4
+* Added method the `ERD.add_parts` method, which adds the part tables of all tables currently in the ERD.
+* `ERD() + arg` and `ERD() - arg` can now accept relation classes as arg.

--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -16,8 +16,8 @@ import logging
 import os
 
 __author__ = "Dimitri Yatsenko, Edgar Walker, and Fabian Sinz at Baylor College of Medicine"
-__version__ = "0.3.3"
-__date__ = "July 20, 2016"
+__version__ = "0.3.4"
+__date__ = "July 21, 2016"
 __all__ = ['__author__', '__version__',
            'config', 'conn', 'kill', 'BaseRelation',
            'Connection', 'Heading', 'FreeRelation', 'Not', 'schema',

--- a/tests/test_erd.py
+++ b/tests/test_erd.py
@@ -43,7 +43,9 @@ class TestERD:
         erd1 = erd0 + 3
         erd2 = dj.ERD(E) - 3
         erd3 = erd1 * erd2
+        erd4 = (erd0 + E).add_parts() - B - E
         assert_true(erd0.nodes_to_show == set(cls.full_table_name for cls in [B]))
         assert_true(erd1.nodes_to_show == set(cls.full_table_name for cls in (B, B.C, E, E.F)))
         assert_true(erd2.nodes_to_show == set(cls.full_table_name for cls in (A, B, D, E, L)))
         assert_true(erd3.nodes_to_show == set(cls.full_table_name for cls in (B, E)))
+        assert_true(erd4.nodes_to_show == set(cls.full_table_name for cls in (B.C, E.F)))


### PR DESCRIPTION
(Copied from CHANGELOG)

* Added method the `ERD.add_parts` method, which adds the part tables of all tables currently in the ERD.
* `ERD() + arg` and `ERD() - arg` can now accept relation classes as arg.
* `set_password()` now asks for user confirmation.
