### PR TITLE
Update Connection.connect() to deal with MYSQL 8.0

### DIFF
--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -96,8 +96,7 @@ class Connection:
                 sql_mode="NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,"
                          "STRICT_ALL_TABLES,NO_ENGINE_SUBSTITUTION",
                 charset=config['connection.charset'],
-                **self.conn_info)
-                
+                **self.conn_info)    
         self._conn.autocommit(True)
 
     def close(self):

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -97,16 +97,7 @@ class Connection:
                          "STRICT_ALL_TABLES,NO_ENGINE_SUBSTITUTION",
                 charset=config['connection.charset'],
                 **self.conn_info)
-
-            # If the database version is older then 8.0, then include 'NO_AUTO_CREATE_USER'
-            if self._conn.server_version < '8.0.0':
-                self.close()
-                self._conn = client.connect(
-                init_command=self.init_fun,
-                sql_mode="NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,"
-                         "STRICT_ALL_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION",
-                charset=config['connection.charset'],
-                **self.conn_info)
+                
         self._conn.autocommit(True)
 
     def close(self):

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -94,6 +94,16 @@ class Connection:
             self._conn = client.connect(
                 init_command=self.init_fun,
                 sql_mode="NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,"
+                         "STRICT_ALL_TABLES,NO_ENGINE_SUBSTITUTION",
+                charset=config['connection.charset'],
+                **self.conn_info)
+
+            # If the database version is older then 8.0, then include 'NO_AUTO_CREATE_USER'
+            if self._conn.server_version > '8.0.0':
+                self.close()
+                self._conn = client.connect(
+                init_command=self.init_fun,
+                sql_mode="NO_ZERO_DATE,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,"
                          "STRICT_ALL_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION",
                 charset=config['connection.charset'],
                 **self.conn_info)

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -99,7 +99,7 @@ class Connection:
                 **self.conn_info)
 
             # If the database version is older then 8.0, then include 'NO_AUTO_CREATE_USER'
-            if self._conn.server_version > '8.0.0':
+            if self._conn.server_version < '8.0.0':
                 self.close()
                 self._conn = client.connect(
                 init_command=self.init_fun,


### PR DESCRIPTION
MySQL Server 8.0 completely removed support for the sql_mode = "NO_AUTO_CREATE_USER" thus causing it to fail.

This code creates a connection first without that mode flag and then checks if the server version is greater then 8.0, if not then close the current connection and reconnect with the flag.

This is due to the fact that in 8.0 they enforce the rule of being unable to create accounts via the GRANT command, which is equivalent to this flag always being on.

https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_auto_create_user

This might not be the cleanest way to this, so I am be happy to hear feed back.