### PR TITLE
Fix handling of long error messages in job table

### DIFF
--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -15,9 +15,9 @@ Please cite:
 import logging
 import os
 
-__author__ = "Dimitri Yatsenko, Edgar Walker, and Fabian Sinz at Baylor College of Medicine"
-__version__ = "0.4.1"
-__date__ = "Oct 28, 2016"
+__author__ = "Dimitri Yatsenko, Edgar Y. Walker, and Fabian Sinz at Baylor College of Medicine"
+__version__ = "0.4.2"
+__date__ = "Nov 27, 2016"
 __all__ = ['__author__', '__version__',
            'config', 'conn', 'kill', 'BaseRelation',
            'Connection', 'Heading', 'FreeRelation', 'Not', 'schema',

--- a/datajoint/jobs.py
+++ b/datajoint/jobs.py
@@ -39,13 +39,13 @@ class JobTable(BaseRelation):
         ---
         status  :enum('reserved','error','ignore')  # if tuple is missing, the job is available
         key=null  :blob  # structure containing the key
-        error_message=""  :varchar({error_messsage_length})  # error message returned if failed
+        error_message=""  :varchar({error_message_length})  # error message returned if failed
         error_stack=null  :blob  # error stack if failed
         user="" :varchar(255) # database user
         host=""  :varchar(255)  # system hostname
         pid=0  :int unsigned  # system process id
         timestamp=CURRENT_TIMESTAMP  :timestamp   # automatic timestamp
-        """.format(database=database, error_messsage_length=ERROR_MESSAGE_LENGTH)
+        """.format(database=database, error_message_length=ERROR_MESSAGE_LENGTH)
         if not self.is_declared:
             self.declare()
         self._user = self.connection.get_user()

--- a/datajoint/jobs.py
+++ b/datajoint/jobs.py
@@ -39,13 +39,13 @@ class JobTable(BaseRelation):
         ---
         status  :enum('reserved','error','ignore')  # if tuple is missing, the job is available
         key=null  :blob  # structure containing the key
-        error_message=""  :varchar({error_messsage_lenth})  # error message returned if failed
+        error_message=""  :varchar({error_messsage_length})  # error message returned if failed
         error_stack=null  :blob  # error stack if failed
         user="" :varchar(255) # database user
         host=""  :varchar(255)  # system hostname
         pid=0  :int unsigned  # system process id
         timestamp=CURRENT_TIMESTAMP  :timestamp   # automatic timestamp
-        """.format(database=database, error_messsage_lenth=ERROR_MESSAGE_LENGTH)
+        """.format(database=database, error_messsage_length=ERROR_MESSAGE_LENGTH)
         if not self.is_declared:
             self.declare()
         self._user = self.connection.get_user()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -53,7 +53,7 @@ def test_long_error_message():
     assert_true(subjects)
     table_name = 'fake_table'
 
-    key = subjects.fetch.keys()[0]
+    key = list(subjects.fetch.keys())[0]
 
     # test long error message
     schema.schema.jobs.reserve(table_name, key)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,11 +1,17 @@
 from nose.tools import assert_true, assert_false
 from . import schema
+from datajoint.jobs import ERROR_MESSAGE_LENGTH, TRUNCATION_APPENDIX
+import random
+import string
 
 
 subjects = schema.Subject()
 
 
 def test_reserve_job():
+    # clean jobs table
+    schema.schema.jobs.delete()
+
     assert_true(subjects)
     table_name = 'fake_table'
     # reserve jobs
@@ -33,6 +39,34 @@ def test_reserve_job():
         assert_false(schema.schema.jobs.reserve(table_name, key),
                      'failed to ignore error jobs')
     # clear error jobs
-    (schema.schema.jobs & dict(status="error")).delete_quick()
+    (schema.schema.jobs & dict(status="error")).delete()
     assert_false(schema.schema.jobs,
                  'failed to clear error jobs')
+
+def test_long_error_message():
+    # clear out jobs table
+    schema.schema.jobs.delete()
+
+    # create long error message
+    long_error_message = ''.join(random.choice(string.ascii_letters) for _ in range(ERROR_MESSAGE_LENGTH + 100))
+    short_error_message = ''.join(random.choice(string.ascii_letters) for _ in range(ERROR_MESSAGE_LENGTH // 2))
+    assert_true(subjects)
+    table_name = 'fake_table'
+
+    key = subjects.fetch.keys()[0]
+
+    # test long error message
+    schema.schema.jobs.reserve(table_name, key)
+    schema.schema.jobs.error(table_name, key, long_error_message)
+    error_message = schema.schema.jobs.fetch1['error_message']
+    assert_true(len(error_message) == ERROR_MESSAGE_LENGTH, 'error message is longer than max allowed')
+    assert_true(error_message.endswith(TRUNCATION_APPENDIX), 'appropriate ending missing for truncated error message')
+    schema.schema.jobs.delete()
+
+    # test long error message
+    schema.schema.jobs.reserve(table_name, key)
+    schema.schema.jobs.error(table_name, key, short_error_message)
+    error_message = schema.schema.jobs.fetch1['error_message']
+    assert_true(error_message == short_error_message, 'error messages do not agree')
+    assert_false(error_message.endswith(TRUNCATION_APPENDIX), 'error message should not be truncated')
+    schema.schema.jobs.delete()


### PR DESCRIPTION
Job table now defaults to accepting longer error message, and when error message is longer than max allowed length, it appropriately truncates the error message with `...truncated` appended to the end. Fix issue #265 