### PR TITLE
Update Log table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ build/
 ./tests/dj-store/*
 *.log
 *.env
-local-docker-compose.yml
+docker-compose.yml
 notebooks/*
 __main__.py
 jupyter_custom.js

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build/
 *.log
 *.env
 docker-compose.yml
-notebooks/*
+notebook
+.vscode
 __main__.py
 jupyter_custom.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ main: &main
       dist: xenial # precise, trusty, xenial, bionic
       language: shell
       script:
-        - docker-compose -f LNX-docker-compose.yml up --build --exit-code-from dj
+        - docker-compose -f LNX-docker-compose.yml up --build --exit-code-from app
 jobs:
   include:
     - <<: *main

--- a/LNX-docker-compose.yml
+++ b/LNX-docker-compose.yml
@@ -3,7 +3,7 @@ x-net: &net
   networks:
       - main
 services:
-  dj:
+  app:
     <<: *net
     image: datajoint/pydev:${PY_VER}-alpine${ALPINE_VER}
     depends_on:

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ GID=1000
 | Use Case                     | Shell Code                                                                    |
 | ---------------------------- | ------------------------------------------------------------------------------ |
 | Run all tests                | `nosetests -vsw tests --with-coverage --cover-package=datajoint`                                                              |
-| Run one class of tests       | `nosetests -vs --tests=tests.test_fetch:TestFetch.test_getattribute_for_fetch1`                                                           |
-| Run one specific test        | `nosetests -vs --tests=tests.test_external_class:test_insert_and_fetch`                                   |
+| Run one specific class test       | `nosetests -vs --tests=tests.test_fetch:TestFetch.test_getattribute_for_fetch1`                                                           |
+| Run one specific basic test        | `nosetests -vs --tests=tests.test_external_class:test_insert_and_fetch`                                   |
 
 
 ### Launch Docker Terminal

--- a/README.md
+++ b/README.md
@@ -98,3 +98,43 @@ A number of labs are currently adopting DataJoint and we are quickly getting the
 * https://docs.datajoint.io -- up-to-date documentation
 * https://tutorials.datajoint.io -- step-by-step tutorials
 * https://catalog.datajoint.io -- catalog of example pipelines
+
+## Running Tests Locally
+
+
+* Create an `.env` with desired development environment values e.g.
+``` sh
+PY_VER=3.7
+ALPINE_VER=3.10
+MYSQL_VER=5.7
+MINIO_VER=RELEASE.2019-09-26T19-42-35Z
+UID=1000
+GID=1000
+```
+* `cp local-docker-compose.yml docker-compose.yml`
+* `docker-compose up -d` (Note configured `JUPYTER_PASSWORD`)
+* Select a means of running Tests e.g. Docker Terminal, or Local Terminal (see bottom)
+* Run desired tests. Some examples are as follows:
+
+| Use Case                     | Shell Code                                                                    |
+| ---------------------------- | ------------------------------------------------------------------------------ |
+| Run all tests                | `nosetests -vsw tests --with-coverage --cover-package=datajoint`                                                              |
+| Run one class of tests       | `nosetests -vs --tests=tests.test_fetch:TestFetch.test_getattribute_for_fetch1`                                                           |
+| Run one specific test        | `nosetests -vs --tests=tests.test_external_class:test_insert_and_fetch`                                   |
+
+
+### Launch Docker Terminal
+* Shell into `datajoint-python_app_1` i.e. `docker exec -it datajoint-python_app_1 sh`
+
+
+### Launch Local Terminal
+* See `datajoint-python_app` environment variables in `local-docker-compose.yml`
+* Launch local terminal
+* `export` environment variables in shell
+* Add entry in `/etc/hosts` for `127.0.0.1 fakeminio.datajoint.io`
+
+
+### Launch Jupyter Notebook for Interactive Use
+* Navigate to `localhost:8888`
+* Input Jupyter password
+* Launch a notebook i.e. `New > Python 3`

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -12,7 +12,7 @@ from .utils import OrderedDict
 
 UUID_DATA_TYPE = 'binary(16)'
 MAX_TABLE_NAME_LENGTH = 64
-CONSTANT_LITERALS = {'CURRENT_TIMESTAMP', 'CURRENT_TIMESTAMP(3)'}  # SQL literals to be used without quotes (case insensitive)
+CONSTANT_LITERALS = {'CURRENT_TIMESTAMP'}  # SQL literals to be used without quotes (case insensitive)
 EXTERNAL_TABLE_ROOT = '~external'
 
 TYPE_PATTERN = {k: re.compile(v, re.I) for k, v in dict(
@@ -443,7 +443,8 @@ def compile_attribute(line, in_key, foreign_key_sql, context):
         match['default'] = 'DEFAULT NULL'  # nullable attributes default to null
     else:
         if match['default']:
-            quote = match['default'].upper() not in CONSTANT_LITERALS and match['default'][0] not in '"\''
+            quote = (match['default'].split('(')[0].upper() not in CONSTANT_LITERALS
+                        and match['default'][0] not in '"\'')
             match['default'] = 'NOT NULL DEFAULT ' + ('"%s"' if quote else "%s") % match['default']
         else:
             match['default'] = 'NOT NULL'

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -12,7 +12,7 @@ from .utils import OrderedDict
 
 UUID_DATA_TYPE = 'binary(16)'
 MAX_TABLE_NAME_LENGTH = 64
-CONSTANT_LITERALS = {'CURRENT_TIMESTAMP'}  # SQL literals to be used without quotes (case insensitive)
+CONSTANT_LITERALS = {'CURRENT_TIMESTAMP', 'CURRENT_TIMESTAMP(3)'}  # SQL literals to be used without quotes (case insensitive)
 EXTERNAL_TABLE_ROOT = '~external'
 
 TYPE_PATTERN = {k: re.compile(v, re.I) for k, v in dict(

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -16,7 +16,7 @@ CONSTANT_LITERALS = {'CURRENT_TIMESTAMP'}  # SQL literals to be used without quo
 EXTERNAL_TABLE_ROOT = '~external'
 
 TYPE_PATTERN = {k: re.compile(v, re.I) for k, v in dict(
-    INTEGER=r'(((tiny|small|medium|big|)int|integer)(\s*\(.+\))?(\s+unsigned)?(\s+auto_increment))|serial?$',
+    INTEGER=r'((tiny|small|medium|big|)int|integer)(\s*\(.+\))?(\s+unsigned)?(\s+auto_increment)?|serial$',
     DECIMAL=r'(decimal|numeric)(\s*\(.+\))?(\s+unsigned)?$',
     FLOAT=r'(double|float|real)(\s*\(.+\))?(\s+unsigned)?$',
     STRING=r'(var)?char\s*\(.+\)$',

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -16,7 +16,7 @@ CONSTANT_LITERALS = {'CURRENT_TIMESTAMP'}  # SQL literals to be used without quo
 EXTERNAL_TABLE_ROOT = '~external'
 
 TYPE_PATTERN = {k: re.compile(v, re.I) for k, v in dict(
-    INTEGER=r'((tiny|small|medium|big|)int|integer)(\s*\(.+\))?(\s+unsigned)?(\s+auto_increment)?$',
+    INTEGER=r'(((tiny|small|medium|big|)int|integer)(\s*\(.+\))?(\s+unsigned)?(\s+auto_increment))|serial?$',
     DECIMAL=r'(decimal|numeric)(\s*\(.+\))?(\s+unsigned)?$',
     FLOAT=r'(double|float|real)(\s*\(.+\))?(\s+unsigned)?$',
     STRING=r'(var)?char\s*\(.+\)$',

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -683,7 +683,7 @@ class Log(Table):
         self.database = database
         self._connection = arg
         self._definition = """    # event logging table for `{database}`
-        id :  smallint auto_increment
+        id :  serial
         ---
         timestamp = CURRENT_TIMESTAMP(3) : timestamp(3)
         version  :varchar(12)   # datajoint version

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -683,13 +683,13 @@ class Log(Table):
         self.database = database
         self._connection = arg
         self._definition = """    # event logging table for `{database}`
-        id :  serial
+        id       :int unsigned auto_increment     # event order id
         ---
-        timestamp = CURRENT_TIMESTAMP(3) : timestamp(3)
-        version  :varchar(12)   # datajoint version
-        user     :varchar(255)  # user@host
-        host=""  :varchar(255)  # system hostname
-        event="" :varchar(255)  # custom message
+        timestamp = CURRENT_TIMESTAMP : timestamp # event timestamp
+        version  :varchar(12)                     # datajoint version
+        user     :varchar(255)                    # user@host
+        host=""  :varchar(255)                    # system hostname
+        event="" :varchar(255)                    # event message
         """.format(database=database)
 
         if not self.is_declared:

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -683,8 +683,9 @@ class Log(Table):
         self.database = database
         self._connection = arg
         self._definition = """    # event logging table for `{database}`
-        timestamp = CURRENT_TIMESTAMP : timestamp
+        id :  smallint auto_increment
         ---
+        timestamp = CURRENT_TIMESTAMP(3) : timestamp(3)
         version  :varchar(12)   # datajoint version
         user     :varchar(255)  # user@host
         host=""  :varchar(255)  # system hostname

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -45,7 +45,7 @@ services:
         done;
        "
     ports:
-      - "8888:8888"
+      - "8889:8888"
       - "5678:5678"
     user: ${UID}:${GID}
     volumes:
@@ -60,7 +60,7 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=simple
     ports:
-      - "3306:3306"
+      - "3307:3306"
     # To persist MySQL data
     # volumes:
     #   - ./mysql/data:/var/lib/mysql

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -3,7 +3,7 @@ x-net: &net
   networks:
       - main
 services:
-  dj:
+  app:
     <<: *net
     image: datajoint/pydev:${PY_VER}-alpine${ALPINE_VER}
     depends_on:
@@ -32,7 +32,7 @@ services:
        "
         pip install --user nose nose-cov coveralls ptvsd .;
         pip freeze | grep datajoint;
-        ## You may run the below tests once sh'ed into container i.e. docker exec -it datajoint-python_dj_1 sh
+        ## You may run the below tests once sh'ed into container i.e. docker exec -it datajoint-python_app_1 sh
         # nosetests -vsw tests --with-coverage --cover-package=datajoint; #run all tests
         # nosetests -vs --tests=tests.test_external_class:test_insert_and_fetch; #run specific basic test
         # nosetests -vs --tests=tests.test_fetch:TestFetch.test_getattribute_for_fetch1; #run specific Class test
@@ -45,22 +45,22 @@ services:
         done;
        "
     ports:
-      - "8889:8888"
+      - "8888:8888"
       - "5678:5678"
     user: ${UID}:${GID}
     volumes:
       - .:/src
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       # Additional mounted notebooks may go here
-      - ./notebook:/home/dja/notebooks
-      - ../dj-python-101/ch1:/home/dja/tutorials
+      # - ./notebook:/home/dja/notebooks
+      # - ../dj-python-101/ch1:/home/dja/tutorials
   db:
     <<: *net
     image: datajoint/mysql:$MYSQL_VER
     environment:
       - MYSQL_ROOT_PASSWORD=simple
     ports:
-      - "3307:3306"
+      - "3306:3306"
     # To persist MySQL data
     # volumes:
     #   - ./mysql/data:/var/lib/mysql

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -52,7 +52,8 @@ services:
       - .:/src
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
       # Additional mounted notebooks may go here
-      # - ./notebooks:/home/dja/notebooks
+      - ./notebook:/home/dja/notebooks
+      - ../dj-python-101/ch1:/home/dja/tutorials
   db:
     <<: *net
     image: datajoint/mysql:$MYSQL_VER

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -1,0 +1,104 @@
+version: '2.2'
+x-net: &net
+  networks:
+      - main
+services:
+  dj:
+    <<: *net
+    image: datajoint/pydev:${PY_VER}-alpine${ALPINE_VER}
+    depends_on:
+      db:
+        condition: service_healthy 
+      minio:
+        condition: service_healthy 
+    environment:
+      - DJ_HOST=db
+      - DJ_USER=root
+      - DJ_PASS=simple
+      - DJ_TEST_HOST=db
+      - DJ_TEST_USER=datajoint
+      - DJ_TEST_PASSWORD=datajoint
+      # If running tests locally, make sure to add entry in /etc/hosts for 127.0.0.1 fakeminio.datajoint.io
+      - S3_ENDPOINT=fakeminio.datajoint.io:9000
+      - S3_ACCESS_KEY=datajoint
+      - S3_SECRET_KEY=datajoint
+      - S3_BUCKET=datajoint-test
+      - PYTHON_USER=dja
+      - JUPYTER_PASSWORD=datajoint
+      - DISPLAY
+    working_dir: /src
+    command: >
+      /bin/sh -c
+       "
+        pip install --user nose nose-cov coveralls ptvsd .;
+        pip freeze | grep datajoint;
+        ## You may run the below tests once sh'ed into container i.e. docker exec -it datajoint-python_dj_1 sh
+        # nosetests -vsw tests --with-coverage --cover-package=datajoint; #run all tests
+        # nosetests -vs --tests=tests.test_external_class:test_insert_and_fetch; #run specific basic test
+        # nosetests -vs --tests=tests.test_fetch:TestFetch.test_getattribute_for_fetch1; #run specific Class test
+        ## Interactive Jupyter Notebook environment
+        jupyter notebook &
+        ## Remote debugger
+        while true;
+        do python -m ptvsd --host 0.0.0.0 --port 5678 --wait .;
+        sleep 2;
+        done;
+       "
+    ports:
+      - "8888:8888"
+      - "5678:5678"
+    user: ${UID}:${GID}
+    volumes:
+      - .:/src
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+      # Additional mounted notebooks may go here
+      # - ./notebooks:/home/dja/notebooks
+  db:
+    <<: *net
+    image: datajoint/mysql:$MYSQL_VER
+    environment:
+      - MYSQL_ROOT_PASSWORD=simple
+    ports:
+      - "3306:3306"
+    # To persist MySQL data
+    # volumes:
+    #   - ./mysql/data:/var/lib/mysql
+  minio:
+    <<: *net
+    environment:
+      - MINIO_ACCESS_KEY=datajoint
+      - MINIO_SECRET_KEY=datajoint
+    image: minio/minio:$MINIO_VER
+    # To persist MinIO data and config
+    # volumes:
+    #   - ./minio/data:/data
+    #   - ./minio/config:/root/.minio
+    command: server /data
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://minio:9000/minio/health/live"]
+      timeout: 5s
+      retries: 60
+      interval: 1s
+  fakeminio.datajoint.io:
+    <<: *net
+    image: nginx:alpine
+    environment:
+      - URL=datajoint.io
+      - SUBDOMAINS=fakeminio
+      - MINIO_SERVER=http://minio:9000
+    entrypoint: /entrypoint.sh
+    healthcheck:
+      test: wget --quiet --tries=1 --spider https://fakeminio.datajoint.io:443/minio/health/live || exit 1
+      timeout: 5s
+      retries: 300
+      interval: 1s
+    ports:
+      - "9000:9000"
+      - "443:443"
+    volumes:
+      - ./tests/nginx/base.conf:/base.conf
+      - ./tests/nginx/entrypoint.sh:/entrypoint.sh
+      - ./tests/nginx/fullchain.pem:/certs/fullchain.pem
+      - ./tests/nginx/privkey.pem:/certs/privkey.pem
+networks:
+  main:


### PR DESCRIPTION
- Update Log table to auto increment entries to prevent collisions and increase timestamp precision to millisecond.
- Add docs that describe how to run tests locally.