### PR TITLE
Enclose attribute names in backquotes in `ExternalTable.delete`

### DIFF
--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -168,7 +168,7 @@ class ExternalTable(Table):
         self.connection.query(
             "DELETE FROM `{db}`.`{tab}` WHERE ".format(tab=self.table_name, db=self.database) + (
                     " AND ".join(
-                        'hash NOT IN (SELECT {column_name} FROM {referencing_table})'.format(**ref)
+                        'hash NOT IN (SELECT `{column_name}` FROM {referencing_table})'.format(**ref)
                         for ref in self.references) or "TRUE"))
         print('Deleted %d items' % self.connection.query("SELECT ROW_COUNT()").fetchone()[0])
 


### PR DESCRIPTION
Before this fix, if an external blob attribute name happened to be a reserved word in MySQL, deleting from the external table would fail with a syntax error. To fix the problem, the attribute name was enclosed in backquotes. 

This issue was discovered in a table that used `signal` as the blob attribute name.