### PR TITLE
Add BLOB support for dict of simple types

### DIFF
--- a/DevDockerfile
+++ b/DevDockerfile
@@ -3,4 +3,5 @@ FROM eywalker/jupyter
 MAINTAINER Edgar Y. Walker <edgar.walker@gmail.com>
 
 ADD . /src
-RUN pip install -e /src
+RUN pip install -e /src &&\
+    pip install nose

--- a/DevDockerfile
+++ b/DevDockerfile
@@ -1,0 +1,6 @@
+FROM eywalker/jupyter
+
+MAINTAINER Edgar Y. Walker <edgar.walker@gmail.com>
+
+ADD . /src
+RUN pip install -e /src

--- a/datajoint/blob.py
+++ b/datajoint/blob.py
@@ -3,7 +3,7 @@ Provides serialization methods for numpy.ndarrays that ensure compatibility with
 """
 
 import zlib
-from collections import OrderedDict
+from collections import OrderedDict, Mapping, Iterable
 import numpy as np
 from . import DataJointError
 
@@ -34,12 +34,18 @@ decode_lookup = {
     b'ZL123\0': zlib.decompress
 }
 
+def forward_squeeze_shape(shape):
+    for p in range(len(shape)):
+        if shape[p] != 1:
+            break
+    return shape[p:]
 
 class BlobReader:
-    def __init__(self, blob, simplify=False):
+    def __init__(self, blob, simplify=False, as_dict=False):
         self._simplify = simplify
         self._blob = blob
         self._pos = 0
+        self._as_dict = as_dict
 
     @property
     def pos(self):
@@ -92,10 +98,10 @@ class BlobReader:
         dtype = dtype_list[dtype_id]
         is_complex = self.read_value('uint32')
 
-        if dtype_id == 4: # if dealing with character array
+        if dtype_id == 4:  # if dealing with character array
             data = self.read_value(dtype, count=2 * n_elem)
-            data = data[::2].astype('<U1')
-            if n_dims == 2 and shape[0] == 1:
+            data = data[::2].astype('U1')
+            if self._simplify and n_dims == 2 and shape[0] == 1 or n_dims == 1:
                 compact = data.squeeze()
                 data = compact if compact.shape == () else np.array(''.join(data.squeeze()))
                 shape = (1,)
@@ -129,17 +135,22 @@ class BlobReader:
         dt = [(f, np.object) for f in field_names]
         raw_data = []
         for k in range(n_elem):
-            vals = []
+            values = []
             for i in range(n_field):
                 nb = int(self.read_value('uint64')) # dealing with a weird bug of numpy
-                vals.append(self.read_mym_data(n_bytes=nb))
-            raw_data.append(tuple(vals))
-        data = np.rec.array(raw_data, dtype=dt)
+                values.append(self.read_mym_data(n_bytes=nb))
+            raw_data.append(tuple(values))
         if n_bytes is not None:
             assert self.pos - start == n_bytes
         if not advance:
             self.pos = start
-        return self.simplify(data.reshape(shape, order='F'))
+
+        if self._as_dict and n_elem == 1:
+            data = dict(zip(field_names, values))
+            return data
+        else:
+            data = np.rec.array(raw_data, dtype=dt)
+            return self.simplify(data.reshape(shape, order='F'))
 
     def simplify(self, array):
         """
@@ -201,35 +212,87 @@ class BlobReader:
         return str(self._blob[self.pos:])
 
 
-def pack(obj):
-    """
-    Packs an object into a blob to be compatible with mym.mex
+def pack(obj, compress=True):
+    blob = b"mYm\0"
+    blob += pack_obj(obj)
 
-    :param obj: object to be packed
-    :type obj: numpy.ndarray
-    """
-    if not isinstance(obj, np.ndarray):
-        raise DataJointError("Only numpy arrays can be saved in blobs")
+    if compress:
+        compressed = b'ZL123\0' + np.uint64(len(blob)).tostring() + zlib.compress(blob)
+        if len(compressed) < len(blob):
+            blob = compressed
 
-    blob = b"mYm\0A"  # TODO: extend to process other data types besides arrays
-    blob += np.asarray((len(obj.shape),) + obj.shape, dtype=np.uint64).tostring()
+    return blob
 
