### PR TITLE
datajoint/jobs.py: use platform.node() for windows (fix for #470)

### DIFF
--- a/datajoint/jobs.py
+++ b/datajoint/jobs.py
@@ -1,6 +1,7 @@
 from _decimal import Decimal
 from .hash import key_hash
 import os
+import platform
 import pymysql
 from .base_relation import BaseRelation
 from . import DataJointError
@@ -78,7 +79,7 @@ class JobTable(BaseRelation):
             table_name=table_name,
             key_hash=key_hash(key),
             status='reserved',
-            host=os.uname().nodename,
+            host=platform.node(),
             pid=os.getpid(),
             connection_id=self.connection.connection_id,
             key=self.packable_or_none(key),
@@ -113,7 +114,7 @@ class JobTable(BaseRelation):
         self.insert1(
             dict(job_key,
                  status="error",
-                 host=os.uname().nodename,
+                 host=platform.node(),
                  pid=os.getpid(),
                  connection_id=self.connection.connection_id,
                  user=self._user,


### PR DESCRIPTION
Fix for #470.

Only tested against current unit tests on unix, which obviously is not a very good test in terms of completeness or correctness. Will hope to do a proper run on windows and also verify the jobs unit test covers the case (probably does, but not 100%), unless someone else feels more confident about impact.

Also, `os.getpid()` does work on windows; this was verified even if actual change was not otherwise.