### PR TITLE
add blob.encode_bypass setting to facillitate clean round-trip fetch/insert

### DIFF
--- a/datajoint/blob.py
+++ b/datajoint/blob.py
@@ -8,6 +8,8 @@ from decimal import Decimal
 from datetime import datetime
 import numpy as np
 from .errors import DataJointError
+from .settings import config
+
 
 mxClassID = OrderedDict((
     # see http://www.mathworks.com/help/techdoc/apiref/mxclassid.html
@@ -210,6 +212,9 @@ class BlobReader:
 
 
 def pack(obj, compress=True):
+    if config['blob.encode_bypass'] is True:
+        return obj
+
     blob = b"mYm\0"
     blob += pack_obj(obj)
 
@@ -300,8 +305,11 @@ def pack_dict(obj):
 
 
 def unpack(blob, **kwargs):
+
+    if config['blob.encode_bypass'] is True:
+        return blob
+
     if blob is None:
         return None
 
     return BlobReader(blob, **kwargs).unpack()
-

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -40,7 +40,8 @@ default = OrderedDict({
     'fetch_format': 'array',
     'display.limit': 12,
     'display.width': 14,
-    'display.show_tuple_count': True
+    'display.show_tuple_count': True,
+    'blob.encode_bypass': False
 })
 
 logger = logging.getLogger(__name__)

--- a/tests/test_blob_bypass.py
+++ b/tests/test_blob_bypass.py
@@ -1,0 +1,53 @@
+#! /usr/bin/env python
+
+import os
+
+import datajoint as dj
+import numpy as np
+
+
+schema_in = dj.schema('test_blob_bypass_in')
+schema_out = dj.schema('test_blob_bypass_out')
+
+schema_in.drop(force=True)
+schema_out.drop(force=True)
+
+schema_in = dj.schema('test_blob_bypass_in')
+schema_out = dj.schema('test_blob_bypass_out')
+
+tst_dat = np.array([1, 2, 3])  # test blob; TODO: more complex example
+
+
+@schema_in
+class InputTable(dj.Lookup):
+    definition = """
+    id:                 int
+    ---
+    data:               blob
+    """
+    contents = [(0, tst_dat)]
+
+
+@schema_out
+class OutputTable(dj.Manual):
+    definition = """
+    id:                 int
+    ---
+    data:               blob
+    """
+
+
+
+def test_blob_bypass():
+    dj.config['blob.encode_bypass'] = True
+    OutputTable.insert(InputTable.fetch(as_dict=True))
+    dj.config['blob.encode_bypass'] = False
+
+    ins = InputTable.fetch(as_dict=True)
+    outs = OutputTable.fetch(as_dict=True)
+
+    assert((i[0]['data'] == tst_dat and i[0]['data'] == i[1]['data'])
+           for i in zip(ins, outs))
+
+    schema_in.drop(force=True)
+    schema_out.drop(force=True)


### PR DESCRIPTION
In order to work around issues concerning round-trip blob fetch/insert, add a config setting `blob.encode_bypass` to bypass blob decode/encode serialization.

this is needed if e.g. dict->(insert)->table->(fetch)->recarray->(insert)->table causes unserializable data scenario

(see also: #427/#520)

as a side effect, when using this method for specific case of fetch->insert copying, the process is much faster due to no serialization overhead.
