### PR TITLE
blobs can be read from the explicit filepath in the external tables,

### DIFF
--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -75,7 +75,7 @@ def build_foreign_key_parser():
 
 
 def build_attribute_parser():
-    quoted = pp.Or(pp.QuotedString('"'), pp.QuotedString("'"))
+    quoted = pp.QuotedString('"') ^ pp.QuotedString("'")
     colon = pp.Literal(':').suppress()
     attribute_name = pp.Word(pp.srange('[a-z]'), pp.srange('[a-z0-9_]')).setResultsName('name')
     data_type = pp.Combine(pp.Word(pp.alphas) + pp.SkipTo("#", ignore=quoted)).setResultsName('type')

--- a/datajoint/errors.py
+++ b/datajoint/errors.py
@@ -35,3 +35,9 @@ class DuplicateError(DataJointError):
     Error caused by a violation of a unique constraint when inserting data
     """
     pass
+
+
+class MissingExternalFile(DataJointError):
+    """
+    Error raised when an external file managed by DataJoint is no longer accessible
+    """

--- a/datajoint/heading.py
+++ b/datajoint/heading.py
@@ -4,7 +4,7 @@ from itertools import chain
 import re
 import logging
 from .errors import DataJointError
-from .declare import UUID_DATA_TYPE, CUSTOM_TYPES, TYPE_PATTERN, EXTERNAL_TYPES, SERIALIZED_TYPES
+from .declare import UUID_DATA_TYPE, CUSTOM_TYPES, TYPE_PATTERN, EXTERNAL_TYPES
 from .utils import OrderedDict
 
 
@@ -225,11 +225,13 @@ class Heading:
                 try:
                     category = next(c for c in CUSTOM_TYPES if TYPE_PATTERN[c].match(attr['type']))
                 except StopIteration:
+                    if attr['type'].startswith('external'):
+                        raise DataJointError('Legacy datatype `{type}`.'.format(**attr)) from None
                     raise DataJointError('Unknown attribute type `{type}`'.format(**attr)) from None
                 attr.update(
                     is_attachment=category in ('INTERNAL_ATTACH', 'EXTERNAL_ATTACH'),
                     is_filepath=category == 'FILEPATH',
-                    is_blob=category in ('INTERNAL_BLOB', 'EXTERNAL_BLOB'), # INTERNAL_BLOB is not a custom type but is included for completeness
+                    is_blob=category in ('INTERNAL_BLOB', 'EXTERNAL_BLOB'),  # INTERNAL_BLOB is not a custom type but is included for completeness
                     uuid=category == 'UUID',
                     is_external=category in EXTERNAL_TYPES,
                     store=attr['type'].split('@')[1] if category in EXTERNAL_TYPES else None)


### PR DESCRIPTION
enabling compatibility with 0.11

This pull request contains one proposed path for blob migration from version 0.11.* that goes along with the update procedure captured in https://github.com/dimitri-yatsenko/db-programming-with-datajoint/blob/master/notebooks/External-Migration.ipynb