### PR TITLE
Fix Jobs table to handle multiple restrictions correctly

### DIFF
--- a/datajoint/jobs.py
+++ b/datajoint/jobs.py
@@ -22,15 +22,15 @@ class JobTable(BaseRelation):
     A base relation with no definition. Allows reserving jobs
     """
     def __init__(self, arg, database=None):
-        super().__init__()
         if isinstance(arg, JobTable):
+            super().__init__(arg)
             # copy constructor
             self.database = arg.database
             self._connection = arg._connection
             self._definition = arg._definition
             self._user = arg._user
             return
-
+        super().__init__()
         self.database = database
         self._connection = arg
         self._definition = """    # job reservation table for `{database}`

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -43,6 +43,22 @@ def test_reserve_job():
     assert_false(schema.schema.jobs,
                  'failed to clear error jobs')
 
+def test_restrictions():
+    # clear out jobs table
+    jobs = schema.schema.jobs
+    jobs.delete()
+    jobs.reserve('a', {'key': 'a1'})
+    jobs.reserve('a', {'key': 'a2'})
+    jobs.reserve('b', {'key': 'b1'})
+    jobs.error('a', {'key': 'a2'}, 'error')
+    jobs.error('b', {'key': 'b1'}, 'error')
+
+    assert_true(len(jobs & 'table_name = "a"') == 2, 'There should be two entries for table a')
+    assert_true(len(jobs & 'status = "error"') == 2, 'There should be two entries with error status')
+    assert_true(len(jobs & 'table_name = "a"' & 'status = "error"') == 1,
+                'There should be only one entries with error status in table a')
+    jobs.delete()
+
 
 def test_sigint():
     # clear out job table


### PR DESCRIPTION
`JobTable` was not properly utilizing the copy constructor of `RelationalOperand`, resulting in erroneous behavior as described in #290. Fixed the handling in `__init__` and added a test case. 

Fixes #290 