### PR TITLE
requirements.txt: pyparsing<=2.4.0 interim fix for #629

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 pymysql>=0.7.2
-pyparsing
+pyparsing<=2.4.0
 ipython
 pandas
 tqdm


### PR DESCRIPTION
Suggesting to apply this, issue datajoint 0.11.3 for master as solution for #629 
dev not impacted; leaving this for 'proper fix'  