### PR TITLE
Local context; garbage collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Release notes
 
+### 0.9.0 -- November 17, 2017
+* Bug fixes
+* Made graphviz installation optional
+* Implement file-based external storage
+* Add Union operator +
+
+
 ### 0.8.0 -- July 26, 2017 
 Documentation and tutorials available at https://docs.datajoint.io and https://tutorials.datajoint.io
 * improved the ERD graphics and features using the graphviz libraries (#207, #333)

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -167,15 +167,13 @@ class BaseRelation(RelationalOperand):
                 except StopIteration:
                     pass
             fields = list(name for name in heading if name in rows.heading)
-
             query = '{command} INTO {table} ({fields}) {select}{duplicate}'.format(
                 command='REPLACE' if replace else 'INSERT',
                 fields='`' + '`,`'.join(fields) + '`',
                 table=self.full_table_name,
                 select=rows.make_sql(select_fields=fields),
                 duplicate=(' ON DUPLICATE KEY UPDATE `{pk}`=`{pk}`'.format(pk=self.primary_key[0])
-                           if skip_duplicates else '')
-            )
+                           if skip_duplicates else ''))
             self.connection.query(query)
             return
 

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -530,7 +530,7 @@ def lookup_class_name(name, context, depth=3):
                 except AttributeError:
                     pass  # not a UserRelation -- cannot have part tables.
                 else:
-                    for part in (getattr(member, p) for p in parts if hasattr(member, p)):
+                    for part in (getattr(member, p) for p in parts if p[0].isupper() and hasattr(member, p)):
                         if inspect.isclass(part) and issubclass(part, BaseRelation) and part.full_table_name == name:
                             return '.'.join([node['context_name'], member_name, part.__name__]).lstrip('.')
             elif node['depth'] > 0 and inspect.ismodule(member) and member.__name__ != 'datajoint':

--- a/datajoint/base_relation.py
+++ b/datajoint/base_relation.py
@@ -620,7 +620,7 @@ class Log(BaseRelation):
                 version=version + 'py',
                 host=platform.uname().node,
                 event=event), skip_duplicates=True, ignore_extra_fields=True)
-        except pymysql.err.OperationalError:
+        except DataJointError:
             logger.info('could not log event in table ~log')
 
     def delete(self):

