### PR TITLE
Revamp of restriction

### DIFF
--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -69,7 +69,7 @@ from .connection import conn, Connection
 from .s3 import bucket, Bucket
 from .base_relation import FreeRelation, BaseRelation
 from .user_relations import Manual, Lookup, Imported, Computed, Part
-from .relational_operand import Not, AndList, OrList, U
+from .relational_operand import Not, AndList, U
 from .heading import Heading
 from .schema import Schema as schema
 from .erd import ERD

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -9,7 +9,7 @@ import warnings
 from pymysql import OperationalError, InternalError, IntegrityError
 from . import config, DataJointError
 from .declare import declare
-from .relational_operand import RelationalOperand, OrList
+from .relational_operand import RelationalOperand
 from .blob import pack
 from .utils import user_choice
 from .heading import Heading
@@ -319,11 +319,11 @@ class BaseRelation(RelationalOperand):
 
         # construct restrictions for each relation
         restrict_by_me = set()
-        restrictions = collections.defaultdict(OrList)
+        restrictions = collections.defaultdict(list)
         # restrict by self
-        if self.restrictions:
+        if self.restriction:
             restrict_by_me.add(self.full_table_name)
-            restrictions[self.full_table_name].append(self.restrictions)  # copy own restrictions
+            restrictions[self.full_table_name].append(self.restriction)  # copy own restrictions
         # restrict by renamed nodes
         restrict_by_me.update(table for table in delete_list if table.isdigit())  # restrict by all renamed nodes
         # restrict by tables restricted by a non-primary semijoin

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -315,8 +315,7 @@ class BaseRelation(RelationalOperand):
                 parent, edge = next(iter(graph.parents(table).items()))
                 delete_list[table] = FreeRelation(self.connection, parent).proj(
                     **{new_name: old_name
-                       for new_name, old_name in zip(edge['referencing_attributes'], edge['referenced_attributes'])
-                       if new_name != old_name})
+                       for new_name, old_name in edge['attr_map'].items() if new_name != old_name})
 
         # construct restrictions for each relation
         restrict_by_me = set()
@@ -437,9 +436,9 @@ class BaseRelation(RelationalOperand):
             attributes_thus_far.add(attr.name)
             do_include = True
             for parent_name, fk_props in list(parents.items()):  # need list() to force a copy
-                if attr.name in fk_props['referencing_attributes']:
+                if attr.name in fk_props['attr_map']:
                     do_include = False
-                    if attributes_thus_far.issuperset(fk_props['referencing_attributes']):
+                    if attributes_thus_far.issuperset(fk_props['attr_map']):
                         # simple foreign key
                         parents.pop(parent_name)
                         if not parent_name.isdigit():
@@ -448,15 +447,13 @@ class BaseRelation(RelationalOperand):
                         else:
                             # aliased foreign key
                             parent_name = self.connection.dependencies.in_edges(parent_name)[0][0]
-                            lst = [(attr, ref) for attr, ref in zip(
-                                fk_props['referencing_attributes'], fk_props['referenced_attributes'])
-                                   if ref != attr]
+                            lst = [(attr, ref) for attr, ref in fk_props['attr_map'].items() if ref != attr]
                             definition += '({attr_list}) -> {class_name}{ref_list}\n'.format(
                                 attr_list=','.join(r[0] for r in lst),
                                 class_name=lookup_class_name(parent_name, self.context) or parent_name,
                                 ref_list=('' if len(attributes_thus_far) - len(attributes_declared) == 1
                                           else '(%s)' % ','.join(r[1] for r in lst)))
-                            attributes_declared.update(fk_props['referencing_attributes'])
+                            attributes_declared.update(fk_props['attr_map'])
             if do_include:
                 attributes_declared.add(attr.name)
                 name = attr.name.lstrip('_')  # for external

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -9,7 +9,7 @@ import warnings
 from pymysql import OperationalError, InternalError, IntegrityError
 from . import config, DataJointError
 from .declare import declare
-from .relational_operand import RelationalOperand
+from .relational_operand import RelationalOperand, OrList
 from .blob import pack
 from .utils import user_choice
 from .heading import Heading
@@ -319,7 +319,7 @@ class BaseRelation(RelationalOperand):
 
         # construct restrictions for each relation
         restrict_by_me = set()
-        restrictions = collections.defaultdict(list)
+        restrictions = collections.defaultdict(OrList)
         # restrict by self
         if self.restrictions:
             restrict_by_me.add(self.full_table_name)

