### PR TITLE
Update minimum python versioning checks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,10 @@ from setuptools import setup, find_packages
 from os import path
 import sys
 
-if sys.version_info < (3, 4):
-    sys.exit('DataJoint is only supported on Python 3.4 or higher')
+min_py_version = (3, 4)
+
+if sys.version_info <  min_py_version:
+    sys.exit('DataJoint is only supported on Python {}.{} or higher'.format(*min_py_version))
 
 here = path.abspath(path.dirname(__file__))
 
@@ -29,4 +31,5 @@ setup(
     keywords='database organization',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     install_requires=requirements,
+    python_requires='~={}.{}'.format(*min_py_version)
 )


### PR DESCRIPTION
Use `python_requires` to specify required minimum version. This will make PyPI
aware of the requirement so pip will not try to install it on the wrong version.
I kept the sys.version check in there too as a 'belt-and-suspenders' approach
in case users manage to install it some other way (like with an outdated pip).