### PR TITLE
Report how many keys need to be populated

### DIFF
--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -16,8 +16,8 @@ import logging
 import os
 
 __author__ = "Dimitri Yatsenko, Edgar Y. Walker, and Fabian Sinz at Baylor College of Medicine"
-__version__ = "0.4.4"
-__date__ = "December 6, 2016"
+__version__ = "0.4.5"
+__date__ = "December 20, 2016"
 __all__ = ['__author__', '__version__',
            'config', 'conn', 'kill', 'BaseRelation',
            'Connection', 'Heading', 'FreeRelation', 'Not', 'schema',

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -81,6 +81,7 @@ class AutoPopulate:
 
         jobs = self.connection.jobs[self.target.database] if reserve_jobs else None
         todo -= self.target.proj()
+        n_to_populate = len(todo)
         keys = todo.fetch.keys()
         if order == "reverse":
             keys = list(keys)
@@ -89,6 +90,7 @@ class AutoPopulate:
             keys = list(keys)
             random.shuffle(keys)
 
+        logger.info('Found %d keys to populate' % n_to_populate)
         for key in keys:
             if not reserve_jobs or jobs.reserve(self.target.table_name, key):
                 self.connection.start_transaction()

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -81,7 +81,6 @@ class AutoPopulate:
 
         jobs = self.connection.jobs[self.target.database] if reserve_jobs else None
         todo -= self.target.proj()
-        n_to_populate = len(todo)
         keys = todo.fetch.keys()
         if order == "reverse":
             keys = list(keys)
@@ -90,7 +89,7 @@ class AutoPopulate:
             keys = list(keys)
             random.shuffle(keys)
 
-        logger.info('Found %d keys to populate' % n_to_populate)
+        logger.info('Found %d keys to populate' % len(todo))
         for key in keys:
             if not reserve_jobs or jobs.reserve(self.target.table_name, key):
                 self.connection.start_transaction()

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -81,15 +81,13 @@ class AutoPopulate:
 
         jobs = self.connection.jobs[self.target.database] if reserve_jobs else None
         todo -= self.target.proj()
-        keys = todo.fetch.keys()
+        keys = list(todo.fetch.keys())
         if order == "reverse":
-            keys = list(keys)
             keys.reverse()
         elif order == "random":
-            keys = list(keys)
             random.shuffle(keys)
 
-        logger.info('Found %d keys to populate' % len(todo))
+        logger.info('Found %d keys to populate' % len(keys))
         for key in keys:
             if not reserve_jobs or jobs.reserve(self.target.table_name, key):
                 self.connection.start_transaction()


### PR DESCRIPTION
Unlike in Matlab, `populate` does not report how many keys still have to be populated at the beginning of the `populate` invocation. This information is a useful quick indicator.