### PR TITLE
fix for 'ignore_extra_fields'/insert select (datajoint-python#355)

### DIFF
--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -143,7 +143,7 @@ class BaseRelation(RelationalOperand):
 
         if isinstance(rows, RelationalOperand):
             # INSERT FROM SELECT - build alternate field-narrowing query (only) when needed
-            if ignore_extra_fields and False in [name in self.heading.names for name in rows.heading.names]:
+            if ignore_extra_fields and not all(name in self.heading.names for name in rows.heading.names):
                 query = 'INSERT{ignore} INTO {table} ({fields}) SELECT {fields} FROM ({select}) as `__alias`'.format(
                 ignore=" IGNORE" if ignore_errors or skip_duplicates else "",
                 table=self.full_table_name,

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -144,14 +144,10 @@ class BaseRelation(RelationalOperand):
         if isinstance(rows, RelationalOperand):
             # INSERT FROM SELECT - build alternate field-narrowing query (only) when needed
             if ignore_extra_fields and False in [name in self.heading.names for name in rows.heading.names]:
-                alias = '___' + self.table_name + '_IFS_' + rows.table_name
-                afields = [str('`'+alias+'`.`')+ x + '`' for x in self.heading.names]
-                query = 'INSERT{ignore} INTO {table} ({fields}) SELECT {afields} FROM ({select}) as `{alias}`'.format(
-                alias=alias,
+                query = 'INSERT{ignore} INTO {table} ({fields}) SELECT {fields} FROM ({select}) as `__alias`'.format(
                 ignore=" IGNORE" if ignore_errors or skip_duplicates else "",
                 table=self.full_table_name,
                 fields='`'+'`,`'.join(self.heading.names)+'`',
-                afields=','.join(afields),
                 select=rows.make_sql())
             else:
                 query = 'INSERT{ignore} INTO {table} ({fields}) {select}'.format(

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -28,7 +28,7 @@ class TestExtra(dj.Manual):
 
 
 @schema
-class TestNoExtra(dj.extra):
+class TestNoExtra(dj.Manual):
     ''' clone of Test but with no extra fields '''
     definition = Test.definition
 

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -22,6 +22,18 @@ class Test(dj.Lookup):
 
 
 @schema
+class TestExtra(dj.Manual):
+    ''' clone of Test but with an extra field '''
+    definition = Test.definition + "\nextra : int # extra int\n"
+
+
+@schema
+class TestNoExtra(dj.extra):
+    ''' clone of Test but with no extra fields '''
+    definition = Test.definition
+
+
+@schema
 class Auto(dj.Lookup):
     definition = """
     id  :int auto_increment

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -120,6 +120,13 @@ class TestRelation:
         self.test_no_extra.delete()
         self.test_no_extra.insert(self.test, ignore_extra_fields=True)
 
+    def test_insert_select_ignore_extra_fields3(self):
+        ''' make sure insert select works for from query result '''
+        self.test_no_extra.delete()
+        keystr = str(self.test_extra.fetch('key').max())
+        self.test_no_extra.insert((self.test_extra & '`key`=' + keystr),
+                                  ignore_extra_fields=True)
+
     def test_replace(self):
         """
         Test replacing or ignoring duplicate entries

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -104,7 +104,7 @@ class TestRelation:
     @raises(InternalError)
     def test_insert_select_ignore_extra_fields0(self):
         ''' need ignore extra fields for insert select '''
-        self.test_extra.insert1((self.test.fetch('key').max() + 1))
+        self.test_extra.insert1((self.test.fetch('key').max() + 1, 0, 0))
         self.test.insert(self.test_extra)
 
     def test_insert_select_ignore_extra_fields1(self):

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -3,7 +3,7 @@ import re
 
 import numpy as np
 from nose.tools import assert_equal, assert_not_equal, assert_true, assert_list_equal, raises
-from pymysql import IntegrityError, ProgrammingError
+from pymysql import IntegrityError, InternalError, ProgrammingError
 import datajoint as dj
 from datajoint import utils
 from datajoint.base_relation import BaseRelation
@@ -25,6 +25,9 @@ class TestRelation:
     """
 
     def __init__(self):
+        self.test = schema.Test()
+        self.test_extra = schema.TestExtra()
+        self.test_no_extra = schema.TestNoExtra()
         self.user = schema.User()
         self.subject = schema.Subject()
         self.experiment = schema.Experiment()
@@ -97,6 +100,25 @@ class TestRelation:
         self.subject.insert(self.subject.proj(
             'real_id', 'date_of_birth', 'subject_notes', subject_id='subject_id+1000', species='"human"'))
         assert_equal(len(self.subject), 2*original_length)
+
+    @raises(InternalError)
+    def test_insert_select_ignore_extra_fields0(self):
+        ''' need ignore extra fields for insert select '''
+        self.test_extra.insert1((self.test.fetch('key').max() + 1))
+        self.test.insert(self.test_extra)
+
+    def test_insert_select_ignore_extra_fields1(self):
+        ''' make sure extra fields works in insert select '''
+        self.test_extra.delete()
+        keyno = self.test.fetch('key').max() + 1
+        self.test_extra.insert1((keyno, 0, 0))
+        self.test.insert(self.test_extra, ignore_extra_fields=True)
+        assert(keyno in self.test.fetch('key'))
+
+    def test_insert_select_ignore_extra_fields2(self):
+        ''' make sure insert select still works when ignoring extra fields when there are none '''
+        self.test_no_extra.delete()
+        self.test_no_extra.insert(self.test, ignore_extra_fields=True)
 
     def test_replace(self):
         """


### PR DESCRIPTION
Discussed with @dimitri-yatsenko -

Rather than getting deep into the rest of the query building mechanism, short-circuit this case and build a custom query from the fields in the destination table.

Table alias required by query is of the form ___<rel1>_IFR_<rel2> in order to reduce the likelihood of namespace collisions.