### PR TITLE
datajoint/fetch.py: teach _get not to call UUID initializer if data is None (fix for #581)

### DIFF
--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -43,7 +43,7 @@ def _get(connection, attr, data, squeeze, download_path):
     :return: unpacked data
     """
     if attr.is_external:
-        data = connection.schemas[attr.database].external[attr.store].get(uuid.UUID(bytes=data))
+        data = connection.schemas[attr.database].external[attr.store].get(uuid.UUID(bytes=data) if data is not None else data)
     return (uuid.UUID(bytes=data) if attr.uuid else
             blob.unpack(data, squeeze=squeeze) if attr.is_blob else
             attach.save(data, download_path) if attr.is_attachment else data)


### PR DESCRIPTION
fix for #581