### PR TITLE
Fix for specific MySQL exception discussed in #35[567].

### DIFF
--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -160,7 +160,7 @@ class BaseRelation(RelationalOperand):
             except pymysql.err.InternalError as err:
                 if err.args[0] == server_error_codes['unknown column']:
                     # args[1] -> Unknown column 'extra' in 'field list'
-                    raise DataJointError('%s : set ignore_extra_fields?' % err.args[1])
+                    raise DataJointError('%s : To ignore extra fields, set ignore_extra_fields=True in insert.' % err.args[1])
                 else:
                     raise
             return

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -155,7 +155,14 @@ class BaseRelation(RelationalOperand):
                 table=self.full_table_name,
                 fields='`'+'`,`'.join(rows.heading.names)+'`',
                 select=rows.make_sql())
-            self.connection.query(query)
+            try:
+                self.connection.query(query)
+            except pymysql.err.InternalError as err:
+                if err.args[0] == server_error_codes['unknown column']:
+                    # args[1] -> Unknown column 'extra' in 'field list'
+                    raise DataJointError('%s : set ignore_extra_fields?' % err.args[1])
+                else:
+                    raise
             return
 
         heading = self.heading

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -29,6 +29,7 @@ prefix_to_role = dict(zip(role_to_prefix.values(), role_to_prefix.keys()))
 
 
 server_error_codes = {
+    'unknown column': 1054,
     'command denied': 1142,
     'tables does not exist': 1146,
     'syntax error': 1149

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -101,7 +101,7 @@ class TestRelation:
             'real_id', 'date_of_birth', 'subject_notes', subject_id='subject_id+1000', species='"human"'))
         assert_equal(len(self.subject), 2*original_length)
 
-    @raises(InternalError)
+    @raises(dj.DataJointError)
     def test_insert_select_ignore_extra_fields0(self):
         ''' need ignore extra fields for insert select '''
         self.test_extra.insert1((self.test.fetch('key').max() + 1, 0, 0))


### PR DESCRIPTION
Recast the mysql InternalError to DataJointError in the specific case of extra columns given in insert-from-select queries.