### PR TITLE
erd.py: fix for #393 

### DIFF
--- a/datajoint/erd.py
+++ b/datajoint/erd.py
@@ -208,7 +208,11 @@ else:
             graph = nx.DiGraph(self).subgraph(nodes)
             nx.set_node_attributes(graph, 'node_type', {n: _get_tier(n) for n in graph})
             # relabel nodes to class names
-            mapping = {node: (lookup_class_name(node, self.context) or node) for node in graph.nodes()}
+            mapping = {node: (node) for node in graph.nodes()}
+            clean_context = dict((k, self.context[k]) for k in self.context
+                                 if '_' not in k)  # hack for ipython '_' var
+            mapping = {node: (lookup_class_name(node, clean_context) or node)
+                       for node in graph.nodes()}
             new_names = [mapping.values()]
             if len(new_names) > len(set(new_names)):
                 raise DataJointError('Some classes have identical names. The ERD cannot be plotted.')

--- a/datajoint/erd.py
+++ b/datajoint/erd.py
@@ -208,7 +208,6 @@ else:
             graph = nx.DiGraph(self).subgraph(nodes)
             nx.set_node_attributes(graph, 'node_type', {n: _get_tier(n) for n in graph})
             # relabel nodes to class names
-            mapping = {node: (node) for node in graph.nodes()}
             clean_context = dict((k, self.context[k]) for k in self.context
                                  if '_' not in k)  # hack for ipython '_' var
             mapping = {node: (lookup_class_name(node, clean_context) or node)


### PR DESCRIPTION
handled in erd vs base_relation.lookup_class_name.

fixes #393 

other option would be to modify 'lookup_class_name'; this seems less intrusive
and localized to the problem - other uses of lookup_class_name do not need/use
'module' component and skipping search in '_' there could potentially cause
undefined behavior in some corner cases.