-    is_complex = np.iscomplexobj(obj)
+
+def pack_obj(obj):
+    blob = b''
+    if isinstance(obj, np.ndarray):
+        blob += pack_array(obj)
+    elif isinstance(obj, Mapping):  # TODO: check if this is a good inheritance check for dict etc.
+        blob += pack_dict(obj)
+    elif isinstance(obj, str):
+        blob += pack_array(np.array(obj, dtype=np.dtype('c')))
+    elif isinstance(obj, Iterable):
+        blob += pack_array(np.array(obj))
+    else:
+        raise DataJointError("Packing object of type %s currently not supported!" % type(obj))
+
+    return blob
+
+
+def pack_array(array):
+    if not isinstance(array, np.ndarray):
+        raise ValueError("argument must be a numpy array!")
+
+    blob = b"A"
+    blob += np.array((len(array.shape), ) + array.shape, dtype=np.uint64).tostring()
+
+    is_complex = np.iscomplexobj(array)
     if is_complex:
-        obj, imaginary = np.real(obj), np.imag(obj)
+        array, imaginary = np.real(array), np.imag(array)
 
-    type_number = rev_class_id[obj.dtype]
-    assert dtype_list[type_number] == obj.dtype, 'ambiguous or unknown array type'
-    blob += np.asarray(type_number, dtype=np.uint32).tostring()
-    blob += np.int8(is_complex).tostring() + b'\0\0\0'
-    blob += obj.tostring(order='F')
+    type_number = rev_class_id[array.dtype]
+
+    if dtype_list[type_number] is None:
+        raise DataJointError("Type %s is ambiguous or unknown" % array.dtype)
+
+    blob += np.array(type_number, dtype=np.uint32).tostring()
+
+    blob += np.int32(is_complex).tostring()
+    if type_number == 4:  # if dealing with character array
+        blob += ('\x00'.join(array.tostring(order='F').decode()) + '\x00').encode()
+    else:
+        blob += array.tostring(order='F')
 
     if is_complex:
         blob += imaginary.tostring(order='F')
 
-    compressed = b'ZL123\0' + np.uint64(len(blob)).tostring() + zlib.compress(blob)
-    if len(compressed) < len(blob):
-        blob = compressed
+    return blob
+
+
+def pack_string(value):
+    return value.encode('ascii') + b'\0'
+
+
+def pack_dict(obj):
+    """
+    Write dictionary object as a singular structure array
+    :param obj: dictionary object to serialize. The fields must be simple scalar or an array.
+    """
+    obj = OrderedDict(obj)
+    blob = b'S'
+    blob += np.array((2, 1, 1), dtype=np.uint64).tostring()
+    blob += np.array(len(obj), dtype=np.uint32).tostring()
+
+    # write out field names
+    for k in obj:
+        blob += pack_string(k)
+
+    for k, v in obj.items():
+        blob_part = pack_obj(v)
+        blob += np.array(len(blob_part), dtype=np.uint64).tostring()
+        blob += blob_part
+
     return blob
 
 

--- a/datajoint/blob.py
+++ b/datajoint/blob.py
@@ -234,6 +234,8 @@ def pack_obj(obj):
         blob += pack_array(np.array(obj, dtype=np.dtype('c')))
     elif isinstance(obj, Iterable):
         blob += pack_array(np.array(obj))
+    elif isinstance(obj, int) or isinstance(obj, float):
+        blob += pack_array(np.array(obj))
     else:
         raise DataJointError("Packing object of type %s currently not supported!" % type(obj))
 

--- a/datajoint/blob.py
+++ b/datajoint/blob.py
@@ -298,9 +298,9 @@ def pack_dict(obj):
     return blob
 
 
-def unpack(blob):
+def unpack(blob, **kwargs):
     if blob is None:
         return None
 
-    return BlobReader(blob).unpack()
+    return BlobReader(blob, **kwargs).unpack()
 

--- a/datajoint/blob.py
+++ b/datajoint/blob.py
@@ -34,11 +34,6 @@ decode_lookup = {
     b'ZL123\0': zlib.decompress
 }
 
-def forward_squeeze_shape(shape):
-    for p in range(len(shape)):
-        if shape[p] != 1:
-            break
-    return shape[p:]
 
 class BlobReader:
     def __init__(self, blob, simplify=False, as_dict=False):

