### PR TITLE
Load dependencies from information_schema

### DIFF
--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -34,7 +34,8 @@ class AutoPopulate:
                 Users may override to change the granularity or the scope of populate() calls.
         """
         if self._key_source is None:
-            self.connection.dependencies.load()
+            if self.target.full_table_name not in self.connection.dependencies:
+                self.connection.dependencies.load()
             parents = list(self.target.parents(primary=True))
             if not parents:
                 raise DataJointError('A relation must have parent relations to be able to be populated')

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -34,7 +34,7 @@ class AutoPopulate:
                 Users may override to change the granularity or the scope of populate() calls.
         """
         if self._key_source is None:
-            self.connection.dependencies.load(self.full_table_name)
+            self.connection.dependencies.load()
             parents = list(self.target.parents(primary=True))
             if not parents:
                 raise DataJointError('A relation must have parent relations to be able to be populated')

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -423,7 +423,8 @@ class BaseRelation(RelationalOperand):
         :return:  the definition string for the relation using DataJoint DDL.
             This does not yet work for aliased foreign keys.
         """
-        self.connection.dependencies.load()
+        if self.full_table_name not in self.connection.dependencies:
+            self.connection.dependencies.load()
         parents = self.parents()
         in_key = True
         definition = '# ' + self.heading.table_info['comment'] + '\n'

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -315,8 +315,7 @@ class BaseRelation(RelationalOperand):
                 parent, edge = next(iter(graph.parents(table).items()))
                 delete_list[table] = FreeRelation(self.connection, parent).proj(
                     **{new_name: old_name
-                       for new_name, old_name in zip(edge['referencing_attributes'], edge['referenced_attributes'])
-                       if new_name != old_name})
+                       for new_name, old_name in edge['attr_map'].items() if new_name != old_name})
 
         # construct restrictions for each relation
         restrict_by_me = set()
@@ -437,9 +436,9 @@ class BaseRelation(RelationalOperand):
             attributes_thus_far.add(attr.name)
             do_include = True
             for parent_name, fk_props in list(parents.items()):  # need list() to force a copy
-                if attr.name in fk_props['referencing_attributes']:
+                if attr.name in fk_props['attr_map']:
                     do_include = False
-                    if attributes_thus_far.issuperset(fk_props['referencing_attributes']):
+                    if attributes_thus_far.issuperset(fk_props['attr_map']):
                         # simple foreign key
                         parents.pop(parent_name)
                         if not parent_name.isdigit():
@@ -448,15 +447,13 @@ class BaseRelation(RelationalOperand):
                         else:
                             # aliased foreign key
                             parent_name = self.connection.dependencies.in_edges(parent_name)[0][0]
-                            lst = [(attr, ref) for attr, ref in zip(
-                                fk_props['referencing_attributes'], fk_props['referenced_attributes'])
-                                   if ref != attr]
+                            lst = [(attr, ref) for attr, ref in fk_props['attr_map'].items() if ref != attr]
                             definition += '({attr_list}) -> {class_name}{ref_list}\n'.format(
                                 attr_list=','.join(r[0] for r in lst),
                                 class_name=lookup_class_name(parent_name, self.context) or parent_name,
                                 ref_list=('' if len(attributes_thus_far) - len(attributes_declared) == 1
                                           else '(%s)' % ','.join(r[1] for r in lst)))
-                            attributes_declared.update(fk_props['referencing_attributes'])
+                            attributes_declared.update(fk_props['attr_map'])
             if do_include:
                 attributes_declared.add(attr.name)
                 name = attr.name.lstrip('_')  # for external

--- a/datajoint/dependencies.py
+++ b/datajoint/dependencies.py
@@ -47,7 +47,7 @@ class Dependencies(nx.DiGraph):
         """.format(schemas="','".join(self._conn.schemas)), as_dict=True)
         fks = defaultdict(lambda: dict(attr_map=dict()))
         for key in keys:
-            d = fks[key['constraint_name']]
+            d = fks[key['constraint_name'] + key['referencing_table'] + key['referenced_table']]
             d['referencing_table'] = key['referencing_table']
             d['referenced_table'] = key['referenced_table']
             d['attr_map'][key['column_name']] = key['referenced_column_name']

--- a/datajoint/dependencies.py
+++ b/datajoint/dependencies.py
@@ -10,11 +10,10 @@ class Dependencies(nx.DiGraph):
     """
     def __init__(self, connection):
         self._conn = connection
-        self.loaded_tables = set()
         self._node_alias_count = itertools.count()
         super().__init__(self)
 
-    def load(self, target=None):
+    def load(self):
         """
         Load dependencies for all loaded schemas.
         This method gets called before any operation that requires dependencies: delete, drop, populate, progress.

--- a/datajoint/dependencies.py
+++ b/datajoint/dependencies.py
@@ -22,10 +22,10 @@ class Dependencies(nx.DiGraph):
 
         # load primary keys
         keys = self._conn.query("""
-                SELECT 
+                SELECT
                     concat('`', table_schema, '`.`', table_name, '`') as tab, column_name
-                FROM information_schema.key_column_usage 
-                WHERE referenced_table_name IS NULL AND table_schema in ('{schemas}') AND constraint_name="PRIMARY" 
+                FROM information_schema.key_column_usage
+                WHERE table_name not LIKE "~%%" AND table_schema in ('{schemas}') AND constraint_name="PRIMARY"
                 """.format(schemas="','".join(self._conn.schemas)))
         pks = defaultdict(set)
         for key in keys:
@@ -37,13 +37,13 @@ class Dependencies(nx.DiGraph):
 
         # load foreign keys
         keys = self._conn.query("""
-        SELECT constraint_name,  
+        SELECT constraint_name,
             concat('`', table_schema, '`.`', table_name, '`') as referencing_table,
-            concat('`', referenced_table_schema, '`.`',  referenced_table_name, '`') as referenced_table, 
+            concat('`', referenced_table_schema, '`.`',  referenced_table_name, '`') as referenced_table,
             column_name, referenced_column_name
-        FROM information_schema.key_column_usage 
-        WHERE referenced_table_name NOT LIKE "~%%" AND (referenced_table_schema in ('{schemas}') OR 
-            referenced_table_schema is not NULL AND table_schema in ('{schemas}')) 
+        FROM information_schema.key_column_usage
+        WHERE referenced_table_name NOT LIKE "~%%" AND (referenced_table_schema in ('{schemas}') OR
+            referenced_table_schema is not NULL AND table_schema in ('{schemas}'))
         """.format(schemas="','".join(self._conn.schemas)), as_dict=True)
         fks = defaultdict(lambda: dict(attr_map=dict()))
         for key in keys:

--- a/datajoint/dependencies.py
+++ b/datajoint/dependencies.py
@@ -1,6 +1,6 @@
-import pyparsing as pp
 import networkx as nx
 import itertools
+from collections import defaultdict
 from . import DataJointError
 
 
@@ -8,84 +8,67 @@ class Dependencies(nx.DiGraph):
     """
     The graph of dependencies (foreign keys) between loaded tables.
     """
-    __primary_key_parser = (pp.CaselessLiteral('PRIMARY KEY') +
-                            pp.QuotedString('(', endQuoteChar=')').setResultsName('primary_key'))
-
     def __init__(self, connection):
         self._conn = connection
         self.loaded_tables = set()
         self._node_alias_count = itertools.count()
         super().__init__(self)
 