--- a/datajoint/dependencies.py
+++ b/datajoint/dependencies.py
@@ -1,6 +1,6 @@
-import pyparsing as pp
 import networkx as nx
 import itertools
+from collections import defaultdict
 from . import DataJointError
 
 
@@ -8,84 +8,67 @@ class Dependencies(nx.DiGraph):
     """
     The graph of dependencies (foreign keys) between loaded tables.
     """
-    __primary_key_parser = (pp.CaselessLiteral('PRIMARY KEY') +
-                            pp.QuotedString('(', endQuoteChar=')').setResultsName('primary_key'))
-
     def __init__(self, connection):
         self._conn = connection
         self.loaded_tables = set()
         self._node_alias_count = itertools.count()
         super().__init__(self)
 
-    @staticmethod
-    def __foreign_key_parser(database):
-        def paste_database(unused1, unused2, toc):
-            return ['`{database}`.`{table}`'.format(database=database, table=toc[0])]
-
-        return (pp.CaselessLiteral('CONSTRAINT').suppress() +
-                pp.QuotedString('`').suppress() +
-                pp.CaselessLiteral('FOREIGN KEY').suppress() +
-                pp.QuotedString('(', endQuoteChar=')').setResultsName('attributes') +
-                pp.CaselessLiteral('REFERENCES') +
-                pp.Or([
-                    pp.QuotedString('`').setParseAction(paste_database),
-                    pp.Combine(pp.QuotedString('`', unquoteResults=False) + '.' +
-                               pp.QuotedString('`', unquoteResults=False))]).setResultsName('referenced_table') +
-                pp.QuotedString('(', endQuoteChar=')').setResultsName('referenced_attributes'))
-
-    def add_table(self, table_name):
-        """
-        Adds table to the dependency graph
-        :param table_name: in format `schema`.`table`
-        """
-        if table_name in self.loaded_tables:
-            return
-        fk_parser = self.__foreign_key_parser(table_name.split('.')[0].strip('`'))
-        self.loaded_tables.add(table_name)
-        self.add_node(table_name)
-        create_statement = self._conn.query('SHOW CREATE TABLE %s' % table_name).fetchone()[1].split('\n')
-        primary_key = None
-        for line in create_statement:
-            if primary_key is None:
-                try:
-                    result = self.__primary_key_parser.parseString(line)
-                except pp.ParseException:
-                    pass
-                else:
-                    primary_key = [s.strip(' `') for s in result.primary_key.split(',')]
-            try:
-                result = fk_parser.parseString(line)
-            except pp.ParseException:
-                pass
-            else:
-                if '`.`~' not in result.referenced_table:  # omit external tables
-                    referencing_attributes = [r.strip('` ') for r in result.attributes.split(',')]
-                    referenced_attributes = [r.strip('` ') for r in result.referenced_attributes.split(',')]
-                    props = dict(
-                        primary=all(a in primary_key for a in referencing_attributes),
-                        referencing_attributes=referencing_attributes,
-                        referenced_attributes=referenced_attributes,
-                        aliased=not all(a == b for a, b in zip(referencing_attributes, referenced_attributes)),
-                        multi=not all(a in referencing_attributes for a in primary_key))
-                    if not props['aliased']:
-                        self.add_edge(result.referenced_table, table_name, **props)
-                    else:
-                        # for aliased dependencies, add an extra node in the format '1', '2', etc
-                        alias_node = '%d' % next(self._node_alias_count)
-                        self.add_node(alias_node)
-                        self.add_edge(result.referenced_table, alias_node, **props)
-                        self.add_edge(alias_node, table_name, **props)
-
-    def load(self):
+    def load(self, target=None):
         """
         Load dependencies for all loaded schemas.
         This method gets called before any operation that requires dependencies: delete, drop, populate, progress.
         """
