### PR TITLE
fix #562: implement UUID support

### DIFF
--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -12,6 +12,7 @@ from .errors import DataJointError
 STORE_NAME_LENGTH = 8
 STORE_HASH_LENGTH = 43
 HASH_DATA_TYPE = 'char(51)'
+UUID_DATA_TYPE = 'binary(16)'
 MAX_TABLE_NAME_LENGTH = 64
 
 logger = logging.getLogger(__name__)
@@ -272,7 +273,7 @@ def compile_attribute(line, in_key, foreign_key_sql):
     match['nullable'] = match['default'].lower() == 'null'
     blob_datatype = r'(tiny|small|medium|long)?blob'
     accepted_datatype = (
-        r'time|date|year|enum|(var)?char|float|real|double|decimal|numeric|'
+        r'time|date|year|enum|(var)?char|float|real|double|decimal|numeric|uuid|'
         r'(tiny|small|medium|big)?int|bool|external|attach|' + blob_datatype)
     if re.match(accepted_datatype, match['type'], re.I) is None:
         raise DataJointError('DataJoint does not support datatype "{type}"'.format(**match))
@@ -289,6 +290,9 @@ def compile_attribute(line, in_key, foreign_key_sql):
         else:
             match['default'] = 'NOT NULL'
     match['comment'] = match['comment'].replace('"', '\\"')   # escape double quotes in comment
+    if match['type'] == 'uuid':
+        match['comment'] = ':{type}:{comment}'.format(**match)
+        match['type'] = UUID_DATA_TYPE
     is_configurable = match['type'].startswith(('external', 'blob-', 'attach'))
     is_external = False
     if is_configurable:

--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -8,6 +8,7 @@ import datetime
 import decimal
 import pandas
 import uuid
+import binascii   # for Python 3.4 compatibility
 from .settings import config
 from .errors import DataJointError
 from .fetch import Fetch, Fetch1
@@ -123,7 +124,7 @@ class QueryExpression:
         """
         def prep_value(v):
             """prepare value v for inclusion as a string in an SQL condition"""
-            return "X'%s'" % bytes.hex(v.bytes) if isinstance(v, uuid.UUID) else '%r' % (
+            return "X'%s'" % binascii.hexlify(v.bytes).decode() if isinstance(v, uuid.UUID) else '%r' % (
                     str(v) if isinstance(v, (datetime.date, datetime.datetime, datetime.time, decimal.Decimal)) else v)
 
         negate = False

--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -123,7 +123,7 @@ class QueryExpression:
         """
         def prep_value(v):
             """prepare value v for inclusion as a string in an SQL condition"""
-            return "X'%s'" % v.bytes.hex() if isinstance(v, uuid.UUID) else '%r' % (
+            return "X'%s'" % bytes.hex(v.bytes) if isinstance(v, uuid.UUID) else '%r' % (
                     str(v) if isinstance(v, (datetime.date, datetime.datetime, datetime.time, decimal.Decimal)) else v)
 
         negate = False

--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+import sys
 from functools import partial
 import warnings
 import pandas
@@ -8,6 +8,11 @@ import uuid
 from . import blob, attach
 from .errors import DataJointError
 from .settings import config
+if sys.version_info[1] < 6:
+    from collections import OrderedDict
+else:
+    # use dict in Python 3.6+ -- They are already ordered and look nicer
+    OrderedDict = dict
 
 
 class key:

--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -26,8 +26,9 @@ class key:
 def is_key(attr):
     return attr is key or attr == 'KEY'
 
+
 def is_key_array(attr):
-    return isinstance(attr, str) and attr == "KEY"
+    return isinstance(attr, str) and attr == "KEY_ARRAY"
 
 
 def to_dicts(recarray):
@@ -144,7 +145,7 @@ class Fetch:
                 if format == "frame":
                     ret = pandas.DataFrame(ret).set_index(heading.primary_key)
         else:  # if list of attributes provided
-            attributes = [a for a in attrs if not is_key(a)]
+            attributes = [a for a in attrs if not is_key(a) and not is_key_array(a)]
             result = self._expression.proj(*attributes).fetch(
                 offset=offset, limit=limit, order_by=order_by,
                 as_dict=False, squeeze=squeeze, download_path=download_path)
@@ -193,7 +194,7 @@ class Fetch1:
                                           squeeze=squeeze, download_path=download_path))
                               for name in heading.names)
         else:  # fetch some attributes, return as tuple
-            attributes = [a for a in attrs if not is_key(a)]
+            attributes = [a for a in attrs if not is_key(a) and not is_key_array(a)]
             result = self._expression.proj(*attributes).fetch(squeeze=squeeze, download_path=download_path)
             if len(result) != 1:
                 raise DataJointError('fetch1 should only return one tuple. %d tuples were found' % len(result))

--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -26,6 +26,9 @@ class key:
 def is_key(attr):
     return attr is key or attr == 'KEY'
 
+def is_key_array(attr):
+    return isinstance(attr, str) and attr == "KEY"
+
 
 def to_dicts(recarray):
     """convert record array to a dictionaries"""
