### PR TITLE
Fix #499: Proj accepts Ellipsis ... and '-attr' to exclude attributes

### DIFF
--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -701,7 +701,7 @@ class Projection(QueryExpression):
         # clean up renamed attributes
         named_attributes = {k: v.strip() for k, v in named_attributes.items()}
         # process Ellipsis
-        excluded_attributes = set(a.lstrip('-') for a in attributes if a.startswith('-'))
+        excluded_attributes = set(a.lstrip('-').strip() for a in attributes if a.startswith('-'))
         if has_ellipsis:
             included_already = set(named_attributes.values())
             attributes = [a for a in arg.heading.secondary_attributes if a not in included_already]
@@ -718,7 +718,6 @@ class Projection(QueryExpression):
         :param include_primary_key:  True if the primary key must be included even if it's not in attributes.
         :return: the resulting Projection object
         """
-
         obj = cls()
         obj._connection = arg.connection
 

--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -691,28 +691,28 @@ class Projection(QueryExpression):
     @staticmethod
     def prepare_attribute_lists(arg, attributes, named_attributes):
         # check that all attributes are strings
+        has_ellipsis = Ellipsis in attributes
+        attributes = [a for a in attributes if a is not Ellipsis]
         try:
             raise DataJointError("Attribute names must be strings or ..., got %s" % next(
-                type(a) for a in attributes if a is not Ellipsis and not isinstance(a, str)))
+                type(a) for a in attributes if not isinstance(a, str)))
         except StopIteration:
             pass
         # clean up renamed attributes
         named_attributes = {k: v.strip() for k, v in named_attributes.items()}
         # process Ellipsis
-        if Ellipsis in attributes:
-            included_already = set(attributes).union(named_attributes.values())
-            attributes = list(attributes) + [
-                a for a in arg.heading.secondary_attributes
-                if a not in included_already and a is not Ellipsis]
-        # process excluded attributes
         excluded_attributes = set(a.lstrip('-') for a in attributes if a.startswith('-'))
+        if has_ellipsis:
+            included_already = set(named_attributes.values())
+            attributes = [a for a in arg.heading.secondary_attributes if a not in included_already]
+        # process excluded attributes
         attributes = [a for a in attributes if a not in excluded_attributes]
         return attributes, named_attributes
 
     @classmethod
     def create(cls, arg, attributes, named_attributes, include_primary_key=True):
         """
-        :param arg: The QueryExression to be projected
+        :param arg: The QueryExpression to be projected
         :param attributes:  attributes to select
         :param named_attributes:  new attributes to create by renaming or computing
         :param include_primary_key:  True if the primary key must be included even if it's not in attributes.

--- a/datajoint/heading.py
+++ b/datajoint/heading.py
@@ -87,7 +87,7 @@ class Heading:
         return [k for k, v in self.attributes.items() if v.in_key]
 
     @property
-    def dependent_attributes(self):
+    def secondary_attributes(self):
         return [k for k, v in self.attributes.items() if not v.in_key]
 
     @property
@@ -308,8 +308,8 @@ class Heading:
         return Heading(
             [self.attributes[name].todict() for name in self.primary_key] +
             [other.attributes[name].todict() for name in other.primary_key if name not in self.primary_key] +
-            [self.attributes[name].todict() for name in self.dependent_attributes if name not in other.primary_key] +
-            [other.attributes[name].todict() for name in other.dependent_attributes if name not in self.primary_key])
+            [self.attributes[name].todict() for name in self.secondary_attributes if name not in other.primary_key] +
+            [other.attributes[name].todict() for name in other.secondary_attributes if name not in self.primary_key])
 
     def make_subquery_heading(self):
         """

--- a/tests/test_relational_operand.py
+++ b/tests/test_relational_operand.py
@@ -346,6 +346,12 @@ class TestRelational:
                     "Join of projected relations does not work")
 
     @staticmethod
+    def test_ellipsis():
+        r = Experiment.proj(..., '-data_path').head(1, as_dict=True)
+        assert_set_equal(set.difference(Experiment.heading.names, r), {'data_path'})
+
+
+    @staticmethod
     @raises(dj.DataJointError)
     def test_update_single_key():
         """Test that only one row can be updated"""

--- a/tests/test_relational_operand.py
+++ b/tests/test_relational_operand.py
@@ -348,8 +348,7 @@ class TestRelational:
     @staticmethod
     def test_ellipsis():
         r = Experiment.proj(..., '-data_path').head(1, as_dict=True)
-        assert_set_equal(set.difference(Experiment.heading.names, r), {'data_path'})
-
+        assert_set_equal(set(Experiment.heading).difference(r[0]), {'data_path'})
 
     @staticmethod
     @raises(dj.DataJointError)

--- a/tests/test_relational_operand.py
+++ b/tests/test_relational_operand.py
@@ -347,7 +347,7 @@ class TestRelational:
 
     @staticmethod
     def test_ellipsis():
-        r = Experiment.proj(..., '-data_path').head(1, as_dict=True)
+        r = Experiment.proj(..., '- data_path').head(1, as_dict=True)
         assert_set_equal(set(Experiment.heading).difference(r[0]), {'data_path'})
 
     @staticmethod

--- a/tests/test_schema_keywords.py
+++ b/tests/test_schema_keywords.py
@@ -44,6 +44,3 @@ def test_inherited_part_table():
     assert_true('a_id' in D.C().heading.attributes)
     assert_true('b_id' in D.C().heading.attributes)
     assert_true('name' in D.C().heading.attributes)
-
-
-


### PR DESCRIPTION
Fix #499  to allow Ellipsis in `proj` and `aggr`

You may now do something like:
```python
q = Person.proj(..., '-date_of_birth')  # all attributes except the date of birth
```

Review after merging #569