-        for database in self._conn.schemas:
-            for row in self._conn.query('SHOW TABLES FROM `{database}`'.format(database=database)):
-                table = row[0]
-                if not table.startswith('~'):  # exclude service tables
-                    self.add_table('`{db}`.`{tab}`'.format(db=database, tab=table))
+        self.clear()  # reload from scratch and prevent duplication
+
+        # load primary keys
+        keys = self._conn.query("""
+                SELECT 
+                    concat('`', table_schema, '`.`', table_name, '`') as tab, column_name
+                FROM information_schema.key_column_usage 
+                WHERE referenced_table_name IS NULL AND table_schema in ('{schemas}') AND constraint_name="PRIMARY" 
+                """.format(schemas="','".join(self._conn.schemas)))
+        pks = defaultdict(set)
+        for key in keys:
+            pks[key[0]].add(key[1])
+
+        # add nodes to the graph
+        for n, pk in pks.items():
+            self.add_node(n, primary_key=pk)
+
+        # load foreign keys
+        keys = self._conn.query("""
+        SELECT constraint_name,  
+            concat('`', table_schema, '`.`', table_name, '`') as referencing_table,
+            concat('`', referenced_table_schema, '`.`',  referenced_table_name, '`') as referenced_table, 
+            column_name, referenced_column_name
+        FROM information_schema.key_column_usage 
+        WHERE referenced_table_name NOT LIKE "~%%" AND (referenced_table_schema in ('{schemas}') OR 
+            referenced_table_schema is not NULL AND table_schema in ('{schemas}')) 
+        """.format(schemas="','".join(self._conn.schemas)), as_dict=True)
+        fks = defaultdict(lambda: dict(attr_map=dict()))
+        for key in keys:
+            d = fks[key['constraint_name']]
+            d['referencing_table'] = key['referencing_table']
+            d['referenced_table'] = key['referenced_table']
+            d['attr_map'][key['column_name']] = key['referenced_column_name']
+
+        # add edges to the graph
+        for fk in fks.values():
+            props = dict(
+                primary=all(attr in pks[fk['referencing_table']] for attr in fk['attr_map']),
+                attr_map=fk['attr_map'],
+                aliased=any(k != v for k, v in fk['attr_map'].items()),
+                multi=not all(a in fk['attr_map'] for a in pks[fk['referencing_table']]))
+            if not props['aliased']:
+                self.add_edge(fk['referenced_table'], fk['referencing_table'], **props)
+            else:
+                # for aliased dependencies, add an extra node in the format '1', '2', etc
+                alias_node = '%d' % next(self._node_alias_count)
+                self.add_node(alias_node)
+                self.add_edge(fk['referenced_table'], alias_node, **props)
+                self.add_edge(alias_node, fk['referencing_table'], **props)
+
         if not nx.is_directed_acyclic_graph(self):  # pragma: no cover
             raise DataJointError('DataJoint can only work with acyclic dependencies')
 

--- a/datajoint/dependencies.py
+++ b/datajoint/dependencies.py
@@ -19,9 +19,11 @@ class Dependencies(nx.DiGraph):
         Load dependencies for all loaded schemas.
         This method gets called before any operation that requires dependencies: delete, drop, populate, progress.
         """
-        self.clear()  # reload from scratch and prevent duplication
 
-        # load primary keys
+        # reload from scratch to prevent duplication of renamed edges
+        self.clear()
+
+        # load primary key info
         keys = self._conn.query("""
                 SELECT 
                     concat('`', table_schema, '`.`', table_name, '`') as tab, column_name

--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -108,20 +108,3 @@ class ExternalTable(BaseRelation):
             raise DataJointError('Unknown external storage %s' % store)
 
         return unpack(blob)
-
-    def clean(self, batch=10000):
-        """
-        Perform garbage collection.  Remove all objects that are not longer referenced in this schema.
-        """
-        # get all the tables that reference this table
-        tables = self.connection.query("""
-        SELECT concat('`', table_schema, '`.`', table_name, '`') as referencing_table
-        FROM information_schema.key_column_usage 
-        WHERE referenced_table_name NOT LIKE "~%%" AND (referenced_table_schema={db} and referenced_table={tab}        
-        """.format(db=self.database, tab=self.table_name))
-        # query all hashes that are not referenced by any table
-        restriction = ' AND '.join(
-            'hash NOT in (SELECT hash FROM {tab})'.format(tab=tab) for tab in tables)
-        hashes_to_delete = self.connection.query(
-            "SELECT hash WHERE TRUE AND {restriction}".format(restriction=restriction)).fetchall()
-

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -114,9 +114,9 @@ class RelationalOperand:
                 return not negate   # and empty AndList is True
             return template % ' AND '.join(items)
 
-        # restriction by dj.U has no effect
+        # restriction by dj.U evaluates to True
         if isinstance(arg, U):
