### PR TITLE
pydot ERD patch 

### DIFF
--- a/datajoint/erd.py
+++ b/datajoint/erd.py
@@ -6,7 +6,7 @@ import warnings
 
 try:
     from matplotlib import pyplot as plt
-    from networkx.drawing.nx_agraph import graphviz_layout
+    from networkx.drawing.nx_pydot import pydot_layout
     erd_active = True
 except:
     erd_active = False
@@ -304,5 +304,4 @@ else:
 
         @staticmethod
         def _layout(graph, **kwargs):
-            return graphviz_layout(graph, prog='dot', **kwargs)
-
+            return pydot_layout(graph, prog='dot', **kwargs)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,3 @@
 matplotlib
-pygraphviz
+pydot
 moto

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,3 @@
 matplotlib
-pydot
+pydotplus
 moto


### PR DESCRIPTION
This uses pydot, which in turn uses an executable for layout rather than native graphviz c-api calls
and so avoids python/graphviz/pygraphviz build complications on Win64.

Should fix #353.

Limited testing appears OK (2 node 'Foo'->'Bar' plot, older version of RET1 schema).

Would probably be good to do more extensive testing to ensure plotting holds -
Of note - multi-schema plots & node renames have not yet been tested.  

Possible TODOs:
- dispatch to native on non-windows platforms instead of entirely switching?
- attempt to locate graphviz install in common places to simplify configuration?
   (have not looked into what mechanisms are available to set executable called yet)