-    @staticmethod
-    def __foreign_key_parser(database):
-        def paste_database(unused1, unused2, toc):
-            return ['`{database}`.`{table}`'.format(database=database, table=toc[0])]
-
-        return (pp.CaselessLiteral('CONSTRAINT').suppress() +
-                pp.QuotedString('`').suppress() +
-                pp.CaselessLiteral('FOREIGN KEY').suppress() +
-                pp.QuotedString('(', endQuoteChar=')').setResultsName('attributes') +
-                pp.CaselessLiteral('REFERENCES') +
-                pp.Or([
-                    pp.QuotedString('`').setParseAction(paste_database),
-                    pp.Combine(pp.QuotedString('`', unquoteResults=False) + '.' +
-                               pp.QuotedString('`', unquoteResults=False))]).setResultsName('referenced_table') +
-                pp.QuotedString('(', endQuoteChar=')').setResultsName('referenced_attributes'))
-
-    def add_table(self, table_name):
-        """
-        Adds table to the dependency graph
-        :param table_name: in format `schema`.`table`
-        """
-        if table_name in self.loaded_tables:
-            return
-        fk_parser = self.__foreign_key_parser(table_name.split('.')[0].strip('`'))
-        self.loaded_tables.add(table_name)
-        self.add_node(table_name)
-        create_statement = self._conn.query('SHOW CREATE TABLE %s' % table_name).fetchone()[1].split('\n')
-        primary_key = None
-        for line in create_statement:
-            if primary_key is None:
-                try:
-                    result = self.__primary_key_parser.parseString(line)
-                except pp.ParseException:
-                    pass
-                else:
-                    primary_key = [s.strip(' `') for s in result.primary_key.split(',')]
-            try:
-                result = fk_parser.parseString(line)
-            except pp.ParseException:
-                pass
-            else:
-                if '`.`~' not in result.referenced_table:  # omit external tables
-                    referencing_attributes = [r.strip('` ') for r in result.attributes.split(',')]
-                    referenced_attributes = [r.strip('` ') for r in result.referenced_attributes.split(',')]
-                    props = dict(
-                        primary=all(a in primary_key for a in referencing_attributes),
-                        referencing_attributes=referencing_attributes,
-                        referenced_attributes=referenced_attributes,
-                        aliased=not all(a == b for a, b in zip(referencing_attributes, referenced_attributes)),
-                        multi=not all(a in referencing_attributes for a in primary_key))
-                    if not props['aliased']:
-                        self.add_edge(result.referenced_table, table_name, **props)
-                    else:
-                        # for aliased dependencies, add an extra node in the format '1', '2', etc
-                        alias_node = '%d' % next(self._node_alias_count)
-                        self.add_node(alias_node)
-                        self.add_edge(result.referenced_table, alias_node, **props)
-                        self.add_edge(alias_node, table_name, **props)
-
-    def load(self):
+    def load(self, target=None):
         """
         Load dependencies for all loaded schemas.
         This method gets called before any operation that requires dependencies: delete, drop, populate, progress.
         """