-            return True
+            return not negate
 
         # restrict by boolean
         if isinstance(arg, bool):

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -108,13 +108,9 @@ class RelationalOperand:
             return (template % (' AND '.join(self._make_condition(item) for item in arg))
                     if arg else not negate)  # an empty AndList is equivalent to True
 
-        # restrict by None -- equivalent to False
-        if arg is None:
-            return False
-
         # restrict by boolean
         if isinstance(arg, bool):
-            return not arg if negate else arg
+            return negate != arg
 
         # restrict by a mapping such as a dict -- convert to an AndList of string equality conditions
         if isinstance(arg, collections.abc.Mapping):

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -10,20 +10,6 @@ from .fetch import Fetch, Fetch1
 
 logger = logging.getLogger(__name__)
 
-class OrList(list):
-    """
-    A list of conditions to restrict a relation.  The conditions are OR-ed.
-    If any restriction is True, then the overall condition is True.
-    Each condition can be a AndList.
-
-    Example:
-    rel2 = rel & dj.ORList((cond1, cond2, cond3))
-    is equivalent to
-    rel2 = rel & [cond1, cond2, cond3]
-    """
-    pass
-
-
 class AndList(list):
     """
     A list of restrictions to by applied to a relation.  The restrictions are AND-ed.
@@ -148,7 +134,7 @@ class RelationalOperand:
             common_attributes = [q for q in self.heading.names if q in arg.heading.names]
             return (
                 # without common attributes, any non-empty relation matches everything
-                not negate if arg else negate if not common_attributes
+                (not negate if arg else negate) if not common_attributes
                 else '({fields}) {not_}in ({subquery})'.format(
                     fields='`' + '`,`'.join(common_attributes) + '`',
                     not_="not " if negate else "",
@@ -156,7 +142,7 @@ class RelationalOperand:
 
         # if iterable (but not a string, a relation, or an AndList), treat as an OrList
         try:
-            or_list = OrList(self._make_condition(q) for q in arg if q is not False)
+            or_list = [self._make_condition(q) for q in arg if q is not False]
         except TypeError:
             raise DataJointError('Invalid restriction type %r' % arg)
         else:

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -295,8 +295,8 @@ class RelationalOperand:
         :param restriction: a sequence or an array (treated as OR list), another relation, an SQL condition string, or
             an AndList.
         """
-        assert not self.heading.expressions or isinstance(self, GroupBy), \
-                "Cannot restrict in place a projection with renamed attributes."
+        assert not self.heading.expressions or isinstance(self, GroupBy), "Cannot restrict a projection" \
+                                                                          " with renamed attributes in place."
         self.restriction.append(restriction)
         return self
 

--- a/datajoint/relational_operand.py
+++ b/datajoint/relational_operand.py
@@ -18,23 +18,23 @@ def equal_ignore_case(str1, str2):
         return False
 
 
-def restricts_to_same(arg):
+def restricts_true(arg):
     """
     returns True if restriction with arg produces the same result as not restricting at all
     """
     return (isinstance(arg, U) or arg is True or equal_ignore_case(arg, "TRUE") or
-            isinstance(arg, Not) and restricts_to_empty(arg.restriction))
+            isinstance(arg, Not) and restricts_false(arg.restriction))
 
 
-def restricts_to_empty(arg):
+def restricts_false(arg):
     """
     returns True if restriction with arg must produce the empty relation.
     """
     or_lists = (list, set, tuple, np.ndarray)
-    return (arg is None or (isinstance(arg, AndList) and any(restricts_to_empty(r) for r in arg)) or
-            arg is None or arg is False or equal_ignore_case(arg, "FALSE") or
+    return (arg is None or (isinstance(arg, AndList) and any(restricts_false(r) for r in arg)) or
+            arg is False or equal_ignore_case(arg, "FALSE") or
             isinstance(arg, or_lists) and len(arg) == 0 or  # empty OR-list equals FALSE
-            isinstance(arg, Not) and restricts_to_same(arg.restriction))
+            isinstance(arg, Not) and restricts_true(arg.restriction))
 
 
 class OrList(list):
