### PR TITLE
Add support for secure S3 connection. Fix #663

### DIFF
--- a/datajoint/s3.py
+++ b/datajoint/s3.py
@@ -13,7 +13,7 @@ class Folder:
     """
     A Folder instance manipulates a flat folder of objects within an S3-compatible object store
     """
-    def __init__(self, endpoint, bucket, access_key, secret_key, secure=False, **_):
+    def __init__(self, endpoint, bucket, access_key, secret_key, *, secure=False, **_):
         self.client = minio.Minio(endpoint, access_key=access_key, secret_key=secret_key, secure=secure)
         self.bucket = bucket
         if not self.client.bucket_exists(bucket):

--- a/datajoint/s3.py
+++ b/datajoint/s3.py
@@ -13,8 +13,8 @@ class Folder:
     """
     A Folder instance manipulates a flat folder of objects within an S3-compatible object store
     """
-    def __init__(self, endpoint, bucket, access_key, secret_key, **_):
-        self.client = minio.Minio(endpoint, access_key=access_key, secret_key=secret_key, secure=False)
+    def __init__(self, endpoint, bucket, access_key, secret_key, secure=False, **_):
+        self.client = minio.Minio(endpoint, access_key=access_key, secret_key=secret_key, secure=secure)
         self.bucket = bucket
         if not self.client.bucket_exists(bucket):
             warnings.warn('Creating bucket "%s"' % self.bucket)

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -137,7 +137,7 @@ class Config(collections.MutableMapping):
         spec['subfolding'] = spec.get('subfolding', DEFAULT_SUBFOLDING)
         spec_keys = {  # REQUIRED in uppercase and allowed in lowercase
             'file': ('PROTOCOL', 'LOCATION', 'subfolding', 'stage'),
-            's3': ('PROTOCOL', 'ENDPOINT', 'BUCKET', 'ACCESS_KEY', 'SECRET_KEY', 'LOCATION', 'subfolding', 'stage')}
+            's3': ('PROTOCOL', 'ENDPOINT', 'BUCKET', 'ACCESS_KEY', 'SECRET_KEY', 'LOCATION', 'secure', 'subfolding', 'stage')}
 
         try:
             spec_keys = spec_keys[spec.get('protocol', '').lower()]
@@ -147,7 +147,7 @@ class Config(collections.MutableMapping):
 
         # check that all required keys are present in spec
         try:
-            raise DataJointError('dj.config["stores"]["{store}" is missing "{k}"'.format(
+            raise DataJointError('dj.config["stores"]["{store}"] is missing "{k}"'.format(
                 store=store, k=next(k.lower() for k in spec_keys if k.isupper() and k.lower() not in spec)))
         except StopIteration:
             pass


### PR DESCRIPTION
Add a new optional configuration for S3 protocol storage called `secure` to control  whether S3 connection should be secure or not. Defaults to `False`, and is configured for each storage separately.

Fix #663 