### PR TITLE
reject unsupported datatypes at declaration time

### DIFF
--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -263,6 +263,11 @@ def compile_attribute(line, in_key, foreign_key_sql):
         match['default'] = ''
     match = {k: v.strip() for k, v in match.items()}
     match['nullable'] = match['default'].lower() == 'null'
+    acceptable_datatype_pattern = r'^(time|date|year|enum|(var)?char|float|double|decimal|' \
+                                  r'(tiny||small|medium|big)int|' \
+                                  r'(tiny||small|medium|long)blob|external)'
+    if re.match(acceptable_datatype_pattern, match['type']) is None:
+        raise DataJointError('DataJoint does not support datatype "{type}"'.format(**match))
 
     literals = ['CURRENT_TIMESTAMP']   # not to be enclosed in quotes
     if match['nullable']:

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -164,3 +164,15 @@ class TestDeclare:
             ----
             -> [optional] User
             """
+
+    @staticmethod
+    @raises(dj.DataJointError)
+    def test_unsupported_datatype():
+
+        @schema
+        class Q(dj.Manual):
+            definition = """
+            experiment : int
+            ---
+            description : text
+            """


### PR DESCRIPTION
Until now datajoint allowed creating tables with fields that it does not support.  Now it checks whether datatype is supported before declaring the table.