@@ -48,28 +48,7 @@ class OrList(list):
     is equivalent to
     rel2 = rel & [cond1, cond2, cond3]
     """
-
-    @staticmethod
-    def _recurse(other):
-        for item in other:
-            if isinstance(item, OrList):
-                yield from OrList._recurse(item)  # flatten list
-            else:
-                if not isinstance(item, AndList):
-                    yield item
-                elif len(item) == 0:
-                    yield True
-                elif len(item) == 1:
-                    if isinstance(item[0], OrList):
-                        OrList._recurse(item[0])
-                    else:
-                        yield item[0]
-                else:
-                    yield item
-
-    def __init__(self, other):
-        lst = list(self._recurse(other))
-        super().__init__([True] if any(i is True for i in lst) else lst)
+    pass
 
 
 class AndList(list):
@@ -84,24 +63,12 @@ class AndList(list):
     rel2 = rel & cond1 & cond2 & cond3
     """
 
-    def set(self, items):
-        self.clear()
-        self.append(items)
-
-    def append(self, item):
-        # append item, reducing nesting
-        if isinstance(item, AndList):
-            self.extend(item)
-        elif isinstance(item, OrList):
-            if not item:  # an empty OrList is equivalent to False
-                super().append(False)
-            else:  # an OrList with one element is equivalent to the element
-                super().append(item[0] if len(item) == 1 else item)
+    def append(self, restriction):
+        if isinstance(restriction, AndList):
+            # extend to reduce nesting
+            self.extend(restriction)
         else:
-            super().append(item)
-        # an AndList with a False in it is False
-        if len(self) > 1 and any(i is False for i in self):
-            self.set(False)
+            self.append(restriction)
 
 
 class RelationalOperand:
@@ -116,12 +83,12 @@ class RelationalOperand:
     def __init__(self, arg=None):
         if arg is None:  # initialize
             # initialize
-            self._restrictions = AndList()
+            self._restriction = AndList()
             self._distinct = False
             self._heading = None
         else:  # copy
             assert isinstance(arg, RelationalOperand), 'Cannot make RelationalOperand from %s' % arg.__class__.__name__
-            self._restrictions = AndList(arg._restrictions)
+            self._restriction = AndList(arg._restriction)
             self._distinct = arg.distinct
             self._heading = arg._heading
 
@@ -150,78 +117,81 @@ class RelationalOperand:
         return self._distinct
 
     @property
-    def restrictions(self):
+    def restriction(self):
         """
         :return:  The AndList of restrictions applied to the relation.
         """
-        assert isinstance(self._restrictions, AndList)
-        return self._restrictions
-
-    @property
-    def is_restricted(self):
-        return len(self.restrictions) > 0
+        assert isinstance(self._restriction, AndList)
+        return self._restriction
 
     @property
     def primary_key(self):
         return self.heading.primary_key
 
+    def _make_condition(self, arg):
+        """
+        Translate the input arg into the equivalent SQL condition (a string)
+        :param arg: any valid restriction object.
+        :return: an SQL condition string.  It may also be a boolean that is intended to be treated as a string.
+        """
+        negate = False
+        while isinstance(arg, Not):
+            negate = not negate
+            arg = arg.restriction
+        template = "NOT (%s)" if negate else "%s"
+
+        # restrict by string
+        if isinstance(arg, str):
+            return template % arg.strip()
+
+        # restrict by AndList
+        if isinstance(arg, AndList):
+            return (template % (' AND '.join(self._make_condition(item) for item in arg))
+                    if arg else not negate)  # an empty AndList is equivalent to True
+
+        # restrict by boolean
+        if isinstance(arg, bool):
+            return not arg if negate else arg
+
+        # restrict by a mapping such as a dict -- convert to an AndList of string equality conditions
+        if isinstance(arg, collections.abc.Mapping):
+            return template % self._make_condition(
+                AndList('`%s`=%r' % (k, (v if not isinstance(v, (
+                    datetime.date, datetime.datetime, datetime.time, decimal.Decimal)) else str(v)))
+                        for k, v in arg.items() if k in self.heading))
+
+        # restrict by a numpy record -- convert to an AndList of string equality conditions
+        if isinstance(arg, np.void):
+            return template % self._make_condition(
+                AndList(('`%s`='+('%s' if self.heading[k].numeric else '"%s"')) % (k, arg[k])
+                        for k in arg.dtype.fields if k in self.heading))
+
+        # restrict by another relation (aka semijoin and antijoin)
+        if isinstance(arg, RelationalOperand):
+            common_attributes = [q for q in self.heading.names if q in arg.heading.names]
+            return (
+                # without common attributes, any non-empty relation matches everything
+                not negate if arg else negate if not common_attributes
+                else '({fields}) {not_}in ({subquery})'.format(
+                    fields='`' + '`,`'.join(common_attributes) + '`',
+                    not_="not " if negate else "",
+                    subquery=arg.make_sql(common_attributes)))
+
+        # if iterable (but not a string, a relation, or an AndList), treat as an OrList
+        try:
+            or_list = OrList(self._make_condition(q) for q in arg if q is not False)
+        except TypeError:
+            raise DataJointError('Invalid restriction type %r' % arg)
+        else:
+            return template % ('(%s)' % ' OR '.join(or_list)) if or_list else False
+
     @property
     def where_clause(self):
         """
-        convert self.restrictions to the SQL WHERE clause
+        convert self.restriction to the SQL WHERE clause
         """
