### PR TITLE
Fix errors with overlapping part table name

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include requirements.txt
+include *.txt

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -204,7 +204,6 @@ class Schema:
                     # allow addressing master by name or keyword 'master'
                     ext = {
                         cls.__name__: cls,
-                        part.__name__: part,
                         'master': cls,
                         'self': part}
                     self.process_relation_class(part, context=dict(self.context, **ext))

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -80,14 +80,18 @@ def test_drop_database():
     schema.drop()  # should do nothing
 
 
-test_schema = dj.schema(PREFIX + '_overlapping_schema', locals(), connection=dj.conn(**CONN_INFO))
 
 def test_overlapping_name():
+    test_schema = dj.schema(PREFIX + '_overlapping_schema', locals(), connection=dj.conn(**CONN_INFO))
+
     @test_schema
     class Unit(dj.Manual):
         definition = """
         id:  int     # simple id
         """
+
+    # hack to update the locals dictionary
+    locals()
 
     @test_schema
     class Cell(dj.Manual):
@@ -100,9 +104,4 @@ def test_overlapping_name():
             -> master
             -> Unit
             """
-
-
-def teardown():
-    test_schema.drop()
-
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -89,23 +89,17 @@ def test_overlapping_name():
         id:  int     # simple id
         """
 
-    error_raised = False
-    try:
-        @test_schema
-        class Cell(dj.Manual):
+    @test_schema
+    class Cell(dj.Manual):
+        definition = """
+        type:  varchar(32)    # type of cell
+        """
+
+        class Unit(dj.Part):
             definition = """
-            type:  varchar(32)    # type of cell
+            -> master
+            -> Unit
             """
-
-            class Unit(dj.Part):
-                definition = """
-                -> master
-                -> Unit
-                """
-    except:
-        error_raised = True
-
-    assert_false(error_raised, 'The name of part table should not hide the same named non-part table outside')
     test_schema.drop()
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -105,3 +105,5 @@ def test_overlapping_name():
             -> Unit
             """
 
+    test_schema.drop()
+

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -80,9 +80,9 @@ def test_drop_database():
     schema.drop()  # should do nothing
 
 
-def test_overlapping_name():
-    test_schema = dj.schema(PREFIX + '_overlapping_schema', locals(), connection=dj.conn(**CONN_INFO))
+test_schema = dj.schema(PREFIX + '_overlapping_schema', locals(), connection=dj.conn(**CONN_INFO))
 
+def test_overlapping_name():
     @test_schema
     class Unit(dj.Manual):
         definition = """
@@ -100,6 +100,9 @@ def test_overlapping_name():
             -> master
             -> Unit
             """
+
+
+def teardown():
     test_schema.drop()
 
 


### PR DESCRIPTION
Fix #365. 

As a side note, in the process of testing I've encountered a bug case as reported in #368, which should be dealt with separately.