### PR TITLE
datajoint/table.py: add 'see allow_direct_insert' to direct_insert error message

### DIFF
--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -170,7 +170,7 @@ class Table(QueryExpression):
         # prohibit direct inserts into auto-populated tables
         if not (allow_direct_insert or getattr(self, '_allow_insert', True)):  # _allow_insert is only present in AutoPopulate
             raise DataJointError(
-                'Auto-populate tables can only be inserted into from their make methods during populate calls.')
+                'Auto-populate tables can only be inserted into from their make methods during populate calls. (see allow_direct_insert)')
 
         heading = self.heading
         if inspect.isclass(rows) and issubclass(rows, QueryExpression):   # instantiate if a class


### PR DESCRIPTION
Add clarification about how to override the direct_insert restriction.

... not sure on precise text since the idea of adding this flag was to protect data purity 
& don't want to encourage blind usage, but at the same time, pointers might be useful..