### PR TITLE
Fix #544: Accept all aliases for supported datatypes. 

### DIFF
--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -272,7 +272,7 @@ def compile_attribute(line, in_key, foreign_key_sql):
     match = {k: v.strip() for k, v in match.items()}
     match['nullable'] = match['default'].lower() == 'null'
     acceptable_datatype_pattern = r'^(time|date|year|enum|(var)?char|float|real|double|decimal|numeric|' \
-                                  r'(tiny|small|medium|big)?int|bool?|' \
+                                  r'(tiny|small|medium|big)?int|bool|' \
                                   r'(tiny|small|medium|long)?blob|external|attach)'
     if re.match(acceptable_datatype_pattern, match['type']) is None:
         raise DataJointError('DataJoint does not support datatype "{type}"'.format(**match))

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -272,7 +272,7 @@ def compile_attribute(line, in_key, foreign_key_sql):
     match = {k: v.strip() for k, v in match.items()}
     match['nullable'] = match['default'].lower() == 'null'
     acceptable_datatype_pattern = r'^(time|date|year|enum|(var)?char|float|real|double|decimal|numeric|' \
-                                  r'(tiny|small|medium|big)?int|bool(ean)?|' \
+                                  r'(tiny|small|medium|big)?int|bool?|' \
                                   r'(tiny|small|medium|long)?blob|external|attach)'
     if re.match(acceptable_datatype_pattern, match['type']) is None:
         raise DataJointError('DataJoint does not support datatype "{type}"'.format(**match))

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -271,7 +271,7 @@ def compile_attribute(line, in_key, foreign_key_sql):
         match['default'] = ''
     match = {k: v.strip() for k, v in match.items()}
     match['nullable'] = match['default'].lower() == 'null'
-    acceptable_datatype_pattern = r'^(time|date|year|enum|(var)?char|float|double|decimal|' \
+    acceptable_datatype_pattern = r'^(time|date|year|enum|(var)?char|float|real|double|decimal|numeric|' \
                                   r'(tiny|small|medium|big)?int|bool(ean)?|' \
                                   r'(tiny|small|medium|long)?blob|external|attach)'
     if re.match(acceptable_datatype_pattern, match['type']) is None:


### PR DESCRIPTION
`bool`, `boolean`, `real`, and `numeric` are not independent datatypes but are aliases for other data types.   `declare` now accepts them.