-        for database in self._conn.schemas:
-            for row in self._conn.query('SHOW TABLES FROM `{database}`'.format(database=database)):
-                table = row[0]
-                if not table.startswith('~'):  # exclude service tables
-                    self.add_table('`{db}`.`{tab}`'.format(db=database, tab=table))
+        self.clear()  # reload from scratch and prevent duplication
+
+        # load primary keys
+        keys = self._conn.query("""
+                SELECT 
+                    concat('`', table_schema, '`.`', table_name, '`') as tab, column_name
+                FROM information_schema.key_column_usage 
+                WHERE referenced_table_name IS NULL AND table_schema in ('{schemas}') AND constraint_name="PRIMARY" 
+                """.format(schemas="','".join(self._conn.schemas)))
+        pks = defaultdict(set)
+        for key in keys:
+            pks[key[0]].add(key[1])
+
+        # add nodes to the graph
+        for n, pk in pks.items():
+            self.add_node(n, primary_key=pk)
+
+        # load foreign keys
+        keys = self._conn.query("""
+        SELECT constraint_name,  
+            concat('`', table_schema, '`.`', table_name, '`') as referencing_table,
+            concat('`', referenced_table_schema, '`.`',  referenced_table_name, '`') as referenced_table, 
+            column_name, referenced_column_name
+        FROM information_schema.key_column_usage 
+        WHERE referenced_table_name NOT LIKE "~%%" AND (referenced_table_schema in ('{schemas}') OR 
+            referenced_table_schema is not NULL AND table_schema in ('{schemas}')) 
+        """.format(schemas="','".join(self._conn.schemas)), as_dict=True)
+        fks = defaultdict(lambda: dict(attr_map=dict()))
+        for key in keys:
+            d = fks[key['constraint_name']]
+            d['referencing_table'] = key['referencing_table']
+            d['referenced_table'] = key['referenced_table']
+            d['attr_map'][key['column_name']] = key['referenced_column_name']
+
+        # add edges to the graph
+        for fk in fks.values():
+            props = dict(
+                primary=all(attr in pks[fk['referencing_table']] for attr in fk['attr_map']),
+                attr_map=fk['attr_map'],
+                aliased=any(k != v for k, v in fk['attr_map'].items()),
+                multi=not all(a in fk['attr_map'] for a in pks[fk['referencing_table']]))
+            if not props['aliased']:
+                self.add_edge(fk['referenced_table'], fk['referencing_table'], **props)
+            else:
+                # for aliased dependencies, add an extra node in the format '1', '2', etc
+                alias_node = '%d' % next(self._node_alias_count)
+                self.add_node(alias_node)
+                self.add_edge(fk['referenced_table'], alias_node, **props)
+                self.add_edge(alias_node, fk['referencing_table'], **props)
+
         if not nx.is_directed_acyclic_graph(self):  # pragma: no cover
             raise DataJointError('DataJoint can only work with acyclic dependencies')
 

--- a/datajoint/dependencies.py
+++ b/datajoint/dependencies.py
@@ -47,7 +47,7 @@ class Dependencies(nx.DiGraph):
         """.format(schemas="','".join(self._conn.schemas)), as_dict=True)
         fks = defaultdict(lambda: dict(attr_map=dict()))
         for key in keys:
-            d = fks[key['constraint_name'] + key['referencing_table'] + key['referenced_table']]
+            d = fks[(key['constraint_name'], key['referencing_table'], key['referenced_table'])]
             d['referencing_table'] = key['referencing_table']
             d['referenced_table'] = key['referenced_table']
             d['attr_map'][key['column_name']] = key['referenced_column_name']

--- a/datajoint/erd.py
+++ b/datajoint/erd.py
@@ -208,7 +208,7 @@ else:
             graph = nx.DiGraph(self).subgraph(nodes)
             nx.set_node_attributes(graph, 'node_type', {n: _get_tier(n) for n in graph})
             # relabel nodes to class names
-            clean_context = dict((k, v) for k, v in self.context.items() if not k.beginswith('_'))  # exclude ipython's implicit variables
+            clean_context = dict((k, v) for k, v in self.context.items() if not k.startswith('_'))  # exclude ipython's implicit variables
             mapping = {node: (lookup_class_name(node, clean_context) or node)
                        for node in graph.nodes()}
             new_names = [mapping.values()]

--- a/tests/test_foreign_keys.py
+++ b/tests/test_foreign_keys.py
@@ -17,7 +17,7 @@ def test_aliased_fk():
     assert_true(person)
     assert_true(parent)
     link = person.proj(parent_name='full_name', parent='person_id')
-    parents = person*parent*link
+    parents = person * parent * link
     parents &= dict(full_name="May K. Hall")
     assert_equal(set(parents.fetch('parent_name')), {'Hanna R. Walters', 'Russel S. James'})
     person.delete()


### PR DESCRIPTION
Several years ago, we decided not to query the information schema because it caused some server crashes.  To load dependencies, we parsed the `SHOW CREATE TABLE` statements for each table to extract the foreign keys.  This had many limitations such as the inability to see downstream dependencies for example.  We now believe that those problems have been addressed.  This pull request replaces the loading of dependencies. 