### PR TITLE
Proper handling of SIGINT and SIGTERM during populate

### DIFF
--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -16,8 +16,8 @@ import logging
 import os
 
 __author__ = "Dimitri Yatsenko, Edgar Y. Walker, and Fabian Sinz at Baylor College of Medicine"
-__version__ = "0.4.5"
-__date__ = "December 20, 2016"
+__version__ = "0.4.6"
+__date__ = "December 22, 2016"
 __all__ = ['__author__', '__version__',
            'config', 'conn', 'kill', 'BaseRelation',
            'Connection', 'Heading', 'FreeRelation', 'Not', 'schema',

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -6,7 +6,6 @@ from pymysql import OperationalError
 from .relational_operand import RelationalOperand, AndList
 from . import DataJointError
 from .base_relation import FreeRelation
-import sys
 import signal
 
 # noinspection PyExceptionInherit,PyCallingNonCallable

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -52,7 +52,7 @@ default = OrderedDict({
     'display.width': 14
 })
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 log_levels = {
     'INFO': logging.INFO,
     'WARNING': logging.WARNING,

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -5,6 +5,7 @@ Sample schema with realistic tables for testing
 import random
 import numpy as np
 import datajoint as dj
+import os, signal
 from . import PREFIX, CONN_INFO
 
 schema = dj.schema(PREFIX + '_test1', locals(), connection=dj.conn(**CONN_INFO))
@@ -204,3 +205,28 @@ class UnterTrash(dj.Manual):
     ---
     """
     contents = [(1, 1), (1, 2)]
+
+
+@schema
+class SimpleSource(dj.Lookup):
+    definition = """
+    id : int  # id
+    """
+    contents = ((x,) for x in range(10))
+
+@schema
+class SigIntTable(dj.Computed):
+    definition = """
+    -> SimpleSource
+    """
+    def _make_tuples(self, key):
+        os.kill(os.getpid(), signal.SIGINT)
+
+@schema
+class SigTermTable(dj.Computed):
+    definition = """
+    -> SimpleSource
+    """
+    def _make_tuples(self, key):
+        os.kill(os.getpid(), signal.SIGTERM)
+


### PR DESCRIPTION
* Fixed #276 : `SIGINT` (i.e. `KeyboardInterrupt`) during `populate` is now properly handled just like any standard exceptions during `populate`.
* Fixed #275 : If `SIGINT` (i.e. `CTRL-C`) or `SIGTERM` (closing terminal) signals are received during `populate` with `reserve_jobs=True`, the appropriate job entry status is updated to `error` to indicate that the `populate` process has been terminated
* Error messages entered into the job table now includes the name of the error. Previously exceptions without explicit error message (e.g. `KeyboardInterrupt`) did not produce any `error_message` entry in the job table.
* Added tests for handling of `SIGINT` and `SIGTERM` during the `populate(reserve_jobs=True)` call.