### PR TITLE
Fixed issue $#259. 

### DIFF
--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -16,8 +16,8 @@ import logging
 import os
 
 __author__ = "Dimitri Yatsenko, Edgar Walker, and Fabian Sinz at Baylor College of Medicine"
-__version__ = "0.4.0"
-__date__ = "Oct 6, 2016"
+__version__ = "0.4.1"
+__date__ = "Oct 28, 2016"
 __all__ = ['__author__', '__version__',
            'config', 'conn', 'kill', 'BaseRelation',
            'Connection', 'Heading', 'FreeRelation', 'Not', 'schema',

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -509,7 +509,7 @@ class Log(BaseRelation):
         self.database = database
         self._connection = arg
         self._definition = """    # event logging table for `{database}`
-        timestamp  : timestamp
+        timestamp = CURRENT_TIMESTAMP : timestamp
         ---
         version  :varchar(12)   # datajoint version
         user     :varchar(255)  # user@host

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -737,7 +737,7 @@ class U:
         """
 
         return (
-            GroupBy.create(self, group=group, keep_all_rows=False, attributes=(),named_attributes=named_attributes)
+            GroupBy.create(self, group=group, keep_all_rows=False, attributes=(), named_attributes=named_attributes)
             if self.primary_key else
             Projection.create(group, attributes=(), named_attributes=named_attributes, include_primary_key=False))
 


### PR DESCRIPTION
Failure to create ~log due to MySQL's rules of default values for timestamps.
Added =CURRENT_TIMESTAMP as the default for ~log's primary key.