### PR TITLE
datajoint/expression.py: remove attribute check for #604

### DIFF
--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -793,9 +793,6 @@ class GroupBy(QueryExpression):
         assert_join_compatibility(arg, group)
         obj = cls()
         obj._keep_all_rows = keep_all_rows
-        if not set(group.primary_key) - set(arg.primary_key):
-            raise DataJointError('The primary key of the grouped set must contain '
-                                 'additional attributes besides those in the grouping set.')
         obj._arg = (Join.make_argument_subquery(group) if isinstance(arg, U)
                     else Join.create(arg, group, keep_all_rows=keep_all_rows))
         obj._connection = obj._arg.connection


### PR DESCRIPTION
Fix for #604 - remove attribute check
(provided by @eywalker  / @dimitri-yatsenko )