### PR TITLE
Keyarray

### DIFF
--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -106,15 +106,11 @@ class Fetch:
 
         # as_dict defaults to False for fetch() and to True for fetch('KEY', ...)
         if as_dict is None:
-            as_dict = not bool(attrs)
-        if attrs:
-            raise DataJointError('Cannot specify attributes to return when as_dict=True. '
-                                 'Use proj() to select attributes or set as_dict=False')
+            as_dict = bool(attrs)
         # format should not be specified with attrs or is_dict=True
         if format is not None and (as_dict or attrs):
             raise DataJointError('Cannot specify output format when as_dict=True or '
                                  'when attributes are selected to be fetched separately.')
-
         if format not in {None, "array", "frame"}:
             raise DataJointError('Fetch output format must be in {{"array", "frame"}} but "{}" was given'.format(format))
 

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -10,8 +10,6 @@ def test_uuid():
     u, n = uuid.uuid4(), -1
     Basic().insert1(dict(item=u, number=n))
     Basic().insert(zip(map(uuid.uuid1, range(20)), count()))
-    keys, key_array = Basic().fetch('KEY', 'KEY_ARRAY')
-    assert_equal(keys[0]['item'], key_array['item'][0])
     number = (Basic() & {'item': u}).fetch1('number')
     assert_equal(number, n)
     item = (Basic & {'number': n}).fetch1('item')


### PR DESCRIPTION
* Fix #414  `expr.fetch('KEY', as_dict=False)`  returns 'KEY' as a recarray

In the `as_dict` argument in `fetch` now defaults to `None`, which tells to assume the default behavior. The default behavior for `fetch()` is `as_dict=False` whereas the default behavior for `fetch("KEY")` is `as_dict=True`. 