### PR TITLE
Add multiprocessing to AutoPopulate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Release notes
 
+## 0.12.3 -- Nov 22, 2019
+* Bugfix #675 (PR #705) networkx 2.4+ is now supported
+* Bugfix #698 and #699 (PR #706) display table definition in doc string and help
+* Bugfix #701 (PR #702) job reservation works with native python datatype support disabled
+
 ### 0.12.2 -- Nov 11, 2019
 * Bugfix - Convoluted error thrown if there is a reference to a non-existent table attribute (#691)
 * Bugfix - Insert into external does not trim leading slash if defined in `dj.config['stores']['<store>']['location']` (#692)

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -169,7 +169,6 @@ class AutoPopulate:
             if multiprocess is True:
                 nproc = mp.cpu_count()
             else:
-
                 if not isinstance(multiprocess, int):
                     raise DataJointError("multiprocess can be False, True or a positive integer")
                 nproc = multiprocess

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -166,7 +166,7 @@ class AutoPopulate:
         nkeys = len(keys)
 
         if multiprocess: # True or int, presumably
-            if multiprocess == True:
+            if multiprocess is True:
                 nproc = mp.cpu_count()
             else:
                 assert type(multiprocess) == int

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -169,7 +169,9 @@ class AutoPopulate:
             if multiprocess is True:
                 nproc = mp.cpu_count()
             else:
-                assert type(multiprocess) == int
+
+                if not isinstance(multiprocess, int):
+                    raise DataJointError("multiprocess can be False, True or a positive integer")
                 nproc = multiprocess
         else:
             nproc = 1

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -124,11 +124,11 @@ class AutoPopulate:
         :param restrictions: a list of restrictions each restrict (rel.key_source - target.proj())
         :param suppress_errors: if True, do not terminate execution.
         :param return_exception_objects: return error objects instead of just error messages
-        :param reserve_jobs: if true, reserves job to populate in asynchronous fashion
+        :param reserve_jobs: if True, reserve jobs to populate in asynchronous fashion
         :param order: "original"|"reverse"|"random"  - the order of execution
+        :param limit: if not None, check at most this many keys
+        :param max_calls: if not None, populate at most this many keys
         :param display_progress: if True, report progress_bar
-        :param limit: if not None, checks at most that many keys
-        :param max_calls: if not None, populates at max that many keys
         :param max_processes: max number of processes to use simultaneously
         """
         self._make_key_kwargs = {'suppress_errors':suppress_errors,
@@ -144,7 +144,7 @@ class AutoPopulate:
             raise DataJointError('The order argument must be one of %s' % str(valid_order))
         jobs = self.connection.schemas[self.target.database].jobs if reserve_jobs else None
 
-        # define and setup signal handler for SIGTERM
+        # define and set up signal handler for SIGTERM:
         if reserve_jobs:
             def handler(signum, frame):
                 logger.info('Populate terminated by SIGTERM')

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -10,10 +10,24 @@ from .expression import QueryExpression, AndList, U
 from .errors import DataJointError
 from .table import FreeTable
 import signal
+import multiprocessing as mp
 
 # noinspection PyExceptionInherit,PyCallingNonCallable
 
 logger = logging.getLogger(__name__)
+
+
+def initializer(table):
+    """Save pickled copy of (disconnected) table to the current process,
+    then reconnect to server. For use by call_make_key()"""
+    mp.current_process().table = table
+    table.connection.connect() # reconnect
+
+def call_make_key(key):
+    """Call current process' table.make_key()"""
+    table = mp.current_process().table
+    error = table.make_key(key)
+    return error
 
 
 class AutoPopulate:
@@ -103,7 +117,7 @@ class AutoPopulate:
 
     def populate(self, *restrictions, suppress_errors=False, return_exception_objects=False,
                  reserve_jobs=False, order="original", limit=None, max_calls=None,
-                 display_progress=False):
+                 display_progress=False, max_processes=None):
         """
         rel.populate() calls rel.make(key) for every primary key in self.key_source
         for which there is not already a tuple in rel.
@@ -115,14 +129,19 @@ class AutoPopulate:
         :param display_progress: if True, report progress_bar
         :param limit: if not None, checks at most that many keys
         :param max_calls: if not None, populates at max that many keys
+        :param max_processes: max number of processes to use simultaneously
         """
+        self._make_key_kwargs = {'suppress_errors':suppress_errors,
+                                 'return_exception_objects':return_exception_objects,
+                                 'reserve_jobs':reserve_jobs,
+                                }
+
         if self.connection.in_transaction:
             raise DataJointError('Populate cannot be called during a transaction.')
 
         valid_order = ['original', 'reverse', 'random']
         if order not in valid_order:
             raise DataJointError('The order argument must be one of %s' % str(valid_order))
-        error_list = [] if suppress_errors else None
         jobs = self.connection.schemas[self.target.database].jobs if reserve_jobs else None
 
         # define and setup signal handler for SIGTERM
@@ -138,55 +157,93 @@ class AutoPopulate:
         elif order == "random":
             random.shuffle(keys)
 
-        call_count = 0
         logger.info('Found %d keys to populate' % len(keys))
 
-        make = self._make_tuples if hasattr(self, '_make_tuples') else self.make
+        if max_calls is not None:
+            keys = keys[:max_calls]
+        nkeys = len(keys)
 
-        for key in (tqdm(keys) if display_progress else keys):
-            if max_calls is not None and call_count >= max_calls:
-                break
-            if not reserve_jobs or jobs.reserve(self.target.table_name, self._job_key(key)):
-                self.connection.start_transaction()
-                if key in self.target:  # already populated
-                    self.connection.cancel_transaction()
-                    if reserve_jobs:
-                        jobs.complete(self.target.table_name, self._job_key(key))
+        nproc = 1
+        if max_processes and max_processes > 1:
+            nproc = min(max_processes, nkeys)
+        error_list = []
+        if nproc > 1: # spawn multiple processes
+            # prepare to pickle self:
+            self.connection.close() # disconnect parent process from MySQL server
+            del self.connection._conn.ctx # SSLContext is not picklable
+            print('*** Spawning pool of %d processes' % nproc)
+            # send pickled copy of self to each process,
+            # each worker process calls initializer(*initargs) when it starts
+            with mp.Pool(nproc, initializer, (self,)) as pool:
+                if display_progress:
+                    with tqdm(total=nkeys) as pbar:
+                        for error in pool.imap(call_make_key, keys, chunksize=1):
+                            if error is not None:
+                                error_list.append(error)
+                            pbar.update()
                 else:
-                    logger.info('Populating: ' + str(key))
-                    call_count += 1
-                    self.__class__._allow_insert = True
-                    try:
-                        make(dict(key))
-                    except (KeyboardInterrupt, SystemExit, Exception) as error:
-                        try:
-                            self.connection.cancel_transaction()
-                        except OperationalError:
-                            pass
-                        error_message = '{exception}{msg}'.format(
-                            exception=error.__class__.__name__,
-                            msg=': ' + str(error) if str(error) else '')
-                        if reserve_jobs:
-                            # show error name and error message (if any)
-                            jobs.error(
-                                self.target.table_name, self._job_key(key),
-                                error_message=error_message, error_stack=traceback.format_exc())
-                        if not suppress_errors or isinstance(error, SystemExit):
-                            raise
-                        else:
-                            logger.error(error)
-                            error_list.append((key, error if return_exception_objects else error_message))
-                    else:
-                        self.connection.commit_transaction()
-                        if reserve_jobs:
-                            jobs.complete(self.target.table_name, self._job_key(key))
-                    finally:
-                        self.__class__._allow_insert = False
+                    for error in pool.imap(call_make_key, keys):
+                        if error is not None:
+                            error_list.append(error)
+            self.connection.connect() # reconnect parent process to MySQL server
+        else: # use single process
+            for key in tqdm(keys) if display_progress else keys:
+                error = self.make_key(key)
+                if error is not None:
+                    error_list.append(error)
 
-        # place back the original signal handler
+        del self._make_key_kwargs # clean up
+
+        # restore original signal handler:
         if reserve_jobs:
             signal.signal(signal.SIGTERM, old_handler)
-        return error_list
+
+        if suppress_errors:
+            return error_list
+
+    def make_key(self, key):
+        make = self._make_tuples if hasattr(self, '_make_tuples') else self.make
+
+        kwargs = self._make_key_kwargs
+        suppress_errors = kwargs['suppress_errors']
+        return_exception_objects = kwargs['return_exception_objects']
+        reserve_jobs = kwargs['reserve_jobs']
+
+        if not reserve_jobs or jobs.reserve(self.target.table_name, self._job_key(key)):
+            self.connection.start_transaction()
+            if key in self.target: # already populated
+                self.connection.cancel_transaction()
+                if reserve_jobs:
+                    jobs.complete(self.target.table_name, self._job_key(key))
+            else:
+                logger.info('Populating: ' + str(key))
+                self.__class__._allow_insert = True
+                try:
+                    make(dict(key))
+                except (KeyboardInterrupt, SystemExit, Exception) as error:
+                    try:
+                        self.connection.cancel_transaction()
+                    except OperationalError:
+                        pass
+                    error_message = '{exception}{msg}'.format(
+                        exception=error.__class__.__name__,
+                        msg=': ' + str(error) if str(error) else '')
+                    if reserve_jobs:
+                        # show error name and error message (if any)
+                        jobs.error(
+                            self.target.table_name, self._job_key(key),
+                            error_message=error_message, error_stack=traceback.format_exc())
+                    if not suppress_errors or isinstance(error, SystemExit):
+                        raise
+                    else:
+                        logger.error(error)
+                        return (key, error if return_exception_objects else error_message)
+                else:
+                    self.connection.commit_transaction()
+                    if reserve_jobs:
+                        jobs.complete(self.target.table_name, self._job_key(key))
+                finally:
+                    self.__class__._allow_insert = False
 
     def progress(self, *restrictions, display=True):
         """

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -132,11 +132,6 @@ class AutoPopulate:
         :param multiprocess: if True, use as many processes as CPU cores, or use the integer
         number of processes specified
         """
-        self._make_key_kwargs = {'suppress_errors':suppress_errors,
-                                 'return_exception_objects':return_exception_objects,
-                                 'reserve_jobs':reserve_jobs,
-                                }
-
         if self.connection.in_transaction:
             raise DataJointError('Populate cannot be called during a transaction.')
 
@@ -144,6 +139,12 @@ class AutoPopulate:
         if order not in valid_order:
             raise DataJointError('The order argument must be one of %s' % str(valid_order))
         jobs = self.connection.schemas[self.target.database].jobs if reserve_jobs else None
+
+        self._make_key_kwargs = {'suppress_errors':suppress_errors,
+                                 'return_exception_objects':return_exception_objects,
+                                 'reserve_jobs':reserve_jobs,
+                                 'jobs':jobs,
+                                }
 
         # define and set up signal handler for SIGTERM:
         if reserve_jobs:
@@ -215,6 +216,7 @@ class AutoPopulate:
         suppress_errors = kwargs['suppress_errors']
         return_exception_objects = kwargs['return_exception_objects']
         reserve_jobs = kwargs['reserve_jobs']
+        jobs = kwargs['jobs']
 
         if not reserve_jobs or jobs.reserve(self.target.table_name, self._job_key(key)):
             self.connection.start_transaction()

--- a/datajoint/blob.py
+++ b/datajoint/blob.py
@@ -253,6 +253,9 @@ class Blob:
     def read_sparse_array(self):
         raise DataJointError('datajoint-python does not yet support sparse arrays. Issue (#590)')
 
+    def read_scalar(selfs):
+        
+
     def read_decimal(self):
         return Decimal(self.read_string())
 

--- a/datajoint/blob.py
+++ b/datajoint/blob.py
@@ -152,10 +152,8 @@ class Blob:
             return self.pack_array(np.array(obj))
         if isinstance(obj, (bool, np.bool, np.bool_)):
             return self.pack_array(np.array(obj))
-        if isinstance(obj, float):
-            return self.pack_array(np.array(obj, dtype=np.float64))
-        if isinstance(obj, int):
-            return self.pack_array(np.array(obj, dtype=np.int64))
+        if isinstance(obj, (float, int, complex)):
+            return self.pack_array(np.array(obj))
         if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
             return self.pack_datetime(obj)
         if isinstance(obj, Decimal):
@@ -252,9 +250,6 @@ class Blob:
 
     def read_sparse_array(self):
         raise DataJointError('datajoint-python does not yet support sparse arrays. Issue (#590)')
-
-    def read_scalar(selfs):
-        
 
     def read_decimal(self):
         return Decimal(self.read_string())

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -39,10 +39,10 @@ def translate_query_error(client_error, query):
         return errors.DuplicateError(*client_error.args[1:])
     if isinstance(client_error, client.err.IntegrityError) and client_error.args[0] == 1452:
         return errors.IntegrityError(*client_error.args[1:])
-    # Syntax Errors
+    # Syntax errors
     if isinstance(client_error, client.err.ProgrammingError) and client_error.args[0] == 1064:
         return errors.QuerySyntaxError(client_error.args[1], query)
-    # Existence Errors
+    # Existence errors
     if isinstance(client_error, client.err.ProgrammingError) and client_error.args[0] == 1146:
         return errors.MissingTableError(client_error.args[1], query)
     if isinstance(client_error, client.err.InternalError) and client_error.args[0] == 1364:
@@ -286,4 +286,3 @@ class Connection:
             raise
         else:
             self.commit_transaction()
-            

--- a/datajoint/diagram.py
+++ b/datajoint/diagram.py
@@ -236,8 +236,8 @@ else:
             for name in self.nodes_to_show:
                 foreign_attributes = set(
                     attr for p in self.in_edges(name, data=True) for attr in p[2]['attr_map'] if p[2]['primary'])
-                self.node[name]['distinguished'] = (
-                        'primary_key' in self.node[name] and foreign_attributes < self.node[name]['primary_key'])
+                self.nodes[name]['distinguished'] = (
+                        'primary_key' in self.nodes[name] and foreign_attributes < self.nodes[name]['primary_key'])
             # include aliased nodes that are sandwiched between two displayed nodes
             gaps = set(nx.algorithms.boundary.node_boundary(self, self.nodes_to_show)).intersection(
                 nx.algorithms.boundary.node_boundary(nx.DiGraph(self).reverse(), self.nodes_to_show))
@@ -307,7 +307,7 @@ else:
                 props = graph.get_edge_data(src, dest)
                 edge.set_color('#00000040')
                 edge.set_style('solid' if props['primary'] else 'dashed')
-                master_part = graph.node[dest]['node_type'] is Part and dest.startswith(src+'.')
+                master_part = graph.nodes[dest]['node_type'] is Part and dest.startswith(src+'.')
                 edge.set_weight(3 if master_part else 1)
                 edge.set_arrowhead('none')
                 edge.set_penwidth(.75 if props['multi'] else 2)

--- a/datajoint/heading.py
+++ b/datajoint/heading.py
@@ -247,8 +247,10 @@ class Heading:
                     category = next(c for c in SPECIAL_TYPES if TYPE_PATTERN[c].match(attr['type']))
                 except StopIteration:
                     if attr['type'].startswith('external'):
-                        raise DataJointError('Legacy datatype `{type}`. '
-                                             'Migrate your external stores to datajoint 0.12'.format(**attr)) from None
+                        url = "https://docs.datajoint.io/python/admin/5-blob-config.html" \
+                              "#migration-between-datajoint-v0-11-and-v0-12"
+                        raise DataJointError('Legacy datatype `{type}`. Migrate your external stores to '
+                                             'datajoint 0.12: {url}'.format(url=url, **attr)) from None
                     raise DataJointError('Unknown attribute type `{type}`'.format(**attr)) from None
                 if category == 'FILEPATH' and not _support_filepath_types():
                     raise DataJointError("""

--- a/datajoint/heading.py
+++ b/datajoint/heading.py
@@ -247,7 +247,8 @@ class Heading:
                     category = next(c for c in SPECIAL_TYPES if TYPE_PATTERN[c].match(attr['type']))
                 except StopIteration:
                     if attr['type'].startswith('external'):
-                        raise DataJointError('Legacy datatype `{type}`.'.format(**attr)) from None
+                        raise DataJointError('Legacy datatype `{type}`. '
+                                             'Migrate your external stores to datajoint 0.12'.format(**attr)) from None
                     raise DataJointError('Unknown attribute type `{type}`'.format(**attr)) from None
                 if category == 'FILEPATH' and not _support_filepath_types():
                     raise DataJointError("""

--- a/datajoint/jobs.py
+++ b/datajoint/jobs.py
@@ -1,25 +1,12 @@
 from .hash import key_hash
 import os
 import platform
-import numpy as np
 from .table import Table
-from .errors import DuplicateError
 from .settings import config
-from .blob import MatStruct
+from .errors import DuplicateError
 
 ERROR_MESSAGE_LENGTH = 2047
 TRUNCATION_APPENDIX = '...truncated'
-
-
-def _adapt_key_to_matstruct(key):
-    """
-    Only used as a temporary measure for uninterrupted interoperability with datajoint 0.11.
-    Will be deprecated in datajoint 0.13 when support for native python data types is accepted.
-    :param key: a dict representing the primary key
-    :return: converted to dj.blob.MatStruct
-    """
-    return (key if config.get('enable_python_native_blobs')
-            else np.reshape(np.rec.array((list(key.values())), names=list(key)), (1, 1)).view(MatStruct))
 
 
 class JobTable(Table):
@@ -87,10 +74,11 @@ class JobTable(Table):
             host=platform.node(),
             pid=os.getpid(),
             connection_id=self.connection.connection_id,
-            key=_adapt_key_to_matstruct(key),
+            key=key,
             user=self._user)
         try:
-            self.insert1(job, ignore_extra_fields=True)
+            with config(enable_pyton_native_blobs=True):
+                self.insert1(job, ignore_extra_fields=True)
         except DuplicateError:
             return False
         return True
@@ -115,16 +103,17 @@ class JobTable(Table):
         """
         if len(error_message) > ERROR_MESSAGE_LENGTH:
             error_message = error_message[:ERROR_MESSAGE_LENGTH-len(TRUNCATION_APPENDIX)] + TRUNCATION_APPENDIX
-        self.insert1(
-            dict(
-                table_name=table_name,
-                key_hash=key_hash(key),
-                status="error",
-                host=platform.node(),
-                pid=os.getpid(),
-                connection_id=self.connection.connection_id,
-                user=self._user,
-                key=_adapt_key_to_matstruct(key),
-                error_message=error_message,
-                error_stack=error_stack),
-            replace=True, ignore_extra_fields=True)
+        with config(enable_pyton_native_blobs=True):
+            self.insert1(
+                dict(
+                    table_name=table_name,
+                    key_hash=key_hash(key),
+                    status="error",
+                    host=platform.node(),
+                    pid=os.getpid(),
+                    connection_id=self.connection.connection_id,
+                    user=self._user,
+                    key=key,
+                    error_message=error_message,
+                    error_stack=error_stack),
+                replace=True, ignore_extra_fields=True)

--- a/datajoint/jobs.py
+++ b/datajoint/jobs.py
@@ -77,7 +77,7 @@ class JobTable(Table):
             key=key,
             user=self._user)
         try:
-            with config(enable_pyton_native_blobs=True):
+            with config(enable_python_native_blobs=True):
                 self.insert1(job, ignore_extra_fields=True)
         except DuplicateError:
             return False
@@ -103,7 +103,7 @@ class JobTable(Table):
         """
         if len(error_message) > ERROR_MESSAGE_LENGTH:
             error_message = error_message[:ERROR_MESSAGE_LENGTH-len(TRUNCATION_APPENDIX)] + TRUNCATION_APPENDIX
-        with config(enable_pyton_native_blobs=True):
+        with config(enable_python_native_blobs=True):
             self.insert1(
                 dict(
                     table_name=table_name,

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -191,6 +191,10 @@ class Schema:
                 instance.declare(context)
         is_declared = is_declared or instance.is_declared
 
+        # add table definition to the doc string
+        if isinstance(table_class.definition, str):
+            table_class.__doc__ = (table_class.__doc__ or "") + "\n\nTable definition:\n\n" + table_class.definition
+
         # fill values in Lookup tables from their contents property
         if isinstance(instance, Lookup) and hasattr(instance, 'contents') and is_declared:
             contents = list(instance.contents)

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -194,7 +194,7 @@ class Schema:
         # add table definition to the doc string
         if isinstance(table_class.definition, str):
             table_class.__doc__ = ((table_class.__doc__ or "") + "\n\nTable definition:\n"
-                                   + table_class.describe(printout=False))
+                                   + table_class.describe(printout=False, context=context))
 
         # fill values in Lookup tables from their contents property
         if isinstance(instance, Lookup) and hasattr(instance, 'contents') and is_declared:

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -193,7 +193,7 @@ class Schema:
 
         # add table definition to the doc string
         if isinstance(table_class.definition, str):
-            table_class.__doc__ = ((table_class.__doc__ or "") + "\n\nTable definition:\n"
+            table_class.__doc__ = ((table_class.__doc__ or "") + "\nTable definition:\n\n"
                                    + table_class.describe(printout=False, context=context))
 
         # fill values in Lookup tables from their contents property

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -193,7 +193,8 @@ class Schema:
 
         # add table definition to the doc string
         if isinstance(table_class.definition, str):
-            table_class.__doc__ = (table_class.__doc__ or "") + "\n\nTable definition:\n\n" + table_class.definition
+            table_class.__doc__ = ((table_class.__doc__ or "") + "\n\nTable definition:\n"
+                                   + table_class.describe(printout=False))
 
         # fill values in Lookup tables from their contents property
         if isinstance(instance, Lookup) and hasattr(instance, 'contents') and is_declared:

--- a/datajoint/schema.py
+++ b/datajoint/schema.py
@@ -193,8 +193,7 @@ class Schema:
 
         # add table definition to the doc string
         if isinstance(table_class.definition, str):
-            table_class.__doc__ = ((table_class.__doc__ or "") + "\nTable definition:\n\n"
-                                   + table_class.describe(printout=False, context=context))
+            table_class.__doc__ = (table_class.__doc__ or "") + "\nTable definition:\n\n" + table_class.definition
 
         # fill values in Lookup tables from their contents property
         if isinstance(instance, Lookup) and hasattr(instance, 'contents') and is_declared:

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -406,7 +406,7 @@ class Table(QueryExpression):
             print('About to delete:')
 
         if not already_in_transaction:
-            self.connection.start_transaction()
+            conn.start_transaction()
         total = 0
         try:
             for name, table in reversed(list(delete_list.items())):
@@ -418,25 +418,25 @@ class Table(QueryExpression):
         except:
             # Delete failed, perhaps due to insufficient privileges. Cancel transaction.
             if not already_in_transaction:
-                self.connection.cancel_transaction()
+                conn.cancel_transaction()
             raise
         else:
             assert not (already_in_transaction and safe)
             if not total:
                 print('Nothing to delete')
                 if not already_in_transaction:
-                    self.connection.cancel_transaction()
+                    conn.cancel_transaction()
             else:
                 if already_in_transaction:
                     if verbose:
                         print('The delete is pending within the ongoing transaction.')
                 else:
                     if not safe or user_choice("Proceed?", default='no') == 'yes':
-                        self.connection.commit_transaction()
+                        conn.commit_transaction()
                         if verbose or safe:
                             print('Committed.')
                     else:
-                        self.connection.cancel_transaction()
+                        conn.cancel_transaction()
                         if verbose or safe:
                             print('Cancelled deletes.')
 

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -19,7 +19,7 @@ from .version import __version__ as version
 logger = logging.getLogger(__name__)
 
 
-class _rename_map(tuple):
+class _RenameMap(tuple):
     """ for internal use """
     pass
 
@@ -375,7 +375,7 @@ class Table(QueryExpression):
         graph = conn.dependencies
         graph.load()
         delete_list = collections.OrderedDict(
-            (name, _rename_map(next(iter(graph.parents(name).items()))) if name.isdigit() else FreeTable(conn, name))
+            (name, _RenameMap(next(iter(graph.parents(name).items()))) if name.isdigit() else FreeTable(conn, name))
             for name in graph.descendants(self.full_table_name))
 
         # construct restrictions for each relation
@@ -405,7 +405,7 @@ class Table(QueryExpression):
                 table.restrict([
                     r.proj() if isinstance(r, FreeTable) else (
                         delete_list[r[0]].proj(**{a: b for a, b in r[1]['attr_map'].items()})
-                        if isinstance(r, _rename_map) else r)
+                        if isinstance(r, _RenameMap) else r)
                     for r in restrictions[name]])
         if safe:
             print('About to delete:')

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -45,14 +45,9 @@ class Table(QueryExpression):
         """
         if self._heading is None:
             self._heading = Heading()  # instance-level heading
-        if not self._heading:  # lazy loading of heading
-            if self.connection is None:
-                raise DataJointError(
-                    'DataJoint class is missing a database connection. '
-                    'Missing schema decorator on the class? (e.g. @schema)')
-            else:
-                self._heading.init_from_database(
-                    self.connection, self.database, self.table_name, self.declaration_context)
+        if not self._heading and self.connection is not None:  # lazy loading of heading
+            self._heading.init_from_database(
+                self.connection, self.database, self.table_name, self.declaration_context)
         return self._heading
 
     def declare(self, context=None):

--- a/datajoint/user_tables.py
+++ b/datajoint/user_tables.py
@@ -13,7 +13,7 @@ _base_regexp = r'[a-z][a-z0-9]*(_[a-z][a-z0-9]*)*'
 # attributes that trigger instantiation of user classes
 supported_class_attrs = {
     'key_source', 'describe', 'alter', 'heading', 'populate', 'progress', 'primary_key', 'proj', 'aggr',
-    'fetch', 'fetch1','head', 'tail',
+    'fetch', 'fetch1', 'head', 'tail',
     'insert', 'insert1', 'drop', 'drop_quick', 'delete', 'delete_quick'}
 
 
@@ -92,7 +92,7 @@ class UserTable(Table, metaclass=OrderedClass):
 
     @ClassProperty
     def full_table_name(cls):
-        if cls not in {Manual, Imported, Lookup, Computed, Part}:
+        if cls not in {Manual, Imported, Lookup, Computed, Part, UserTable}:
             if cls.database is None:
                 raise DataJointError('Class %s is not properly declared (schema decorator not applied?)' % cls.__name__)
             return r"`{0:s}`.`{1:s}`".format(cls.database, cls.table_name)

--- a/datajoint/version.py
+++ b/datajoint/version.py
@@ -1,3 +1,3 @@
-__version__ = "0.12.2"
+__version__ = "0.12.3"
 
 assert len(__version__) <= 10  # The log table limits version to the 10 characters

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -1,4 +1,11 @@
-0.12.1 -- Nov 11, 2019
+0.12.3 -- Nov 22, 2019
+----------------------
+* Bugfix - networkx 2.4 causes error in diagrams (#675) PR #705
+* Bugfix - include definition in doc string and help (#698, #699) PR #706
+* Bugfix - job reservation fails when native python datatype support is disabled (#701) PR #702 
+
+
+0.12.2 -- Nov 11, 2019
 -------------------------
 * Bugfix - Convoluted error thrown if there is a reference to a non-existent table attribute (#691)
 * Bugfix - Insert into external does not trim leading slash if defined in `dj.config['stores']['<store>']['location']` (#692)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyparsing
 ipython
 pandas
 tqdm
-networkx<2.4
+networkx
 pydot
 minio
 matplotlib

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -13,6 +13,9 @@ schema = dj.schema(PREFIX + '_test1', connection=dj.conn(**CONN_INFO))
 
 @schema
 class TTest(dj.Lookup):
+    """
+    doc string
+    """
     definition = """
     key   :   int     # key
     ---

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -278,6 +278,38 @@ class SigTermTable(dj.Computed):
 
 
 @schema
+class DjExceptionNames(dj.Lookup):
+    definition = """
+    dj_exception_name:    char(64)
+    """
+    @property
+    def contents(self):
+        ret = []
+        for e in dir(dj.errors):
+            ea = getattr(dj.errors, e) 
+            if callable(ea):
+                try:
+                    werks = (isinstance(ea, type(Exception))
+                             and isinstance(ea(), Exception))
+                except TypeError as te:
+                    pass
+                if werks:
+                    ret.append((e,))
+        return ret
+
+
+@schema
+class ErrorClassTable(dj.Computed):
+    definition = """
+    -> DjExceptionNames
+    """
+    def make(self, key):
+        ename = key['dj_exception_name']
+        raise getattr(dj.errors, ename)(ename)
+
+
+
+@schema
 class DecimalPrimaryKey(dj.Lookup):
     definition = """
     id  :  decimal(4,3)

--- a/tests/test_alter.py
+++ b/tests/test_alter.py
@@ -40,3 +40,4 @@ def test_alter():
     restored = schema.connection.query("SHOW CREATE TABLE " + Experiment.full_table_name).fetchone()[1]
     assert_equal(original, restored)
     assert_not_equal(original, altered)
+

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -23,6 +23,9 @@ def test_pack():
     x = np.random.randn(10)
     assert_array_equal(x, unpack(pack(x)), "Arrays do not match!")
 
+    x = 7j
+    assert_equal(x, unpack(pack(x)), "Complex scalar does not match")
+
     x = np.float32(np.random.randn(3, 4, 5))
     assert_array_equal(x, unpack(pack(x)), "Arrays do not match!")
 

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -23,6 +23,20 @@ class TestDeclare:
         assert_true(not issubclass(Subject, dj.Part))
 
     @staticmethod
+    def test_class_help():
+        help(TTest)
+        help(TTest2)
+        assert_true(TTest.definition in TTest.__doc__)
+        assert_true(TTest.definition in TTest2.__doc__)
+
+    @staticmethod
+    def test_instance_help():
+        help(TTest())
+        help(TTest2())
+        assert_true(TTest().definition in TTest().__doc__)
+        assert_true(TTest2().definition in TTest2().__doc__)
+
+    @staticmethod
     def test_describe():
         """real_definition should match original definition"""
         rel = Experiment()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -88,6 +88,18 @@ def test_sigterm():
     assert_equals(error_message, 'SystemExit: SIGTERM received')
     schema.schema.jobs.delete()
 
+
+def test_suppress_dj_errors():
+    ''' test_suppress_dj_errors: dj errors suppressable w/o native py blobs'''
+    schema.schema.jobs.delete()
+    with dj.config(enable_python_native_blobs=False):
+        schema.ErrorClassTable().populate(
+            reserve_jobs=True, suppress_errors=True)
+
+        assert len(schema.DjExceptionNames()) == len(schema.DjExceptionNames
+                                                     & schema.schema.jobs)
+
+
 def test_long_error_message():
     # clear out jobs table
     schema.schema.jobs.delete()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -10,11 +10,11 @@ subjects = schema.Subject()
 
 
 def test_reserve_job():
-    # clean jobs table
-    schema.schema.jobs.delete()
 
+    schema.schema.jobs.delete()
     assert_true(subjects)
     table_name = 'fake_table'
+
     # reserve jobs
     for key in subjects.fetch('KEY'):
         assert_true(schema.schema.jobs.reserve(table_name, key), 'failed to reserve a job')

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -17,37 +17,35 @@ def test_reserve_job():
     table_name = 'fake_table'
     # reserve jobs
     for key in subjects.fetch('KEY'):
-        assert_true(schema.schema.jobs.reserve(table_name, key),
-                    'failed to reserve a job')
+        assert_true(schema.schema.jobs.reserve(table_name, key), 'failed to reserve a job')
+
     # refuse jobs
     for key in subjects.fetch('KEY'):
-        assert_false(schema.schema.jobs.reserve(table_name, key),
-                     'failed to respect reservation')
+        assert_false(schema.schema.jobs.reserve(table_name, key), 'failed to respect reservation')
+
     # complete jobs
     for key in subjects.fetch('KEY'):
         schema.schema.jobs.complete(table_name, key)
-    assert_false(schema.schema.jobs,
-                 'failed to free jobs')
+    assert_false(schema.schema.jobs, 'failed to free jobs')
+
     # reserve jobs again
     for key in subjects.fetch('KEY'):
-        assert_true(schema.schema.jobs.reserve(table_name, key),
-                    'failed to reserve new jobs')
+        assert_true(schema.schema.jobs.reserve(table_name, key), 'failed to reserve new jobs')
+
     # finish with error
     for key in subjects.fetch('KEY'):
-        schema.schema.jobs.error(table_name, key,
-                                 "error message")
+        schema.schema.jobs.error(table_name, key, "error message")
+
     # refuse jobs with errors
     for key in subjects.fetch('KEY'):
-        assert_false(schema.schema.jobs.reserve(table_name, key),
-                     'failed to ignore error jobs')
+        assert_false(schema.schema.jobs.reserve(table_name, key), 'failed to ignore error jobs')
+
     # clear error jobs
     (schema.schema.jobs & dict(status="error")).delete()
-    assert_false(schema.schema.jobs,
-                 'failed to clear error jobs')
+    assert_false(schema.schema.jobs, 'failed to clear error jobs')
 
 
 def test_restrictions():
-    # clear out jobs table
     jobs = schema.schema.jobs
     jobs.delete()
     jobs.reserve('a', {'key': 'a1'})
@@ -56,10 +54,9 @@ def test_restrictions():
     jobs.error('a', {'key': 'a2'}, 'error')
     jobs.error('b', {'key': 'b1'}, 'error')
 
-    assert_true(len(jobs & 'table_name = "a"') == 2, 'There should be two entries for table a')
-    assert_true(len(jobs & 'status = "error"') == 2, 'There should be two entries with error status')
-    assert_true(len(jobs & 'table_name = "a"' & 'status = "error"') == 1,
-                'There should be only one entries with error status in table a')
+    assert_true(len(jobs & {'table_name': "a"}) == 2)
+    assert_true(len(jobs & {'status': "error"}) == 2)
+    assert_true(len(jobs & {'table_name': "a", 'status': "error"}) == 1)
     jobs.delete()
 
 
@@ -109,7 +106,7 @@ def test_long_error_message():
     assert_true(subjects)
     table_name = 'fake_table'
 
-    key = list(subjects.fetch('KEY'))[0]
+    key = subjects.fetch('KEY')[0]
 
     # test long error message
     schema.schema.jobs.reserve(table_name, key)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,4 +1,3 @@
-from decimal import Decimal
 from nose.tools import assert_true, assert_false, assert_equals
 from . import schema
 from datajoint.jobs import ERROR_MESSAGE_LENGTH, TRUNCATION_APPENDIX
@@ -46,6 +45,7 @@ def test_reserve_job():
     assert_false(schema.schema.jobs,
                  'failed to clear error jobs')
 
+
 def test_restrictions():
     # clear out jobs table
     jobs = schema.schema.jobs
@@ -62,6 +62,7 @@ def test_restrictions():
                 'There should be only one entries with error status in table a')
     jobs.delete()
 
+
 def test_sigint():
     # clear out job table
     schema.schema.jobs.delete()
@@ -74,6 +75,7 @@ def test_sigint():
     assert_equals(status, 'error')
     assert_equals(error_message, 'KeyboardInterrupt')
     schema.schema.jobs.delete()
+
 
 def test_sigterm():
     # clear out job table
@@ -90,14 +92,13 @@ def test_sigterm():
 
 
 def test_suppress_dj_errors():
-    ''' test_suppress_dj_errors: dj errors suppressable w/o native py blobs'''
+    """ test_suppress_dj_errors: dj errors suppressable w/o native py blobs """
     schema.schema.jobs.delete()
     with dj.config(enable_python_native_blobs=False):
-        schema.ErrorClassTable().populate(
-            reserve_jobs=True, suppress_errors=True)
-
-        assert len(schema.DjExceptionNames()) == len(schema.DjExceptionNames
-                                                     & schema.schema.jobs)
+        schema.ErrorClass.populate(reserve_jobs=True, suppress_errors=True)
+    number_of_exceptions = len(schema.DjExceptionName())
+    assert_true(number_of_exceptions > 0)
+    assert_equals(number_of_exceptions, len(schema.schema.jobs))
 
 
 def test_long_error_message():

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -96,9 +96,7 @@ def test_suppress_dj_errors():
     schema.schema.jobs.delete()
     with dj.config(enable_python_native_blobs=False):
         schema.ErrorClass.populate(reserve_jobs=True, suppress_errors=True)
-    number_of_exceptions = len(schema.DjExceptionName())
-    assert_true(number_of_exceptions > 0)
-    assert_equals(number_of_exceptions, len(schema.schema.jobs))
+    assert_true(len(schema.DjExceptionName()) == len(schema.schema.jobs) > 0)
 
 
 def test_long_error_message():

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -36,6 +36,12 @@ class TestRelation:
         cls.img = schema.Image()
         cls.trash = schema.UberTrash()
 
+    def test_class_help(self):
+        help(schema.TTest)
+
+    def test_instance_help(self):
+        help(schema.TTest())
+
     def test_contents(self):
         """
         test the ability of tables to self-populate using the contents property

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -36,12 +36,6 @@ class TestRelation:
         cls.img = schema.Image()
         cls.trash = schema.UberTrash()
 
-    def test_class_help(self):
-        help(schema.TTest)
-
-    def test_instance_help(self):
-        help(schema.TTest())
-
     def test_contents(self):
         """
         test the ability of tables to self-populate using the contents property


### PR DESCRIPTION
Here's a stab at addressing issue #695. This adds a `multiprocess` kwarg to `populate()`. From what I can tell, building a subset of our database (with about 40 AutoPopulate tables, some with up to 1M rows) with the default single process is as fast as before, around 10-11 min on our 16 core server. With `multiprocess=True` (which in our case spawns a pool of at most 16 processes, depending on the number of primary keys per table), that drops to around 2 min, so about 1/5 the time. The end result looks exactly the same, including table entry order and returned error lists. Besides often having fewer than 16 primary keys per table, I think much of the lost time is due to some individual keys taking much longer to process than others. Since the granularity of the multiprocessing is at the level of keys, sometimes processes can sit idle waiting for the last one to finish.

Seems to work fine in combination with `reserve_jobs=True`, but the benefit of doing so is probably reduced. I haven't tested the `limit` or `max_calls` kwargs for `populate()`. Not entirely sure if the new `max_calls` logic will work exactly the same as before.

`display_progress` works, but isn't as fine-grained as for the single process `populate()` call. The progress bar only prints out once in a while (and sometimes overwrites itself), but it's still better than nothing. I got some tips on this from https://stackoverflow.com/questions/41920124/multiprocessing-use-tqdm-to-display-a-progress-bar

The strategy of binding the table object as an attribute to each process seems a bit clumsy, but it's something I came up with long ago on a different project where I wanted to multiprocess an object method instead of just a function. It works fine from what I've seen. I wouldn't be surprised if there's a better way to do this though.