-
-        def make_condition(arg, _negate=False):
-            if isinstance(arg, str):
-                return arg, _negate
-            elif isinstance(arg, AndList):
-                return '(' + ' AND '.join([make_condition(element)[0] for element in arg]) + ')', _negate
-            elif isinstance(arg, bool):
-                return 'FALSE' if _negate == arg else 'TRUE', False
-            # semijoin or antijoin
-            elif isinstance(arg, RelationalOperand):
-                common_attributes = [q for q in self.heading.names if q in arg.heading.names]
-                if not common_attributes:
-                    condition = 'FALSE' if _negate else 'TRUE'
-                else:
-                    condition = '({fields}) {not_}in ({subquery})'.format(
-                        fields='`' + '`,`'.join(common_attributes) + '`',
-                        not_="not " if _negate else "",
-                        subquery=arg.make_sql(common_attributes))
-                return condition, False  # _negate is cleared
-
-            # mappings are turned into ANDed equality conditions
-            elif isinstance(arg, collections.abc.Mapping):
-                condition = ['`%s`=%r' % (k, (v if not isinstance(v, (
-                    datetime.date, datetime.datetime, datetime.time, decimal.Decimal)) else str(v)))
-                             for k, v in arg.items() if k in self.heading]
-            elif isinstance(arg, np.void):
-                # element of a record array
-                condition = [('`%s`='+('%s' if self.heading[k].numeric else '"%s"')) % (k, arg[k])
-                             for k in arg.dtype.fields if k in self.heading]
-            else:
-                raise DataJointError('Invalid restriction type')
-            return ' AND '.join(condition) if condition else 'TRUE', _negate
-
-        if not self.is_restricted:
-            return ''
-
-        # An empty or-list in the restrictions immediately causes an empty result
-        if restricts_to_empty(self.restrictions):
-            return ' WHERE FALSE'
-
-        conditions = []
-        for item in self.restrictions:
-            negate = isinstance(item, Not)
-            if negate:
-                item = item.restriction  # NOT is added below
-            if isinstance(item, (list, tuple, set, np.ndarray)):
-                item = '(' + ') OR ('.join(
-                    [make_condition(q)[0] for q in item if q is not restricts_to_empty(q)]) + ')'
-            else:
-                item, negate = make_condition(item, negate)
-            conditions.append(('NOT (%s)' if negate else '(%s)') % item)
-        return ' WHERE ' + ' AND '.join(conditions)
+        cond = self._make_condition(self.restriction)
+        return '' if cond is True else ' WHERE %s' % cond
 
     def get_select_fields(self, select_fields=None):
         """
@@ -355,22 +325,9 @@ class RelationalOperand:
         :param restriction: a sequence or an array (treated as OR list), another relation, an SQL condition string, or
             an AndList.
         """
-        assert not self.heading.expressions or isinstance(self, GroupBy), "Cannot restrict in place" \
-                                                                          " a projection with renamed attributes."
-        if not restricts_to_same(restriction):
-            self.restrictions.append(restriction)
-        elif restricts_to_empty(restriction):
-            self.restrictions.set(False)
-        return self
-
-    def allow(self, arg):
-        assert not self.heading.expressions or isinstance(self, GroupBy), "Cannot restrict in place" \
-                                                                          " a projection with renamed attributes."
-        if self.restrictions:
-            if restricts_to_same(arg):
-                self.restrictions.clear()
-            else:
-                self.restrictions.set(OrList([self.restrictions, arg]))
+        assert not self.heading.expressions or isinstance(self, GroupBy), \
+                "Cannot restrict in place a projection with renamed attributes."
+        self.restriction.append(restriction)
         return self
 
     @property