@@ -146,8 +149,8 @@ class Fetch:
                 offset=offset, limit=limit, order_by=order_by,
                 as_dict=False, squeeze=squeeze, download_path=download_path)
             return_values = [
-                list(to_dicts(result[self._expression.primary_key]))
-                if is_key(attribute) else result[attribute]
+                list(to_dicts(result[self._expression.primary_key])) if is_key(attribute) else (
+                    result[self._expression.primary_key] if is_key_array(attribute) else result[attribute])
                 for attribute in attrs]
             ret = return_values[0] if len(attrs) == 1 else return_values
 
@@ -195,8 +198,8 @@ class Fetch1:
             if len(result) != 1:
                 raise DataJointError('fetch1 should only return one tuple. %d tuples were found' % len(result))
             return_values = tuple(
-                next(to_dicts(result[self._expression.primary_key]))
-                if is_key(attribute) else result[attribute][0]
+                next(to_dicts(result[self._expression.primary_key])) if is_key(attribute) else (
+                    result[self._expression.primary_key][0] if is_key_array(attribute) else result[attribute][0])
                 for attribute in attrs)
             ret = return_values[0] if len(attrs) == 1 else return_values
 

--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -4,6 +4,7 @@ import warnings
 import pandas
 import re
 import numpy as np
+import uuid
 from . import blob, attach
 from .errors import DataJointError
 from .settings import config
@@ -38,7 +39,8 @@ def _get(connection, attr, data, squeeze, download_path):
     """
     if attr.is_external:
         data = connection.schemas[attr.database].external_table.get(data)
-    return (blob.unpack(data, squeeze=squeeze) if attr.is_blob else
+    return (uuid.UUID(bytes=data) if attr.uuid else
+            blob.unpack(data, squeeze=squeeze) if attr.is_blob else
             attach.save(data, download_path) if attr.is_attachment else data)
 
 
@@ -172,7 +174,6 @@ class Fetch1:
         :param download_path: for fetches that download data, e.g. attachments
         :return: the one tuple in the relation in the form of a dict
         """
-
         heading = self._expression.heading
 
         if not attrs:  # fetch all attributes, return as ordered dict

--- a/datajoint/heading.py
+++ b/datajoint/heading.py
@@ -1,9 +1,16 @@
 import numpy as np
-from collections import namedtuple, OrderedDict, defaultdict
+from collections import namedtuple, defaultdict
 from itertools import chain
 import re
 import logging
 from .errors import DataJointError
+import sys
+if sys.version_info[1] < 6:
+    from collections import OrderedDict
+else:
+    # use dict in Python 3.6+ -- They are already ordered and look nicer
+    OrderedDict = dict
+
 
 logger = logging.getLogger(__name__)
 
@@ -198,7 +205,10 @@ class Heading:
             # recognize configurable fields
             configurable_field = re.match(
                 r'^:(?P<type>(blob|external|attach|uuid)(-\w*)?):(?P<comment>.*)$', attr['comment'])
-            attr['uuid'] = configurable_field and configurable_field.group('type') == 'uuid'
+            if configurable_field:
+                attr['type'] = configurable_field.group('type')
+                attr['comment'] = configurable_field.group('comment')
+            attr['uuid'] = attr['type'] == 'uuid'
             if attr['uuid'] or configurable_field is None:
                 attr['is_external'] = False
                 attr['is_attachment'] = False
@@ -206,9 +216,7 @@ class Heading:
                 # configurable fields: blob- and attach
                 if attr['in_key']:
                     raise DataJointError('Configurable store attributes are not allowed in the primary key')
-                attr['comment'] = configurable_field.group('comment')
                 attr['is_external'] = not attr['is_blob']
-                attr['type'] = configurable_field.group('type')
                 attr['is_attachment'] = attr['type'].startswith('attach')
                 attr['is_blob'] = attr['type'].startswith(('blob', 'external'))
                 attr['string'] = False

--- a/datajoint/heading.py
+++ b/datajoint/heading.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 default_attribute_properties = dict(    # these default values are set in computed attributes
     name=None, type='expression', in_key=False, nullable=False, default=None, comment='calculated attribute',
-    autoincrement=False, numeric=None, string=None, is_blob=False, is_attachment=False, is_external=False,
+    autoincrement=False, numeric=None, string=None, uuid=False, is_blob=False, is_attachment=False, is_external=False,
     unsupported=False, sql_expression=None, database=None, dtype=object)
 
 
@@ -197,8 +197,9 @@ class Heading:
 
             # recognize configurable fields
             configurable_field = re.match(
-                r'^:(?P<type>(blob|external|attach)(-\w*)?):(?P<comment>.*)$', attr['comment'])
-            if configurable_field is None:
+                r'^:(?P<type>(blob|external|attach|uuid)(-\w*)?):(?P<comment>.*)$', attr['comment'])
+            attr['uuid'] = configurable_field and configurable_field.group('type') == 'uuid'
+            if attr['uuid'] or configurable_field is None:
                 attr['is_external'] = False
                 attr['is_attachment'] = False
             else:

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas
 import pymysql
 import logging
