### PR TITLE
Fix #382 - deprecate `ignore_errors` and fix errorneous `skip_duplicates` behavior

### DIFF
--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -122,7 +122,7 @@ class BaseRelation(RelationalOperand):
         """
         self.insert((row,), **kwargs)
 
-    def insert(self, rows, replace=False, skip_duplicates=False, ignore_extra_fields=False):
+    def insert(self, rows, replace=False, skip_duplicates=False, ignore_extra_fields=False, ignore_errors=False):
         """
         Insert a collection of rows.
 
@@ -137,6 +137,10 @@ class BaseRelation(RelationalOperand):
         >>>     dict(subject_id=7, species="mouse", date_of_birth="2014-09-01"),
         >>>     dict(subject_id=8, species="mouse", date_of_birth="2014-09-02")])
         """
+
+        if ignore_errors:
+            warnings.warn('Use of `ignore_errors` in `insert` and `insert1` is deprecated. Use try...except... '
+                          'to explicitly handle any errors', stacklevel=2)
 
         # handle query safely - if skip_duplicates=True, wraps the query with transaction and checks for warning
         def safe_query(*args, **kwargs):

--- a/datajoint/jobs.py
+++ b/datajoint/jobs.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import pymysql
 from .base_relation import BaseRelation
+from . import DataJointError
 
 ERROR_MESSAGE_LENGTH = 2047
 TRUNCATION_APPENDIX = '...truncated'
@@ -86,7 +87,7 @@ class JobTable(BaseRelation):
             user=self._user)
         try:
             self.insert1(job, ignore_extra_fields=True)
-        except pymysql.err.IntegrityError:
+        except (pymysql.err.IntegrityError, DataJointError):
             return False
         return True
 

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -32,7 +32,8 @@ server_error_codes = {
     'unknown column': 1054,
     'command denied': 1142,
     'tables does not exist': 1146,
-    'syntax error': 1149
+    'syntax error': 1149,
+    'duplicate entry': 1062,
 }
 
 

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -180,6 +180,12 @@ class TestRelation:
             dtype=self.subject.heading.as_dtype)
         self.subject.insert(tmp, skip_duplicates=False)
 
+    @raises(InternalError)
+    def test_no_error_suppression(self):
+        """skip_duplicates=True should not suppress other errors"""
+        self.test.insert([dict(key=100)], skip_duplicates=True)
+
+
     def test_blob_insert(self):
         """Tests inserting and retrieving blobs."""
         X = np.random.randn(20, 10)

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -5,7 +5,7 @@ import numpy as np
 from nose.tools import assert_equal, assert_not_equal, assert_true, assert_list_equal, raises
 from pymysql import IntegrityError, InternalError, ProgrammingError
 import datajoint as dj
-from datajoint import utils
+from datajoint import utils, DataJointError
 from datajoint.base_relation import BaseRelation
 from unittest.mock import patch
 
@@ -170,7 +170,7 @@ class TestRelation:
             dtype=self.subject.heading.as_dtype)
         self.subject.insert(tmp, skip_duplicates=True)
 
-    @raises(IntegrityError)
+    @raises(DataJointError)
     def test_not_skip_duplicate(self):
         """Tests if duplicates are not skipped."""
         tmp = np.array([


### PR DESCRIPTION
Fix #382

* `ignore_errors` in `insert` is now deprecated - errors are no longer suppressed with this option and warnings are returned notifying users of this deprecation
* `skip_duplicates=True` no longer suppresses other errors
* Add simple test case to detect side effect due to `skip_duplicates=True`
* Known MySQL errors are re-represented as DataJoint errors with helpful error messages