--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -70,7 +70,7 @@ class ExternalTable(BaseRelation):
                     safe_write(full_path, blob)
         else:
             raise DataJointError('Unknown external storage protocol {protocol} for {store}'.format(
-                store=store, protocol=protocol))
+                store=store, protocol=spec['protocol']))
 
         # insert tracking info
         self.connection.query(
@@ -126,16 +126,6 @@ class ExternalTable(BaseRelation):
         FROM information_schema.key_column_usage
         WHERE referenced_table_name="{tab}" and referenced_table_schema="{db}"
         """.format(tab=self.table_name, db=self.database), as_dict=True)
-
-    @property
-    def garbage_count(self):
-        """
-        :return: number of items that are no longer referenced
-        """
-        return self.connection.query(
-            "SELECT COUNT(*) FROM `{db}`.`{tab}` WHERE ".format(tab=self.table_name, db=self.database) +
-            (" AND ".join('hash NOT IN (SELECT {column_name} FROM {referencing_table})'.format(**ref)
-                          for ref in self.references) or "TRUE")).fetchone()[0]
 
     def delete(self):
         return self.delete_quick()

--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -161,7 +161,7 @@ class ExternalTable(BaseRelation):
         raise DataJointError('Please use delete_garbage instead')
 
     def drop_quick(self):
-        if not self:
+        if self:
             raise DataJointError('Cannot non-empty external table. Please use delete_garabge to clear it.')
         self.drop_quick()
 
@@ -193,10 +193,9 @@ class ExternalTable(BaseRelation):
 
         if protocol == 'file':
             folder = os.path.join(spec['location'], self.database)
-            lst = set(os.listdir(folder))
-            lst.difference_update(self.fetch('hash'))
-            print('Deleting %d unused items from %s' % (len(lst), folder), flush=True)
-            for f in tqdm(lst):
+            delete_list = set(os.listdir(folder)).difference(self.fetch('hash'))
+            print('Deleting %d unused items from %s' % (len(delete_list), folder), flush=True)
+            for f in tqdm(delete_list):
                 os.remove(os.path.join(folder, f))
         else:
             raise DataJointError('Unknown external storage protocol {protocol} for {store}'.format(

--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -140,7 +140,7 @@ class ExternalTable(BaseRelation):
     def drop_quick(self):
         """drop the external table -- works only when it's empty"""
         if self:
-            raise DataJointError('Cannot non-empty external table. Please use delete_garabge to clear it.')
+            raise DataJointError('Cannot drop a non-empty external table. Please use delete_garabge to clear it.')
         self.drop_quick()
 
     def delete_garbage(self):

--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -127,16 +127,6 @@ class ExternalTable(BaseRelation):
         WHERE referenced_table_name="{tab}" and referenced_table_schema="{db}"
         """.format(tab=self.table_name, db=self.database), as_dict=True)
 
-    @property
-    def garbage_count(self):
-        """
-        :return: number of items that are no longer referenced
-        """
-        return self.connection.query(
-            "SELECT COUNT(*) FROM `{db}`.`{tab}` WHERE ".format(tab=self.table_name, db=self.database) +
-            (" AND ".join('hash NOT IN (SELECT {column_name} FROM {referencing_table})'.format(**ref)
-                          for ref in self.references) or "TRUE")).fetchone()[0]
-
     def delete(self):
         return self.delete_quick()
 

--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -70,7 +70,7 @@ class ExternalTable(BaseRelation):
                 except FileNotFoundError:
                     os.makedirs(folder)
                     safe_write(full_path, blob)
-        elif protocol == 's3':
+        elif spec['protocol'] == 's3':
             s3.put(self.database, store, blob, blob_hash)
         else:
             raise DataJointError('Unknown external storage protocol {protocol} for {store}'.format(
@@ -111,7 +111,7 @@ class ExternalTable(BaseRelation):
                         blob = f.read()
                 except FileNotFoundError:
                     raise DataJointError('Lost external blob %s.' % full_path) from None
-            elif protocol == 's3':
+            elif spec['protocol'] == 's3':
                 blob = s3.get(self.database, store, blob_hash)
             else:
                 raise DataJointError('Unknown external storage protocol "%s"' % self['protocol'])

--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -157,10 +157,18 @@ class ExternalTable(BaseRelation):
             (" AND ".join('hash NOT IN (SELECT {column_name} FROM {referencing_table})'.format(**ref)
                           for ref in self.references) or "TRUE")).fetchone()[0]
 
+    def delete(self):
+        return self.delete_quick()
+
     def delete_quick(self):
-        raise DataJointError('Please use delete_garbage instead')
+        raise DataJointError('The external table does not support delete. Please use delete_garbage instead.')
+
+    def drop(self):
+        """drop the table"""
+        self.drop_quick()
 
     def drop_quick(self):
+        """drop the external table -- works only when it's empty"""
         if self:
             raise DataJointError('Cannot non-empty external table. Please use delete_garabge to clear it.')
         self.drop_quick()

--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -127,6 +127,16 @@ class ExternalTable(BaseRelation):
         WHERE referenced_table_name="{tab}" and referenced_table_schema="{db}"
         """.format(tab=self.table_name, db=self.database), as_dict=True)
 
+    @property
+    def garbage_count(self):
+        """
+        :return: number of items that are no longer referenced
+        """
+        return self.connection.query(
+            "SELECT COUNT(*) FROM `{db}`.`{tab}` WHERE ".format(tab=self.table_name, db=self.database) +
+            (" AND ".join('hash NOT IN (SELECT {column_name} FROM {referencing_table})'.format(**ref)
+                          for ref in self.references) or "TRUE")).fetchone()[0]
+
     def delete(self):
         return self.delete_quick()
 
@@ -170,7 +180,7 @@ class ExternalTable(BaseRelation):
                 os.remove(os.path.join(folder, f))
         else:
             raise DataJointError('Unknown external storage protocol {protocol} for {store}'.format(
-                store=store, protocol=self['protocol']))
+                store=store, protocol=spec['protocol']))
 
     @staticmethod
     def _get_store_spec(store):

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -1,5 +1,6 @@
 import warnings
 import pymysql
+import inspect
 import logging
 import inspect
 import re
@@ -36,7 +37,7 @@ class Schema:
     It also specifies the namespace `context` in which other UserRelation classes are defined.
     """
 
-    def __init__(self, database, context, connection=None, create_tables=True):
+    def __init__(self, database, context=None, connection=None, create_tables=True):
         """
         Associates the specified database with this schema object. If the target database does not exist
         already, will attempt on creating the database.
@@ -50,7 +51,7 @@ class Schema:
         self._log = None
         self.database = database
         self.connection = connection
-        self.context = context
+        self.context = context if context is not None else inspect.currentframe().f_back.f_locals
         self.create_tables = create_tables
         self._jobs = None
         self._external = None

--- a/datajoint/user_relations.py
+++ b/datajoint/user_relations.py
@@ -44,17 +44,17 @@ class OrderedClass(type):
         return (cls().__getattribute__(name) if name in supported_class_attrs
                 else super().__getattribute__(name))
 
-    def __len__(cls):
-        return len(cls())
-
     def __and__(cls, arg):
         return cls() & arg
 
     def __sub__(cls, arg):
-        return cls() & arg
+        return cls() - arg
 
     def __mul__(cls, arg):
         return cls() * arg
+
+    def __add__(cls, arg):
+        return cls() + arg
 
 
 class UserRelation(BaseRelation, metaclass=OrderedClass):

--- a/datajoint/user_relations.py
+++ b/datajoint/user_relations.py
@@ -22,7 +22,7 @@ class OrderedClass(type):
     Class whose members are ordered
     See https://docs.python.org/3/reference/datamodel.html#metaclass-example
 
-    TODO:  In Python 3.6, this will no longer be necessary and should be removed (PEP 520)
+    Note:  Since Python 3.6, this will no longer be necessary and should be removed (PEP 520)
     https://www.python.org/dev/peps/pep-0520/
     """
     @classmethod
@@ -43,6 +43,9 @@ class OrderedClass(type):
         # trigger instantiation for supported class attrs
         return (cls().__getattribute__(name) if name in supported_class_attrs
                 else super().__getattribute__(name))
+
+    def __len__(cls):
+        return len(cls())
 
     def __and__(cls, arg):
         return cls() & arg

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -8,7 +8,7 @@ import datajoint as dj
 import os, signal
 from . import PREFIX, CONN_INFO
 
-schema = dj.schema(PREFIX + '_test1', locals(), connection=dj.conn(**CONN_INFO))
+schema = dj.schema(PREFIX + '_test1', connection=dj.conn(**CONN_INFO))
 
 
 @schema

--- a/tests/schema_external.py
+++ b/tests/schema_external.py
@@ -8,7 +8,7 @@ import datajoint as dj
 from . import PREFIX, CONN_INFO
 import numpy as np
 
-schema = dj.schema(PREFIX + '_extern', locals(), connection=dj.conn(**CONN_INFO))
+schema = dj.schema(PREFIX + '_extern', connection=dj.conn(**CONN_INFO))
 
 
 dj.config['external'] = {

--- a/tests/test_external_class.py
+++ b/tests/test_external_class.py
@@ -1,4 +1,4 @@
-from nose.tools import assert_true, assert_list_equal
+from nose.tools import assert_true, assert_list_equal, raises
 from numpy.testing import assert_almost_equal
 import datajoint as dj
 from . import schema_external as modu
@@ -37,12 +37,22 @@ def test_populate():
     image = modu.Image()
     image.populate()
     remaining, total = image.progress()
+    image.external_table.clean_store('external-raw')
     assert_true(total == len(modu.Dimension() * modu.Seed()) and remaining == 0)
     for img, neg, dimensions in zip(*(image * modu.Dimension()).fetch('img', 'neg', 'dimensions')):
         assert_list_equal(list(img.shape), list(dimensions))
         assert_almost_equal(img, -neg)
     image.delete()
     image.external_table.delete_garbage()
+    image.external_table.clean_store('external-raw')
+
+
+@raises(dj.DataJointError)
+def test_drop():
+    image = modu.Image()
+    image.populate()
+    image.drop()
+
 
 
 

--- a/tests/test_external_class.py
+++ b/tests/test_external_class.py
@@ -51,8 +51,13 @@ def test_populate():
 def test_drop():
     image = modu.Image()
     image.populate()
-    image.drop()
+    image.external_table.drop()
 
+
+@raises(dj.DataJointError)
+def test_delete():
+    image = modu.Image()
+    image.external_table.delete()
 
 
 

--- a/tests/test_external_class.py
+++ b/tests/test_external_class.py
@@ -41,6 +41,8 @@ def test_populate():
     for img, neg, dimensions in zip(*(image * modu.Dimension()).fetch('img', 'neg', 'dimensions')):
         assert_list_equal(list(img.shape), list(dimensions))
         assert_almost_equal(img, -neg)
+    image.delete()
+    image.external_table.delete_garbage()
 
 
 

--- a/tests/test_s3_mock.py
+++ b/tests/test_s3_mock.py
@@ -27,7 +27,7 @@ class DjS3MockTest(TestCase):
 
     def test_s3_methods(self):
         ext = ExternalTable(schema.connection, schema.database)
-        ext.delete_quick()
+        ext.delete_garbage()
         input_ = np.random.randn(3, 7, 8)
         count = 7
         extra = 3


### PR DESCRIPTION
# Garbage Collection
Implement garbage collection for external. 

# Use of local context by the schema decorator

In creation of the `schema` decorator, the context keyword now defaults to the local context.

Before:
```python
schema = dj.schema('pipeline_tuning', locals())
```
After
```python
schema = dj.schema('pipeline_tuning')
```

The default context value should also fix #368.

Also fixed #379.