### PR TITLE
Maintain column order in preview(), despite blob columns

### DIFF
--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -407,7 +407,7 @@ class RelationalOperand:
         tuples = rel.fetch(limit=limit+1)
         has_more = len(tuples) > limit
         tuples = tuples[:limit]
-        columns = rel.heading.names
+        columns = self.heading.names
         widths = {f: min(max([len(f)] + [len(str(e)) for e in tuples[f]]) + 4, width) for f in columns}
         templates = {f: '%%-%d.%ds' % (widths[f], widths[f]) for f in columns}
         return (
@@ -500,7 +500,7 @@ class RelationalOperand:
             head='</th><th>'.join(
                 head_template.format(column=c, comment=rel.heading.attributes[c].comment,
                                      primary='primary' if c in self.primary_key else 'nonprimary') for c in
-                rel.heading.names),
+                self.heading.names),
             ellipsis='<p>...</p>' if has_more else '',
             body='</tr><tr>'.join(
                 ['\n'.join(['<td>%s</td>' % column for column in tup])

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -498,7 +498,7 @@ class RelationalOperand:
             css=css,
             title="" if info is None else "<b>%s</b>" % info['comment'],
             head='</th><th>'.join(
-                head_template.format(column=c, comment=rel.heading.attributes[c].comment,
+                head_template.format(column=c, comment=self.heading.attributes[c].comment,
                                      primary='primary' if c in self.primary_key else 'nonprimary') for c in
                 self.heading.names),
             ellipsis='<p>...</p>' if has_more else '',


### PR DESCRIPTION
I noticed that the preview for some tables does not always maintain the same column order as in the table definition. This only seems to happen for tables with blob columns. It looks like blobs are being inadvertently pushed to the end of the table preview. This simple PR fixes that. I've only tested `preview()`, not `_repr_html_()`. I'm not sure if the `rel.heading.attributes[c].comment` line in `_repr_html_()` should also be changed to `self.heading.attributes[c].comment`.