### PR TITLE
fix foreign keys with UUID-based foreign keys

### DIFF
--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -3,6 +3,7 @@ import logging
 import datetime
 import traceback
 import random
+import inspect
 from tqdm import tqdm
 from pymysql import OperationalError
 from .expression import QueryExpression, AndList, U
@@ -84,6 +85,11 @@ class AutoPopulate:
             raise DataJointError('Cannot call populate on a restricted table. '
                                  'Instead, pass conditions to populate() as arguments.')
         todo = self.key_source
+
+        # key_source is a QueryExpression subclass -- trigger instantiation
+        if inspect.isclass(todo) and issubclass(todo, QueryExpression):
+            todo = todo()
+
         if not isinstance(todo, QueryExpression):
             raise DataJointError('Invalid key_source value')
         # check if target lacks any attributes from the primary key of key_source

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -208,6 +208,8 @@ def declare(full_table_name, definition, context):
     definition = re.split(r'\s*\n\s*', definition.strip())
     # check for optional table comment
     table_comment = definition.pop(0)[1:].strip() if definition[0].startswith('#') else ''
+    if table_comment.startswith(':'):
+        raise DataJointError('Table comment must not start with a colon ":"')
     in_key = True  # parse primary keys
     primary_key = []
     attributes = []

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -224,12 +224,13 @@ class Table(QueryExpression):
                     return None
                 attr = heading[name]
                 if value is None or (attr.numeric and (value == '' or np.isnan(np.float(value)))):
+                    # set default value
                     placeholder, value = 'DEFAULT', None
-                else:
+                else:  # not NULL
                     placeholder = '%s'
                     if attr.uuid:
                         if not isinstance(value, uuid.UUID):
-                            raise DataJointError('The value of atttribute %s must be of type UUID' % attr)
+                            raise DataJointError('The value of attribute `%s` must be of type UUID' % attr.name)
                         value = value.bytes
                     elif attr.is_blob:
                         value = blob.pack(value)

--- a/datajoint/version.py
+++ b/datajoint/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.12.dev1"
+__version__ = "0.12.dev2"

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -287,10 +287,3 @@ class IndexRich(dj.Manual):
     """
 
 
-@schema
-class Item(dj.Manual):
-    definition = """
-    item : uuid
-    ---
-    number : int
-    """

--- a/tests/schema_uuid.py
+++ b/tests/schema_uuid.py
@@ -1,0 +1,46 @@
+import uuid
+import datajoint as dj
+from . import PREFIX, CONN_INFO
+
+schema = dj.schema(PREFIX + '_test1', connection=dj.conn(**CONN_INFO))
+
+top_level_namespace_id = uuid.UUID('00000000-0000-0000-0000-000000000000')
+
+
+@schema
+class Basic(dj.Manual):
+    definition = """
+    item : uuid
+    ---
+    number : int
+    """
+
+
+@schema
+class Topic(dj.Manual):
+    definition = """
+    # A topic for items
+    topic_id : uuid   # internal identification of a topic, reflects topic name
+    ---
+    topic : varchar(8000)   # full topic name used to generate the topic id
+    """
+
+    def add(self, topic):
+        """add a new topic with a its UUID"""
+        self.insert1(dict(topic_id=uuid.uuid5(top_level_namespace_id, topic), topic=topic))
+
+
+@schema
+class Item(dj.Computed):
+    definition = """
+    item_id : uuid  # internal identification of 
+    ---
+    -> Topic 
+    word : varchar(8000)
+    """
+
+    key_source = Topic    # test key source that is not instantiated
+
+    def make(self, key):
+        for word in ('Habenula', 'Hippocampus', 'Hypothalamus', 'Hypophysis'):
+            self.insert1(dict(key, word=word, item_id=uuid.uuid5(key['topic_id'], word)))

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -1,16 +1,34 @@
-from nose.tools import assert_equal
+from nose.tools import assert_true, assert_equal, raises
 import uuid
-from .schema import Item
+from .schema_uuid import Basic, Item, Topic
+from datajoint import DataJointError
 from itertools import count
 
 
 def test_uuid():
+    """test inserting and fetching of UUID attributes and restricting by UUID attributes"""
     u, n = uuid.uuid4(), -1
-    Item().insert1(dict(item=u, number=n))
-    Item().insert(zip(map(uuid.uuid1, range(20)), count()))
-    keys, key_array = Item().fetch('KEY', 'KEY_ARRAY')
+    Basic().insert1(dict(item=u, number=n))
+    Basic().insert(zip(map(uuid.uuid1, range(20)), count()))
+    keys, key_array = Basic().fetch('KEY', 'KEY_ARRAY')
     assert_equal(keys[0]['item'], key_array['item'][0])
-    number = (Item() & {'item': u}).fetch1('number')
+    number = (Basic() & {'item': u}).fetch1('number')
     assert_equal(number, n)
-    item = (Item & {'number': n}).fetch1('item')
+    item = (Basic & {'number': n}).fetch1('item')
     assert_equal(u, item)
+
+
+@raises(DataJointError)
+def test_invalid_uuid_type():
+    """test that only UUID objects are accepted when inserting UUID fields"""
+    Basic().insert(dict(item='00000000-0000-0000-0000-000000000000', number=0))
+
+
+def test_uuid_dependencies():
+    """
+    :return:
+    """
+    for word in ('Neuroscience', 'Knowledge', 'Curiosity', 'Inspiration', 'Science', 'Philosophy', 'Conscience'):
+        Topic().add(word)
+    Item.populate()
+    assert_equal(Item().progress(), (0, len(Topic())))


### PR DESCRIPTION
This fixes the bug in the previous release that prevented using UUID attributes in foreign keys.