-import warnings
+import uuid
 from pymysql import OperationalError, InternalError, IntegrityError
 from .settings import config
 from .declare import declare
@@ -170,7 +170,7 @@ class Table(QueryExpression):
         # prohibit direct inserts into auto-populated tables
         if not (allow_direct_insert or getattr(self, '_allow_insert', True)):  # _allow_insert is only present in AutoPopulate
             raise DataJointError(
-                'Auto-populate tables can only be inserted into from their make methods during populate calls.' \
+                'Auto-populate tables can only be inserted into from their make methods during populate calls.'
                 ' To override, use the the allow_direct_insert argument.')
 
         heading = self.heading
@@ -181,7 +181,7 @@ class Table(QueryExpression):
             if not ignore_extra_fields:
                 try:
                     raise DataJointError(
-                        "Attribute %s not found.  To ignore extra attributes in insert, set ignore_extra_fields=True." %
+                        "Attribute %s not found. To ignore extra attributes in insert, set ignore_extra_fields=True." %
                         next(name for name in rows.heading if name not in heading))
                 except StopIteration:
                     pass
@@ -224,7 +224,11 @@ class Table(QueryExpression):
                     placeholder, value = 'DEFAULT', None
                 else:
                     placeholder = '%s'
-                    if attr.is_blob:
+                    if attr.uuid:
+                        if not isinstance(value, uuid.UUID):
+                            raise DataJointError('The value of atttribute %s must be of type UUID' % attr)
+                        value = value.bytes
+                    elif attr.is_blob:
                         value = blob.pack(value)
                         value = self.external_table.put(attr.type, value) if attr.is_external else value
                     elif attr.is_attachment:

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -511,9 +511,8 @@ class Table(QueryExpression):
                             attributes_declared.update(fk_props['attr_map'])
             if do_include:
                 attributes_declared.add(attr.name)
-                name = attr.name.lstrip('_')  # for external
                 definition += '%-20s : %-28s %s\n' % (
-                    name if attr.default is None else '%s=%s' % (name, attr.default),
+                    attr.name if attr.default is None else '%s=%s' % (attr.name, attr.default),
                     '%s%s' % (attr.type, ' auto_increment' if attr.autoincrement else ''),
                     '# ' + attr.comment if attr.comment else '')
         # add remaining indexes

--- a/datajoint/version.py
+++ b/datajoint/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.dev"
+__version__ = "0.12.dev1"

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -285,3 +285,12 @@ class IndexRich(dj.Manual):
     value : int
     index (first_date, value)
     """
+
+
+@schema
+class Item(dj.Manual):
+    definition = """
+    item : uuid
+    ---
+    number : int
+    """

--- a/tests/test_blob2.py
+++ b/tests/test_blob2.py
@@ -21,7 +21,7 @@ def insert_blobs():
     """
     This function inserts blobs resulting from the following datajoint-matlab code:
 
-            self.insert({
+        self.insert({
              1  'simple string'    'character string'
              2  '1D vector'        1:15:180
              3  'string array'     {'string1'  'string2'}

--- a/tests/test_foreign_keys.py
+++ b/tests/test_foreign_keys.py
@@ -1,6 +1,5 @@
 from nose.tools import assert_equal, assert_false, assert_true, raises
 from datajoint.declare import declare
-from datajoint import DataJointError
 
 from . import schema_advanced
 

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -9,5 +9,6 @@ def test_uuid():
     Item().insert1(dict(item=u, number=n))
     Item().insert(zip(map(uuid.uuid1, range(20)), count()))
     keys = Item().fetch('KEY')
+    keys_array = Item().fetch('KEY_ARRAY')
     number = (Item() & {'item': u}).fetch1('number')
     assert_equal(number, n)

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -1,0 +1,13 @@
+from nose.tools import assert_equal
+import uuid
+from .schema import Item
+from itertools import count
+
+
+def test_uuid():
+    u, n = uuid.uuid4(), -1
+    Item().insert1(dict(item=u, number=n))
+    Item().insert(zip(map(uuid.uuid1, range(20)), count()))
+    keys = Item().fetch('KEY')
+    number = (Item() & {'item': u}).fetch1('number')
+    assert_equal(number, n)

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -8,7 +8,9 @@ def test_uuid():
     u, n = uuid.uuid4(), -1
     Item().insert1(dict(item=u, number=n))
     Item().insert(zip(map(uuid.uuid1, range(20)), count()))
-    keys = Item().fetch('KEY')
-    keys_array = Item().fetch('KEY_ARRAY')
+    keys, key_array = Item().fetch('KEY', 'KEY_ARRAY')
+    assert_equal(keys[0]['item'], key_array['item'][0])
     number = (Item() & {'item': u}).fetch1('number')
     assert_equal(number, n)
+    item = (Item & {'number': n}).fetch1('item')
+    assert_equal(u, item)


### PR DESCRIPTION
* Fix #562: It is now possible to declare attributes of type `uuid` which will be translated into `binary16`. The values are inserted and fetched as type `uuid.UUID`.
* Fix #414: `expr.fetch('KEY_ARRAY')` retrieves primary key as record array.