### PR TITLE
Fix #279, 428, and 519

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![DOI](https://zenodo.org/badge/16774/datajoint/datajoint-python.svg)](https://zenodo.org/badge/latestdoi/16774/datajoint/datajoint-python)
-[![Build Status](https://travis-ci.org/eywalker/datajoint-python.svg?branch=master)](https://travis-ci.org/eywalker/datajoint-python)
+[![Build Status](https://travis-ci.org/datajoint/datajoint-python.svg?branch=master)](https://travis-ci.org/datajoint/datajoint-python)
 [![Coverage Status](https://coveralls.io/repos/datajoint/datajoint-python/badge.svg?branch=master&service=github)](https://coveralls.io/github/datajoint/datajoint-python?branch=master)
 [![PyPI version](https://badge.fury.io/py/datajoint.svg)](http://badge.fury.io/py/datajoint)
 [![Requirements Status](https://requires.io/github/datajoint/datajoint-python/requirements.svg?branch=master)](https://requires.io/github/datajoint/datajoint-python/requirements/?branch=master)

--- a/datajoint/blob.py
+++ b/datajoint/blob.py
@@ -5,6 +5,7 @@ Provides serialization methods for numpy.ndarrays that ensure compatibility with
 import zlib
 from collections import OrderedDict, Mapping, Iterable
 from decimal import Decimal
+from datetime import datetime
 import numpy as np
 from .errors import DataJointError
 
@@ -234,6 +235,8 @@ def pack_obj(obj):
         blob += pack_array(np.array(obj))
     elif isinstance(obj, Decimal):
         blob += pack_array(np.array(np.float64(obj)))
+    elif isintance(obj, datetime):
+        blob += pack_obj(str(obj))
     else:
         raise DataJointError("Packing object of type %s currently not supported!" % type(obj))
 

--- a/datajoint/blob.py
+++ b/datajoint/blob.py
@@ -235,7 +235,7 @@ def pack_obj(obj):
         blob += pack_array(np.array(obj))
     elif isinstance(obj, Decimal):
         blob += pack_array(np.array(np.float64(obj)))
-    elif isintance(obj, datetime):
+    elif isinstance(obj, datetime):
         blob += pack_obj(str(obj))
     else:
         raise DataJointError("Packing object of type %s currently not supported!" % type(obj))

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -156,7 +156,7 @@ class Connection:
                     logger.debug("Re-executing SQL")
                     cur = self.query(query, args=args, as_dict=as_dict, suppress_warnings=suppress_warnings, reconnect=False)
             else:
-                logger.debug("Caught InterfaceError/OperationalError that are not related to connection issue")
+                logger.debug("Caught InterfaceError/OperationalError.")
                 raise
         except err.ProgrammingError as e:
             if e.args[0] == server_error_codes['parse error']:

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -116,7 +116,7 @@ class Connection:
         except:
             return False
 
-    def query(self, query, args=(), as_dict=False, suppress_warnings=True, reconnect=True):
+    def query(self, query, args=(), as_dict=False, suppress_warnings=True, reconnect=None):
         """
         Execute the specified query and return the tuple generator (cursor).
 
@@ -126,6 +126,8 @@ class Connection:
                         query results as dictionary.
         :param suppress_warnings: If True, suppress all warnings arising from underlying query library
         """
+        if reconnect is None:
+            reconnect = config['database.reconnect']
 
         cursor = client.cursors.DictCursor if as_dict else client.cursors.Cursor
         cur = self._conn.cursor(cursor=cursor)

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -105,13 +105,19 @@ class Connection:
     def register(self, schema):
         self.schemas[schema.database] = schema
 
+    def ping(self):
+        """
+        Pings the connection. Raises an exception if the connection is closed.
+        """
+        self._conn.ping(reconnect=False)
+
     @property
     def is_connected(self):
         """
         Returns true if the object is connected to the database server.
         """
         try:
-            self._conn.ping(reconnect=False)
+            self.ping()
             return True
         except:
             return False

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -191,7 +191,6 @@ class Connection:
     def cancel_transaction(self):
         """
         Cancels the current transaction and rolls back all changes made during the transaction.
-
         """
         self.query('ROLLBACK')
         self._in_transaction = False

--- a/datajoint/errors.py
+++ b/datajoint/errors.py
@@ -1,11 +1,26 @@
+from pymysql import err
+
 server_error_codes = {
     'unknown column': 1054,
     'duplicate entry': 1062,
     'parse error': 1064,
     'command denied': 1142,
     'table does not exist': 1146,
-    'syntax error': 1149
+    'syntax error': 1149,
 }
+
+operation_error_codes = {
+    'connection timedout': 2006,
+    'lost connection': 2013,
+}
+
+def is_connection_error(e):
+    """
+    Checks if error e pertains to a connection issue
+    """
+    return (isinstance(e, err.InterfaceError) and e.args[0] == "(0, '')") or\
+        (isinstance(e, err.OperationalError) and e.args[0] in operation_error_codes.values())
+
 
 
 class DataJointError(Exception):

--- a/datajoint/jobs.py
+++ b/datajoint/jobs.py
@@ -59,13 +59,6 @@ class JobTable(Table):
         """bypass interactive prompts and dependencies"""
         self.drop_quick()
 
-    @staticmethod
-    def packable_or_none(key):
-        for v in key.values():
-            if isinstance(v, Decimal):
-                return None
-        return key
-
     def reserve(self, table_name, key):
         """
         Reserve a job for computation.  When a job is reserved, the job table contains an entry for the
@@ -81,7 +74,7 @@ class JobTable(Table):
             host=platform.node(),
             pid=os.getpid(),
             connection_id=self.connection.connection_id,
-            key=self.packable_or_none(key),
+            key=key,
             user=self._user)
         try:
             self.insert1(job, ignore_extra_fields=True)
@@ -117,7 +110,7 @@ class JobTable(Table):
                  pid=os.getpid(),
                  connection_id=self.connection.connection_id,
                  user=self._user,
-                 key=self.packable_or_none(key),
+                 key=key,
                  error_message=error_message,
                  error_stack=error_stack),
             replace=True, ignore_extra_fields=True)

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -32,6 +32,7 @@ default = OrderedDict({
     'database.password': None,
     'database.user': None,
     'database.port': 3306,
+    'database.reconnect': True,
     'connection.init_function': None,
     'connection.charset': '',   # pymysql uses '' as default
     'loglevel': 'INFO',

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -32,7 +32,6 @@ default = OrderedDict({
     'database.password': None,
     'database.user': None,
     'database.port': 3306,
-    'database.reconnect': False,
     'connection.init_function': None,
     'connection.charset': '',   # pymysql uses '' as default
     'loglevel': 'INFO',

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -1,4 +1,6 @@
 import numpy as np
+from decimal import Decimal
+from datetime import datetime
 from datajoint.blob import pack, unpack
 from numpy.testing import assert_array_equal
 from nose.tools import assert_equal, assert_true
@@ -25,6 +27,13 @@ def test_pack():
 
     x = [1, 2, 3, 4]
     assert_array_equal(x, unpack(pack(x.__iter__())), "Iterator did not pack/unpack correctly")
+
+    x = Decimal('1.24')
+    assert_true(float(x) == unpack(pack(x)), "Decimal object did not pack/unpack correctly")
+
+    x = datetime.now()
+    assert_true(str(x) == unpack(pack(x)), "Datetime object did not pack/unpack correctly")
+
 
 
 def test_complex():

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -105,34 +105,3 @@ class TestTransactions:
                      "Length is not 1. Expected because rollback should have happened.")
         assert_equal(len(self.relation & 'subject_id = 2'), 0,
                      "Length is not 0. Expected because rollback should have happened.")
-
-
-
-class TestReconnect:
-    """
-    test reconnection
-    """
-
-    @classmethod
-    def setup(cls):
-        cls.conn = dj.conn(reset=True, **CONN_INFO)
-
-    def test_close(self):
-        assert_true(self.conn.is_connected, "Connection should be alive")
-        self.conn.close()
-        assert_false(self.conn.is_connected, "Connection should now be closed")
-
-
-    def test_reconnect(self):
-        assert_true(self.conn.is_connected, "Connection should be alive")
-        self.conn.close()
-        self.conn.query('SHOW DATABASES;', reconnect=True).fetchall()
-        assert_true(self.conn.is_connected, "Connection should be alive")
-
-
-    @raises(DataJointError)
-    def reconnect_throws_error_in_transaction(self):
-        assert_true(self.conn.is_connected, "Connection should be alive")
-        self.conn.close()
-        with self.conn.transaction:
-            self.conn.query('SHOW DATABASES;', reconnect=True).fetchall()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -120,13 +120,13 @@ class TestReconnect:
     def test_close(self):
         assert_true(self.conn.is_connected, "Connection should be alive")
         self.conn.close()
-        assert_false(self.conn_is_connected, "Connection should now be closed")
+        assert_false(self.conn.is_connected, "Connection should now be closed")
 
 
     def test_reconnect(self):
         assert_true(self.conn.is_connected, "Connection should be alive")
         self.conn.close()
-        self.conn.query('SHOW DATABASES;').fetchall()
+        self.conn.query('SHOW DATABASES;', reconnect=True).fetchall()
         assert_true(self.conn.is_connected, "Connection should be alive")
 
 
@@ -135,4 +135,4 @@ class TestReconnect:
         assert_true(self.conn.is_connected, "Connection should be alive")
         self.conn.close()
         with self.conn.transaction:
-            self.conn.query('SHOW DATABASES;').fetchall()
+            self.conn.query('SHOW DATABASES;', reconnect=True).fetchall()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -77,14 +77,6 @@ def test_sigint():
     schema.schema.jobs.delete()
 
 
-def test_key_pack_testing():
-    jobs = schema.schema.jobs
-    key = dict(a='string', b=int, c=Decimal())
-    assert jobs.packable_or_none(key) is None
-    key.pop('c')
-    assert jobs.packable_or_none(key) is not None
-
-
 def test_sigterm():
     # clear out job table
     schema.schema.jobs.delete()

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -15,8 +15,9 @@ class TestReconnect:
     test reconnection
     """
 
-    def setup(self):
-        self.conn = dj.conn(reset=True, **CONN_INFO)
+    @classmethod
+    def setup_class(cls):
+        cls.conn = dj.conn(reset=True, **CONN_INFO)
 
     def test_close(self):
         assert_true(self.conn.is_connected, "Connection should be alive")

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -32,7 +32,7 @@ class TestReconnect:
 
 
     @raises(DataJointError)
-    def reconnect_throws_error_in_transaction(self):
+    def test_reconnect_throws_error_in_transaction(self):
         assert_true(self.conn.is_connected, "Connection should be alive")
         self.conn.close()
         with self.conn.transaction:

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -15,9 +15,8 @@ class TestReconnect:
     test reconnection
     """
 
-    @classmethod
-    def setup_class(cls):
-        cls.conn = dj.conn(reset=True, **CONN_INFO)
+    def setup(self):
+        self.conn = dj.conn(reset=True, **CONN_INFO)
 
     def test_close(self):
         assert_true(self.conn.is_connected, "Connection should be alive")

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -16,10 +16,10 @@ class TestReconnect:
     """
 
     def setup(self):
-        print("Setup was invoked")
+        self.conn = dj.conn(reset=True, **CONN_INFO)
+
 
     def test_close(self):
-        self.conn = dj.conn(reset=True, **CONN_INFO)
         assert_true(self.conn.is_connected, "Connection should be alive")
         self.conn.close()
         assert_false(self.conn.is_connected, "Connection should now be closed")

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -1,0 +1,40 @@
+"""
+Collection of test cases to test connection module.
+"""
+
+from nose.tools import assert_true, assert_false, assert_equal, raises
+import datajoint as dj
+import numpy as np
+from datajoint import DataJointError
+from . import CONN_INFO, PREFIX
+
+
+
+class TestReconnect:
+    """
+    test reconnection
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.conn = dj.conn(reset=True, **CONN_INFO)
+
+    def test_close(self):
+        assert_true(self.conn.is_connected, "Connection should be alive")
+        self.conn.close()
+        assert_false(self.conn.is_connected, "Connection should now be closed")
+
+
+    def test_reconnect(self):
+        assert_true(self.conn.is_connected, "Connection should be alive")
+        self.conn.close()
+        self.conn.query('SHOW DATABASES;', reconnect=True).fetchall()
+        assert_true(self.conn.is_connected, "Connection should be alive")
+
+
+    @raises(DataJointError)
+    def reconnect_throws_error_in_transaction(self):
+        assert_true(self.conn.is_connected, "Connection should be alive")
+        self.conn.close()
+        with self.conn.transaction:
+            self.conn.query('SHOW DATABASES;', reconnect=True).fetchall()

--- a/tests/test_reconnection.py
+++ b/tests/test_reconnection.py
@@ -15,11 +15,11 @@ class TestReconnect:
     test reconnection
     """
 
-    @classmethod
-    def setup_class(cls):
-        cls.conn = dj.conn(reset=True, **CONN_INFO)
+    def setup(self):
+        print("Setup was invoked")
 
     def test_close(self):
+        self.conn = dj.conn(reset=True, **CONN_INFO)
         assert_true(self.conn.is_connected, "Connection should be alive")
         self.conn.close()
         assert_false(self.conn.is_connected, "Connection should now be closed")
@@ -35,6 +35,6 @@ class TestReconnect:
     @raises(DataJointError)
     def test_reconnect_throws_error_in_transaction(self):
         assert_true(self.conn.is_connected, "Connection should be alive")
-        self.conn.close()
         with self.conn.transaction:
+            self.conn.close()
             self.conn.query('SHOW DATABASES;', reconnect=True).fetchall()


### PR DESCRIPTION
* Fix #279 - Connection to the database is automatically recovered. If the connection was in a transaction, this triggers a `DataJointError`
* Fix #428 and #519 - Packing of `Decimal` and `Datetime` objects into a blob is now supported by converting them into supported datatypes of float and string, respectively.