### PR TITLE
Fix hick up with `help()` and better user response handling

### DIFF
--- a/datajoint/user_relations.py
+++ b/datajoint/user_relations.py
@@ -61,6 +61,8 @@ class UserRelation(BaseRelation, metaclass=OrderedClass):
         """
         :returns: the table name of the table formatted for mysql.
         """
+        if cls._prefix is None:
+            raise AttributeError('Class prefix is not defined!')
         return cls._prefix + from_camel_case(cls.__name__)
 
     @ClassProperty

--- a/datajoint/utils.py
+++ b/datajoint/utils.py
@@ -22,7 +22,7 @@ def user_choice(prompt, choices=("yes", "no"), default=None):
     valid = False
     while not valid:
         response = input(prompt + ' [' + choice_list + ']: ')
-        response = response if response else default
+        response = response.lower() if response else default
         valid = response in choices
     return response
 


### PR DESCRIPTION
Fix issues #305 and #306 

* user prompts (e.g. when confirming `delete` or `drop`) now ignores the case of the response and thus can accept answers like `Yes`, `YES`, `No`, and `NO` in an expected fashion.
* calling `help` pydoc functionon `dj.UserRelation` subclasses no longer returns errors