### PR TITLE
datajoint/errors.py: DataJointError (re-)subclass from Exception (fix for #701)

### DIFF
--- a/datajoint/errors.py
+++ b/datajoint/errors.py
@@ -6,7 +6,7 @@ import os
 
 
 # --- Top Level ---
-class DataJointError(BaseException):
+class DataJointError(Exception):
     """
     Base class for errors specific to DataJoint internal operation.
     """


### PR DESCRIPTION
Fixes #701 