### PR TITLE
Fix issues #483 and #516

### DIFF
--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -46,6 +46,8 @@ except StopIteration:
     config.add_history('No config file found, using default settings.')
 else:
     config.load(config_file)
+    del config_file
+
 del config_files
 
 # override login credentials with environment variables
@@ -58,6 +60,7 @@ mapping = {k: v for k, v in zip(
 for k in mapping:
     config.add_history('Updated login credentials from %s' % k)
 config.update(mapping)
+del mapping 
 
 logger.setLevel(log_levels[config['loglevel']])
 
@@ -65,7 +68,7 @@ logger.setLevel(log_levels[config['loglevel']])
 from .connection import conn, Connection
 from .table import FreeTable, Table
 from .user_tables import Manual, Lookup, Imported, Computed, Part
-from .query import Not, AndList, U
+from .expression import Not, AndList, U
 from .heading import Heading
 from .schema import Schema as schema
 from .erd import ERD

--- a/datajoint/admin.py
+++ b/datajoint/admin.py
@@ -43,7 +43,8 @@ def kill(restriction=None, connection=None):  # pragma: no cover
     while True:
         print('  ID USER         STATE         TIME  INFO')
         print('+--+ +----------+ +-----------+ +--+')
-        for process in connection.query(query, as_dict=True).fetchall():
+        cur = connection.query(query, as_dict=True)
+        for process in cur:
             try:
                 print('{ID:>4d} {USER:<12s} {STATE:<12s} {TIME:>5d}  {INFO}'.format(**process))
             except TypeError:

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -90,7 +90,7 @@ def compile_foreign_key(line, context, attributes, primary_key, attr_sql, foreig
     """
     # Parse and validate
     from .table import Table
-    from .query import Projection
+    from .expression import Projection
 
     new_style = True   # See issue #436.  Old style to be deprecated in a future release
     try:

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -9,7 +9,7 @@ import warnings
 from pymysql import OperationalError, InternalError, IntegrityError
 from . import config
 from .declare import declare
-from .query import Query
+from .expression import Expression
 from .blob import pack
 from .utils import user_choice
 from .heading import Heading
@@ -24,7 +24,7 @@ class _rename_map(tuple):
     pass
 
 
-class Table(Query):
+class Table(Expression):
     """
     Table is an abstract class that represents a base relation, i.e. a table in the schema.
     To make it a concrete class, override the abstract properties specifying the connection,
@@ -37,7 +37,7 @@ class Table(Query):
     _log_ = None
     _external_table = None
 
-    # -------------- required by Query ----------------- #
+    # -------------- required by Expression ----------------- #
     @property
     def heading(self):
         """
@@ -152,7 +152,8 @@ class Table(Query):
         """
         self.insert((row,), **kwargs)
 
-    def insert(self, rows, replace=False, skip_duplicates=False, ignore_extra_fields=False, ignore_errors=False):
+    def insert(self, rows, replace=False, skip_duplicates=False, ignore_extra_fields=False, ignore_errors=False,
+               allow_direct_insert=None):
         """
         Insert a collection of rows.
 
@@ -161,6 +162,7 @@ class Table(Query):
         :param replace: If True, replaces the existing tuple.
         :param skip_duplicates: If True, silently skip duplicate inserts.
         :param ignore_extra_fields: If False, fields that are not in the heading raise error.
+        :param allow_direct_insert: applies only in auto-populated tables. Set True to insert outside populate calls.
 
         Example::
         >>> relation.insert([
@@ -172,10 +174,15 @@ class Table(Query):
             warnings.warn('Use of `ignore_errors` in `insert` and `insert1` is deprecated. Use try...except... '
                           'to explicitly handle any errors', stacklevel=2)
 
+        # prohibit direct inserts into auto-populated tables
+        if not (allow_direct_insert or getattr(self, '_allow_insert', True)):  # _allow_insert is only present in AutoPopulate
+            raise DataJointError(
+                'Auto-populate tables can only be inserted into from their make methods during populate calls.')
+
         heading = self.heading
-        if inspect.isclass(rows) and issubclass(rows, Query):   # instantiate if a class
+        if inspect.isclass(rows) and issubclass(rows, Expression):   # instantiate if a class
             rows = rows()
-        if isinstance(rows, Query):
+        if isinstance(rows, Expression):
             # insert from select
             if not ignore_extra_fields:
                 try:
@@ -184,7 +191,7 @@ class Table(Query):
                         next(name for name in rows.heading if name not in heading))
                 except StopIteration:
                     pass
-            fields = list(name for name in heading if name in rows.heading)
+            fields = list(name for name in rows.heading if name in heading)
             query = '{command} INTO {table} ({fields}) {select}{duplicate}'.format(
                 command='REPLACE' if replace else 'INSERT',
                 fields='`' + '`,`'.join(fields) + '`',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -46,4 +46,4 @@ def teardown_package():
     cur = conn.query('SHOW DATABASES LIKE "{}\_%%"'.format(PREFIX))
     for db in cur.fetchall():
         conn.query('DROP DATABASE `{}`'.format(db[0]))
-    conn.query('SET FOREIGN_KEY_CHECKS=1')
+    conn.query('SET FOREIGN_KEY_CHECKS=1').close()

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -275,7 +275,7 @@ class DecimalPrimaryKey(dj.Lookup):
 @schema
 class IndexRich(dj.Manual):
     definition = """
-    -> Experiment
+    -> Subject
     ---
     -> [unique, nullable] User.proj(first="username")
     first_date : date

--- a/tests/schema_external.py
+++ b/tests/schema_external.py
@@ -36,6 +36,7 @@ class Simple(dj.Manual):
     item  : external-raw
     """
 
+
 @schema
 class Seed(dj.Lookup):
     definition = """

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -105,8 +105,8 @@ class TestDeclare:
         assert_true(experiment.full_table_name in set(user.children(primary=False)))
         assert_equal(set(experiment.parents(primary=False)), {user.full_table_name})
 
-        assert_equal(set(subject.children(primary=True)), {experiment.full_table_name})
-        assert_equal(set(experiment.parents(primary=True)), {subject.full_table_name})
+        assert_true(experiment.full_table_name in subject.descendants())
+        assert_true(subject.full_table_name in experiment.ancestors())
 
         assert_true(trial.full_table_name in experiment.descendants())
         assert_true(experiment.full_table_name in trial.ancestors())


### PR DESCRIPTION
This pull request follows PR #514

* Update `.proj` to preserve the original order of attributes 
* Renames `Query` -> `Expression` and `query.py` -> `expression.py`