### PR TITLE
introduce limit in populate, fix bug in fetch

### DIFF
--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -355,4 +355,4 @@ class Fetch1(FetchBase, Callable):
 
 def to_dicts(recarray):
     for rec in recarray:
-        yield dict(zip(recarray.dtype.names, rec))
+        yield dict(zip(recarray.dtype.names, rec.tolist()))


### PR DESCRIPTION
1. Sometimes it is useful to specify the maximal number of keys that should be populated. For instance, when running memory intensive jobs on a cluster so only one of two populations can run at a time, it would be nice to take turns. Setting `limit=1` allows one key to be populated instead of all keys to be exhausted before the other relation can be populated. 

2. Fixed the `to_dicts` function. Before, it returned numpy datatypes in the dictionary which was different from `rel.fetch.keys()` and could not be inserted back into a table. Now, the dictionaries have native python datatypes. 