### PR TITLE
Bugfix and optimization of labeling of "distinguished" nodes in diagrams.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Configurable blob storage (#497, #532, #475)
 * Support file attachments: (#480, #532, #475)
+* Support for filepath datatype: (#481, 603)
 * Expand support of blob serialization (fixed #572, #520, #427, #392, #244)
 * Add support for UUID attributes (#562, #567)
 * Support of ellipsis in `proj`:  `query_expression.proj(.., '-movie')` (#499)

--- a/datajoint/dependencies.py
+++ b/datajoint/dependencies.py
@@ -86,8 +86,8 @@ class Dependencies(nx.DiGraph):
             attribute are considered.
         :return: dict of tables referenced by the foreign keys of table
         """
-        return dict(p[::2] for p in self.in_edges(table_name, data=True)
-                    if primary is None or p[2]['primary'] == primary)
+        return {p[0]: p[2] for p in self.in_edges(table_name, data=True)
+                if primary is None or p[2]['primary'] == primary}
 
     def children(self, table_name, primary=None):
         """
@@ -97,8 +97,8 @@ class Dependencies(nx.DiGraph):
             attribute are considered.
         :return: dict of tables referencing the table through foreign keys
         """
-        return dict(p[1:3] for p in self.out_edges(table_name, data=True)
-                    if primary is None or p[2]['primary'] == primary)
+        return {p[1]: p[2] for p in self.out_edges(table_name, data=True)
+                if primary is None or p[2]['primary'] == primary}
 
     def descendants(self, full_table_name):
         """

--- a/datajoint/diagram.py
+++ b/datajoint/diagram.py
@@ -121,17 +121,6 @@ else:
                     if node.startswith('`%s`' % database):
                         self.nodes_to_show.add(node)
 
-            for full_table_name in self.nodes_to_show:
-                #one entry per parent
-                parents = connection.dependencies.parents(full_table_name,True)
-                
-                # all the foreign primary keys
-                # set because multiple foreign constraints can be applied on the same local attribute
-                foreign_primary_attributes = set(attr for parent in parents.values() for attr in parent['attr_map'].keys())
-                
-                #distinguished table if table introduces atleast one primary key in the schema
-                self.nodes._nodes[full_table_name]['distinguished'] = foreign_primary_attributes < self.nodes._nodes[full_table_name]['primary_key']
-                
         @classmethod
         def from_sequence(cls, sequence):
             """
@@ -238,7 +227,11 @@ else:
             """
             Make the self.graph - a graph object ready for drawing
             """
-            # include aliased nodes
+            # mark "distinguished" tables, i.e. those that introduce new primary key attributes
+            for name in self.nodes_to_show:
+                foreign_attributes = set(attr for p in self.in_edges(name, data=True) for attr in p[2]['attr_map'])
+                self.node[name]['distinguished'] = foreign_attributes < self.node[name]['primary_key']
+            # include aliased nodes that are sandwiched between two displayed nodes
             gaps = set(nx.algorithms.boundary.node_boundary(self, self.nodes_to_show)).intersection(
                 nx.algorithms.boundary.node_boundary(nx.DiGraph(self).reverse(), self.nodes_to_show))
             nodes = self.nodes_to_show.union(a for a in gaps if a.isdigit)


### PR DESCRIPTION
Distinguished tables are those that introduce new primary key attributes. They are underlined in the schema diagram. Before this PR, this underlining did not work correctly when the diagram was built by using graph algebra such as `dj.Diagram(table) + 1 - 1`  because the tables were marked as distinguished only in the original diagram. This PR moves the labeling to the point right before plotting, so all tables are checked.