### PR TITLE
add `create_virtual_module`

### DIFF
--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -81,7 +81,7 @@ from .admin import set_password, kill
 def create_virtual_module(modulename, dbname):
     """
     Creates a python module with the given name from a database name in mysql with datajoint tables.
-    Automatically creates the classed of the appropriate tier in the module.
+    Automatically creates the classes of the appropriate tier in the module.
 
     :param modulename: desired name of the module
     :param dbname:     name of the database in mysql

--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -14,6 +14,7 @@ Please cite:
 
 import logging
 import os
+from types import ModuleType
 from .version import __version__
 
 __author__ = "Dimitri Yatsenko, Edgar Y. Walker, and Fabian Sinz at Baylor College of Medicine"
@@ -75,3 +76,18 @@ from .heading import Heading
 from .schema import Schema as schema
 from .erd import ERD
 from .admin import set_password, kill
+
+
+def create_virtual_module(modulename, dbname):
+    """
+    Creates a python module with the given name from a database name in mysql with datajoint tables.
+    Automatically creates the classed of the appropriate tier in the module.
+
+    :param modulename: desired name of the module
+    :param dbname:     name of the database in mysql
+    :return: the python module
+    """
+    mod = ModuleType(modulename)
+    s = schema(dbname, mod.__dict__)
+    s.spawn_missing_classes()
+    return mod

--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -90,4 +90,5 @@ def create_virtual_module(modulename, dbname):
     mod = ModuleType(modulename)
     s = schema(dbname, mod.__dict__)
     s.spawn_missing_classes()
+    mod.__dict__['schema'] = s
     return mod

--- a/datajoint/utils.py
+++ b/datajoint/utils.py
@@ -1,7 +1,6 @@
 import re
 from datajoint import DataJointError
 
-
 class ClassProperty:
     def __init__(self, f):
         self.f = f


### PR DESCRIPTION
This allows the user to create modules with datajoint classes on the fly. This is particularly useful if one python package wants to use data from another one without the need to install all the dependencies. 