### PR TITLE
Strip root from external S3 storage on insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release notes
 
+### 0.12.2 -- Nov 8, 2019
+* Bugfix - Insert into external does not trim leading slash if defined in `dj.config['stores']['<store>']['location']` (#692)
+
 ### 0.12.1 -- Nov 2, 2019
 * Bugfix - AttributeAdapter converts into a string (#684)
 

--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -1,4 +1,4 @@
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from collections import Mapping
 from tqdm import tqdm
 from .settings import config
@@ -74,7 +74,12 @@ class ExternalTable(Table):
 
     def _make_external_filepath(self, relative_filepath):
         """resolve the complete external path based on the relative path"""
-        return PurePosixPath(Path(self.spec['location']), relative_filepath)
+        posix_path = PurePosixPath(PureWindowsPath(self.spec['location']))
+        location_path = Path(
+                *posix_path.parts[1:]) if any(
+                    case in posix_path.parts[0] for case in (
+                        '\\', ':')) else Path(posix_path)
+        return PurePosixPath(location_path, relative_filepath)
 
     def _make_uuid_path(self, uuid, suffix=''):
         """create external path based on the uuid hash"""

--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -74,6 +74,7 @@ class ExternalTable(Table):
 
     def _make_external_filepath(self, relative_filepath):
         """resolve the complete external path based on the relative path"""
+        # Strip root
         if self.spec['protocol'] == 's3':
             posix_path = PurePosixPath(PureWindowsPath(self.spec['location']))
             location_path = Path(
@@ -81,6 +82,7 @@ class ExternalTable(Table):
                         case in posix_path.parts[0] for case in (
                             '\\', ':')) else Path(posix_path)
             return PurePosixPath(location_path, relative_filepath)
+        # Preserve root
         elif self.spec['protocol'] == 'file':
             return PurePosixPath(Path(self.spec['location']), relative_filepath)
         else:

--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -74,12 +74,17 @@ class ExternalTable(Table):
 
     def _make_external_filepath(self, relative_filepath):
         """resolve the complete external path based on the relative path"""
-        posix_path = PurePosixPath(PureWindowsPath(self.spec['location']))
-        location_path = Path(
-                *posix_path.parts[1:]) if any(
-                    case in posix_path.parts[0] for case in (
-                        '\\', ':')) else Path(posix_path)
-        return PurePosixPath(location_path, relative_filepath)
+        if self.spec['protocol'] == 's3':
+            posix_path = PurePosixPath(PureWindowsPath(self.spec['location']))
+            location_path = Path(
+                    *posix_path.parts[1:]) if any(
+                        case in posix_path.parts[0] for case in (
+                            '\\', ':')) else Path(posix_path)
+            return PurePosixPath(location_path, relative_filepath)
+        elif self.spec['protocol'] == 'file':
+            return PurePosixPath(Path(self.spec['location']), relative_filepath)
+        else:
+            assert False
 
     def _make_uuid_path(self, uuid, suffix=''):
         """create external path based on the uuid hash"""

--- a/datajoint/external.py
+++ b/datajoint/external.py
@@ -78,9 +78,10 @@ class ExternalTable(Table):
         if self.spec['protocol'] == 's3':
             posix_path = PurePosixPath(PureWindowsPath(self.spec['location']))
             location_path = Path(
-                    *posix_path.parts[1:]) if any(
-                        case in posix_path.parts[0] for case in (
-                            '\\', ':')) else Path(posix_path)
+                    *posix_path.parts[1:]) if len(
+                    self.spec['location']) > 0 and any(
+                    case in posix_path.parts[0] for case in (
+                        '\\', ':')) else Path(posix_path)
             return PurePosixPath(location_path, relative_filepath)
         # Preserve root
         elif self.spec['protocol'] == 'file':

--- a/datajoint/version.py
+++ b/datajoint/version.py
@@ -1,3 +1,3 @@
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 
 assert len(__version__) <= 10  # The log table limits version to the 10 characters

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -1,3 +1,7 @@
+0.12.1 -- Nov 8, 2019
+-------------------------
+* Bugfix - Insert into external does not trim leading slash if defined in `dj.config['stores']['<store>']['location']` (#692)
+
 0.12.1 -- Nov 2, 2019
 -------------------------
 * Bugfix - AttributeAdapter converts into a string (#684)

--- a/tests/schema_external.py
+++ b/tests/schema_external.py
@@ -56,6 +56,15 @@ class Simple(dj.Manual):
 
 
 @schema
+class SimpleRemote(dj.Manual):
+    definition = """
+    simple  : int
+    ---
+    item  : blob@share
+    """
+
+
+@schema
 class Seed(dj.Lookup):
     definition = """
     seed :  int

--- a/tests/test_blob_migrate.py
+++ b/tests/test_blob_migrate.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from . import S3_CONN_INFO
 from . import CONN_INFO
 from datajoint.migrate import _migrate_dj011_blob
+dj.config['enable_python_native_blobs'] = True
 
 
 class TestBlobMigrate:

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -65,3 +65,9 @@ def test_leading_slash():
     SimpleRemote.insert([{'simple': id, 'item': value}])
     assert_true(np.array_equal(
         value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))
+
+    id = 104
+    dj.config['stores']['share']['location'] = 'f:\\leading/slash\\test'
+    SimpleRemote.insert([{'simple': id, 'item': value}])
+    assert_true(np.array_equal(
+        value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -8,7 +8,8 @@ from .schema_external import schema
 import datajoint as dj
 from .schema_external import stores_config
 from .schema_external import SimpleRemote
-current_location = dj.config['stores']['share']['location']
+current_location_s3 = dj.config['stores']['share']['location']
+current_location_local = dj.config['stores']['local']['location']
 
 
 def setUp(self):
@@ -16,7 +17,8 @@ def setUp(self):
 
 
 def tearDown(self):
-    dj.config['stores']['share']['location'] = current_location
+    dj.config['stores']['share']['location'] = current_location_s3
+    dj.config['stores']['local']['location'] = current_location_local
 
 
 def test_external_put():
@@ -41,38 +43,63 @@ def test_external_put():
     assert_array_equal(input_, output_)
 
 
-def test_leading_slash():
+def test_s3_leading_slash(index=100, store='share'):
     """
-    external storage configured with leading slash
+    s3 external storage configured with leading slash
     """
     value = np.array([1, 2, 3])
 
-    id = 100
-    dj.config['stores']['share']['location'] = 'leading/slash/test'
+    id = index
+    dj.config['stores'][store]['location'] = 'leading/slash/test'
     SimpleRemote.insert([{'simple': id, 'item': value}])
     assert_true(np.array_equal(
         value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))
 
-    id = 101
-    dj.config['stores']['share']['location'] = '/leading/slash/test'
+    id = index + 1
+    dj.config['stores'][store]['location'] = '/leading/slash/test'
     SimpleRemote.insert([{'simple': id, 'item': value}])
     assert_true(np.array_equal(
         value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))
 
-    id = 102
-    dj.config['stores']['share']['location'] = 'leading\\slash\\test'
+    id = index + 2
+    dj.config['stores'][store]['location'] = 'leading\\slash\\test'
     SimpleRemote.insert([{'simple': id, 'item': value}])
     assert_true(np.array_equal(
         value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))
 
-    id = 103
-    dj.config['stores']['share']['location'] = 'f:\\leading\\slash\\test'
+    id = index + 3
+    dj.config['stores'][store]['location'] = 'f:\\leading\\slash\\test'
     SimpleRemote.insert([{'simple': id, 'item': value}])
     assert_true(np.array_equal(
         value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))
 
-    id = 104
-    dj.config['stores']['share']['location'] = 'f:\\leading/slash\\test'
+    id = index + 4
+    dj.config['stores'][store]['location'] = 'f:\\leading/slash\\test'
     SimpleRemote.insert([{'simple': id, 'item': value}])
     assert_true(np.array_equal(
         value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))
+
+    id = index + 5
+    dj.config['stores'][store]['location'] = '/'
+    SimpleRemote.insert([{'simple': id, 'item': value}])
+    assert_true(np.array_equal(
+        value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))
+
+    id = index + 6
+    dj.config['stores'][store]['location'] = 'C:\\'
+    SimpleRemote.insert([{'simple': id, 'item': value}])
+    assert_true(np.array_equal(
+        value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))
+
+    id = index + 7
+    dj.config['stores'][store]['location'] = ''
+    SimpleRemote.insert([{'simple': id, 'item': value}])
+    assert_true(np.array_equal(
+        value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))
+
+
+def test_file_leading_slash():
+    """
+    file external storage configured with leading slash
+    """
+    test_s3_leading_slash(index=200, store='local')

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -8,10 +8,15 @@ from .schema_external import schema
 import datajoint as dj
 from .schema_external import stores_config
 from .schema_external import SimpleRemote
+current_location = dj.config['stores']['share']['location']
 
 
 def setUp(self):
     dj.config['stores'] = stores_config
+
+
+def tearDown(self):
+    dj.config['stores']['share']['location'] = current_location
 
 
 def test_external_put():

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -7,6 +7,7 @@ from datajoint.blob import pack, unpack
 from .schema_external import schema
 import datajoint as dj
 from .schema_external import stores_config
+from .schema_external import SimpleRemote
 
 
 def setUp(self):
@@ -33,3 +34,34 @@ def test_external_put():
 
     output_ = unpack(ext.get(hash1))
     assert_array_equal(input_, output_)
+
+
+def test_leading_slash():
+    """
+    external storage configured with leading slash
+    """
+    value = np.array([1, 2, 3])
+
+    id = 100
+    dj.config['stores']['share']['location'] = 'leading/slash/test'
+    SimpleRemote.insert([{'simple': id, 'item': value}])
+    assert_true(np.array_equal(
+        value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))
+
+    id = 101
+    dj.config['stores']['share']['location'] = '/leading/slash/test'
+    SimpleRemote.insert([{'simple': id, 'item': value}])
+    assert_true(np.array_equal(
+        value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))
+
+    id = 102
+    dj.config['stores']['share']['location'] = 'leading\\slash\\test'
+    SimpleRemote.insert([{'simple': id, 'item': value}])
+    assert_true(np.array_equal(
+        value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))
+
+    id = 103
+    dj.config['stores']['share']['location'] = 'f:\\leading\\slash\\test'
+    SimpleRemote.insert([{'simple': id, 'item': value}])
+    assert_true(np.array_equal(
+        value, (SimpleRemote & 'simple={}'.format(id)).fetch1('item')))


### PR DESCRIPTION
Fix #692

Currently, on `fetch` the root of the `location` from `s3` storage is stripped but not on `insert`. This change is to align both so that `insert` and `fetch` both strip the root for `s3` storage. This makes it compatible with all S3 providers e.g. Minio does not allow objects on root of `bucket` but AWS hosted objects are allowed. 

`file` storage, however, will still allow `insert` on root.