### PR TITLE
Treat empty string value in numeric field as a nan

### DIFF
--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -177,7 +177,7 @@ class BaseRelation(RelationalOperand):
                     value = pack(value)
                     placeholder = '%s'
                 elif heading[name].numeric:
-                    if value in [None, ''] or np.isnan(np.float(value)): # nans are turned into NULLs
+                    if value is None or value == '' or np.isnan(np.float(value)): # nans are turned into NULLs
                         placeholder = 'NULL'
                         value = None
                     else:

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -177,7 +177,7 @@ class BaseRelation(RelationalOperand):
                     value = pack(value)
                     placeholder = '%s'
                 elif heading[name].numeric:
-                    if value is None or np.isnan(np.float(value)):  # nans are turned into NULLs
+                    if value in [None, ''] or np.isnan(np.float(value)): # nans are turned into NULLs
                         placeholder = 'NULL'
                         value = None
                     else:


### PR DESCRIPTION
Otherwise, empty string values, such as those read from empty cells in a spreadsheet, have to be converted manually ahead of time to None or np.nan, which is a real pain.