### PR TITLE
Support usage of special keywords in table definition

### DIFF
--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -11,6 +11,22 @@ from .base_relation import lookup_class_name, Log
 
 logger = logging.getLogger(__name__)
 
+def ordered_dir(klass):
+    """
+    List (most) attributes of the class including inherited ones, similar to `dir` build-in function,
+    but respects order of attribute declaration as much as possible.
+    :param klass: class to list members for
+    :return: a list of attributes declared in klass and its superclasses
+    """
+    m = []
+    mro = klass.mro()
+    for c in mro:
+        if hasattr(c, '_ordered_class_members'):
+            elements = c._ordered_class_members
+        else:
+            elements = c.__dict__.keys()
+        m = [e for e in elements if e not in m] + m
+    return m
 
 class Schema:
     """
@@ -159,7 +175,7 @@ class Schema:
         self.process_relation_class(cls, context=dict(self.context, **ext))
 
         # Process part relations
-        for part in dir(cls):
+        for part in ordered_dir(cls):
             if part[0].isupper():
                 part = getattr(cls, part)
                 if inspect.isclass(part) and issubclass(part, Part):

--- a/tests/test_schema_keywords.py
+++ b/tests/test_schema_keywords.py
@@ -1,0 +1,45 @@
+from . import PREFIX, CONN_INFO
+import datajoint as dj
+from nose.tools import assert_true
+
+
+schema = dj.schema(PREFIX + '_keywords', locals(), connection=dj.conn(**CONN_INFO))
+
+class A(dj.Manual):
+    definition = """
+    a_id: int   # a id
+    """
+
+class B(dj.Manual):
+    source = None
+    definition = """
+    -> self.source
+    b_id: int   # b id
+    """
+    class C(dj.Part):
+        definition = """
+        -> master
+        name: varchar(128)  # name
+        """
+
+class D(B):
+    source = A
+
+def setup():
+    nonlocal A
+    nonlocal D
+    A = schema(A)
+    D = schema(D)
+
+def teardown():
+    schema.drop(force=True)
+
+def test_inherited_part_table():
+    assert_true('a_id' in D().heading.attributes)
+    assert_true('b_id' in D().heading.attributes)
+    assert_true('a_id' in D.C().heading.attributes)
+    assert_true('b_id' in D.C().heading.attributes)
+    assert_true('name' in D.C().heading.attributes)
+
+
+

--- a/tests/test_schema_keywords.py
+++ b/tests/test_schema_keywords.py
@@ -17,11 +17,18 @@ class B(dj.Manual):
     -> self.source
     b_id: int   # b id
     """
-    class C(dj.Part):
+    class H(dj.Part):
         definition = """
         -> master
         name: varchar(128)  # name
         """
+
+    class C(dj.Part):
+        definition = """
+        -> master
+        -> master.H
+        """
+
 
 class D(B):
     source = A

--- a/tests/test_schema_keywords.py
+++ b/tests/test_schema_keywords.py
@@ -5,6 +5,7 @@ from nose.tools import assert_true
 
 schema = dj.schema(PREFIX + '_keywords', locals(), connection=dj.conn(**CONN_INFO))
 
+
 class A(dj.Manual):
     definition = """
     a_id: int   # a id
@@ -26,8 +27,8 @@ class D(B):
     source = A
 
 def setup():
-    nonlocal A
-    nonlocal D
+    global A
+    global D
     A = schema(A)
     D = schema(D)
 


### PR DESCRIPTION
Address issue #302 and #303 
* `Part` tables can now use keyword `master` to refer to the `Master` table, and thus need not know the explicit name of the `Master` table
* You can now easily add new `Part` tables by inheriting from a mix-in class that defines the `Part` table thanks to the indirection of the `Master` table name
    * to support this, `schema` decorator looks for all available members for the class (including the inherited ones) to search for `Part` table
* support keyword `self` to refer to the table class that is being decorated. This allows for the definition to use the class attributes pointing to another table (refer to issue #303 for more details)
* added `force` keyword argument to `schema.drop` to allow for dropping of tables without being prompted. This is a quicker alternative to setting `safe_mode` config to `False` which as a side effect also affects policy on `delete` on Tables.
* added a test that uses all of the above aspects