--- a/datajoint/blob.py
+++ b/datajoint/blob.py
@@ -228,7 +228,7 @@ def pack_obj(obj):
     elif isinstance(obj, str):
         blob += pack_array(np.array(obj, dtype=np.dtype('c')))
     elif isinstance(obj, Iterable):
-        blob += pack_array(np.array(obj))
+        blob += pack_array(np.array(list(obj)))
     elif isinstance(obj, int) or isinstance(obj, float):
         blob += pack_array(np.array(obj))
     else:

--- a/datajoint/blob.py
+++ b/datajoint/blob.py
@@ -101,7 +101,7 @@ class BlobReader:
         if dtype_id == 4:  # if dealing with character array
             data = self.read_value(dtype, count=2 * n_elem)
             data = data[::2].astype('U1')
-            if self._simplify and n_dims == 2 and shape[0] == 1 or n_dims == 1:
+            if n_dims == 2 and shape[0] == 1 or n_dims == 1:
                 compact = data.squeeze()
                 data = compact if compact.shape == () else np.array(''.join(data.squeeze()))
                 shape = (1,)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,13 @@ services:
   datajoint:
     build:
       context: .
-      dockerfile: JupyterDockerfile
+      dockerfile: DevDockerfile
     environment:
       - DJ_HOST=db
       - DJ_USER=root
       - DJ_PASS=simple
+    volumes:
+      - .:/src
     links:
       - db
     ports:

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -18,6 +18,9 @@ def test_pack():
     x = np.int16(np.random.randn(1, 2, 3))
     assert_array_equal(x, unpack(pack(x)), "Arrays do not match!")
 
+    x = {'name': 'Anonymous', 'age': 15}
+    assert(x == unpack(pack(x)), "Dict do not match!")
+
 
 def test_complex():
     z = np.random.randn(8, 10) + 1j*np.random.randn(8,10)

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -1,8 +1,7 @@
-
-
 import numpy as np
 from datajoint.blob import pack, unpack
 from numpy.testing import assert_array_equal, raises
+from nose.tools import assert_false, assert_true
 
 
 def test_pack():
@@ -19,7 +18,7 @@ def test_pack():
     assert_array_equal(x, unpack(pack(x)), "Arrays do not match!")
 
     x = {'name': 'Anonymous', 'age': 15}
-    assert(x == unpack(pack(x)), "Dict do not match!")
+    assert_true(x == unpack(pack(x), as_dict=True), "Dict do not match!")
 
 
 def test_complex():

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -1,7 +1,7 @@
 import numpy as np
 from datajoint.blob import pack, unpack
 from numpy.testing import assert_array_equal, raises
-from nose.tools import assert_false, assert_true
+from nose.tools import assert_equal, assert_true
 
 
 def test_pack():
@@ -19,6 +19,12 @@ def test_pack():
 
     x = {'name': 'Anonymous', 'age': 15}
     assert_true(x == unpack(pack(x), as_dict=True), "Dict do not match!")
+
+    x = [1, 2, 3, 4]
+    assert_array_equal(x, unpack(pack(x)), "List did not pack/unpack correctly")
+
+    x = [1, 2, 3, 4].__iter__()
+    assert_array_equal(x, unpack(pack(x)), "Iterator did not pack/unpack correctly")
 
 
 def test_complex():

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -23,8 +23,8 @@ def test_pack():
     x = [1, 2, 3, 4]
     assert_array_equal(x, unpack(pack(x)), "List did not pack/unpack correctly")
 
-    x = [1, 2, 3, 4].__iter__()
-    assert_array_equal(x, unpack(pack(x)), "Iterator did not pack/unpack correctly")
+    x = [1, 2, 3, 4]
+    assert_array_equal(x, unpack(pack(x.__iter__())), "Iterator did not pack/unpack correctly")
 
 
 def test_complex():


### PR DESCRIPTION
A dictionary with valid serializable field values (e.g. `np.ndarray` and scalars) can now be serialized and inserted into BLOB. This helps partly address issue #244 and in particular will allow us to solve the issue #243. 

When fetching back BLOB of structure array and if the structure array is a singleton, you can do the following to unpack as dict:

```python
dj.blob.unpack(blob, as_dict=True)
```

This is used to facilitate the testing procedure.