### PR TITLE
refactor the parsing of foreign keys

### DIFF
--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -29,9 +29,9 @@ class AutoPopulate:
     def key_source(self):
         """
         :return: the relation whose primary key values are passed, sequentially, to the
-                ``make`` method when populate() is called.The default value is the
-                join of the parent relations. Users may override to change the granularity
-                or the scope of populate() calls.
+                ``make`` method when populate() is called.
+                The default value is the join of the parent relations.
+                Users may override to change the granularity or the scope of populate() calls.
         """
         if self._key_source is None:
             self.connection.dependencies.load(self.full_table_name)
@@ -43,7 +43,6 @@ class AutoPopulate:
                 self._key_source *= FreeRelation(self.connection, parents.pop(0)).proj()
         return self._key_source
 
-
     def make(self, key):
         """
         Derived classes must implement method `make` that fetches data from tables that are
@@ -51,7 +50,6 @@ class AutoPopulate:
         attributes, and inserts the new tuples into self.
         """
         raise NotImplementedError('Subclasses of AutoPopulate must implement the method `make`')
-
 
     @property
     def target(self):

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -78,26 +78,53 @@ def compile_foreign_key(line, context, attributes, primary_key, attr_sql, foreig
     if not all(r in ref.primary_key for r in result.ref_attrs):
         raise DataJointError('Invalid foreign key attributes in "%s"' % line)
 
-    # match new attributes and referenced attributes and create foreign keys
-    missing_attrs = [attr for attr in ref.primary_key if attr not in attributes] or (
-        ref.primary_key if len(result.new_attrs) == len(ref.primary_key) == 1 else [])
-    new_attrs = result.new_attrs or missing_attrs
-    ref_attrs = result.ref_attrs or missing_attrs
+    try:
+        raise DataJointError('Duplicate attributes "{attr}" in "{line}"'.format(
+            attr=next(attr for attr in result.new_attrs if attr in attributes),
+            line=line))
+    except StopIteration:
+        pass   # the normal outcome
+
+    new_attrs = list(result.new_attrs) or []
+    ref_attrs = list(result.ref_attrs) or []
+
+    if new_attrs and not ref_attrs:
+        # special case, the renamed attribute is implicit
+        if len(new_attrs) != 1:
+            raise DataJointError('Renamed foreign key must be mapped to the primary key in "%s"' % line)
+        if len(ref.primary_key) == 1:
+            # if the primary key has one attribute, allow implicit renaming
+            ref_attrs = ref.primary_key
+        else:
+            # if only one primary key attribute is not yet used, then allow implicit renaming
+            ref_attrs = [attr for attr in ref.primary_key if attr not in attributes]
+            if len(ref_attrs) != 1:
+                raise DataJointError('Could not resovle which primary key attribute should be referenced in "%s"' % line)
+
     if len(new_attrs) != len(ref_attrs):
         raise DataJointError('Mismatched attributes in foreign key "%s"' % line)
 
-    # declare foreign key attributes and foreign keys
-    lookup = dict(zip(ref_attrs, new_attrs))
-    for attr in missing_attrs:
-        new_attr = lookup.get(attr, attr)
+    # expand the primary key of the referenced table
+    lookup = dict(zip(ref_attrs, new_attrs)).get  # from foreign to local
+    ref_attrs = [attr for attr in ref.primary_key if lookup(attr, attr) not in attributes]
+    new_attrs = [lookup(attr, attr) for attr in ref_attrs]
+
+    # sanity check
+    assert len(new_attrs) == len(ref_attrs) and not any(attr in attributes for attr in new_attrs)
+
+    # declare foreign key attributes and foreign key
+    for ref_attr in ref_attrs:
+        new_attr = lookup(ref_attr, ref_attr)
         attributes.append(new_attr)
         if primary_key is not None:
             primary_key.append(new_attr)
-        attr_sql.append(ref.heading[attr].sql.replace(attr, new_attr, 1))
-    fk = [lookup.get(attr, attr) for attr in ref.primary_key]
+        attr_sql.append(ref.heading[ref_attr].sql.replace(ref_attr, new_attr, 1))
+
     foreign_key_sql.append(
         'FOREIGN KEY (`{fk}`) REFERENCES {ref} (`{pk}`) ON UPDATE CASCADE ON DELETE RESTRICT'.format(
-            fk='`,`'.join(fk), pk='`,`'.join(ref.primary_key), ref=ref.full_table_name))
+            fk='`,`'.join(lookup(attr, attr) for attr in ref.primary_key),
+            pk='`,`'.join(ref.primary_key),
+            ref=ref.full_table_name))
 
 
 def declare(full_table_name, definition, context):

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -85,8 +85,8 @@ def compile_foreign_key(line, context, attributes, primary_key, attr_sql, foreig
     except StopIteration:
         pass   # the normal outcome
 
-    new_attrs = list(result.new_attrs) or []
-    ref_attrs = list(result.ref_attrs) or []
+    new_attrs = list(result.new_attrs)
+    ref_attrs = list(result.ref_attrs)
 
     if new_attrs and not ref_attrs:
         # special case, the renamed attribute is implicit

--- a/datajoint/erd.py
+++ b/datajoint/erd.py
@@ -208,7 +208,7 @@ else:
             graph = nx.DiGraph(self).subgraph(nodes)
             nx.set_node_attributes(graph, 'node_type', {n: _get_tier(n) for n in graph})
             # relabel nodes to class names
-            clean_context = dict((k, v) for k, v in self.context.items() if not k.beginswith('_'))  # exclude ipython's implicit variables
+            clean_context = dict((k, v) for k, v in self.context.items() if not k.startswith('_'))  # exclude ipython's implicit variables
             mapping = {node: (lookup_class_name(node, clean_context) or node)
                        for node in graph.nodes()}
             new_names = [mapping.values()]

--- a/datajoint/erd.py
+++ b/datajoint/erd.py
@@ -208,8 +208,7 @@ else:
             graph = nx.DiGraph(self).subgraph(nodes)
             nx.set_node_attributes(graph, 'node_type', {n: _get_tier(n) for n in graph})
             # relabel nodes to class names
-            clean_context = dict((k, self.context[k]) for k in self.context
-                                 if '_' not in k)  # hack for ipython '_' var
+            clean_context = dict((k, v) for k, v in self.context.items() if not k.beginswith('_'))  # exclude ipython's implicit variables
             mapping = {node: (lookup_class_name(node, clean_context) or node)
                        for node in graph.nodes()}
             new_names = [mapping.values()]

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -25,8 +25,8 @@ def ordered_dir(klass):
     attr_list = list()
     for c in reversed(klass.mro()):
         attr_list.extend(e for e in (
-            c._ordered_class_members if hasattr(c, '_ordered_class_members') else
-            c.__dict__) if e not in attr_list)
+            c._ordered_class_members if hasattr(c, '_ordered_class_members') else c.__dict__)
+            if e not in attr_list)
     return attr_list
 
 

--- a/tests/schema_advanced.py
+++ b/tests/schema_advanced.py
@@ -91,6 +91,14 @@ class Cell(dj.Manual):
 
 
 @schema
+class InputCell(dj.Manual):
+    definition = """  # a synapse within the slice
+    -> Cell
+    (input)-> Cell(cell)
+    """
+
+
+@schema
 class LocalSynapse(dj.Manual):
     definition = """  # a synapse within the slice
     (presynaptic) -> Cell(cell)


### PR DESCRIPTION
Improved messages, fixed a bug that arose in the handling of the following declaration, for example:

```python
@schema
class InputCell(dj.Manual):
    definition = """
    -> Cell
    (input)-> Cell(cell)
    """
```
This used to throw an error 