@@ -383,7 +340,7 @@ class RelationalOperand:
 
     def attributes_in_restriction(self):
         """
-        :return: list of attributes that are probably used in the restrictions.
+        :return: list of attributes that are probably used in the restriction.
             The function errs on the side of false positives.
             For example, if the restriction is "val='id'", then the attribute 'id' would be flagged.
             This is used internally for optimizing SQL statements.
@@ -556,9 +513,9 @@ class Not:
     """
     invert restriction
     """
-
     def __init__(self, restriction):
-        self.restriction = True if isinstance(restriction, U) else restriction
+        assert isinstance(restriction, AndList)
+        self.restriction = restriction
 
 
 class Join(RelationalOperand):
@@ -595,8 +552,8 @@ class Join(RelationalOperand):
                 obj._arg1.heading.dependent_attributes).intersection(obj._arg2.heading.dependent_attributes)))
         except StopIteration:
             obj._heading = obj._arg1.heading.join(obj._arg2.heading)
-            obj.restrict(obj._arg1.restrictions)
-            obj.restrict(obj._arg2.restrictions)
+            obj.restrict(obj._arg1.restriction)
+            obj.restrict(obj._arg2.restriction)
         return obj
 
     @staticmethod
@@ -706,7 +663,7 @@ class Projection(RelationalOperand):
         else:
             obj._arg = arg
             obj._heading = obj._arg.heading.project(attributes, named_attributes)
-            obj &= arg.restrictions  # copy restrictions when no subquery
+            obj &= arg.restriction  # copy restriction when no subquery
         return obj
 
     @staticmethod

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -19,7 +19,8 @@ def test_external_put():
     for i in range(extra):
         hash2 = ext.put('external-raw', np.random.randn(4, 3, 2))
 
-    assert_true(all(hash in ext.fetch('hash') for hash in (hash1, hash2)))
+    fetched_hashes = ext.fetch('hash')
+    assert_true(all(hash in fetched_hashes for hash in (hash1, hash2)))
     assert_equal(len(ext), 1 + extra)
 
     output_ = ext.get(hash1)

--- a/tests/test_external_class.py
+++ b/tests/test_external_class.py
@@ -32,3 +32,24 @@ def test_populate():
     for img, neg, dimensions in zip(*(image * modu.Dimension()).fetch('img', 'neg', 'dimensions')):
         assert_list_equal(list(img.shape), list(dimensions))
         assert_almost_equal(img, -neg)
+
+
+def test_clean():
+    image = modu.Image()
+    ext = modu.schema.external_table
+    assert_true(image.external_table is ext)
+
+    image.populate()
+
+    set1 = (image & 'seed MOD 2 = 0')   # to keep
+    set2 = image - set1.proj()          # to delete
+
+    keys1 = list(set1.fetch.keys())
+    keys2 = list(set1.fetch.keys())
+
+    (image & keys2).delete()
+    hashes_before = ext.fetch('hash')
+    ext.clean()
+    hashes_after = ext.fetch('hash')
+
+

--- a/tests/test_external_class.py
+++ b/tests/test_external_class.py
@@ -34,22 +34,4 @@ def test_populate():
         assert_almost_equal(img, -neg)
 
 
-def test_clean():
-    image = modu.Image()
-    ext = modu.schema.external_table
-    assert_true(image.external_table is ext)
-
-    image.populate()
-
-    set1 = (image & 'seed MOD 2 = 0')   # to keep
-    set2 = image - set1.proj()          # to delete
-
-    keys1 = list(set1.fetch.keys())
-    keys2 = list(set1.fetch.keys())
-
-    (image & keys2).delete()
-    hashes_before = ext.fetch('hash')
-    ext.clean()
-    hashes_after = ext.fetch('hash')
-
 

--- a/tests/test_foreign_keys.py
+++ b/tests/test_foreign_keys.py
@@ -17,7 +17,7 @@ def test_aliased_fk():
     assert_true(person)
     assert_true(parent)
     link = person.proj(parent_name='full_name', parent='person_id')
-    parents = person*parent*link
+    parents = person * parent * link
     parents &= dict(full_name="May K. Hall")
     assert_equal(set(parents.fetch('parent_name')), {'Hanna R. Walters', 'Russel S. James'})
     person.delete()


### PR DESCRIPTION
Simplify and correct the logic of restrictions.

This PR includes #403 and should be merged after #403 

Also, fix #406:  `"KEY"` can be used in place of `dj.key`.