### PR TITLE
datajoint/admin.py: add unsafe dj.kill option, expand display to include host

### DIFF
--- a/datajoint/admin.py
+++ b/datajoint/admin.py
@@ -43,7 +43,7 @@ def kill(restriction=None, connection=None, safemode=None):  # pragma: no cover
     query = 'SELECT * FROM information_schema.processlist WHERE id <> CONNECTION_ID()' + (
         "" if restriction is None else ' AND (%s)' % restriction)
 
-    safemode = config.get('safemode', True) if safemode is None else True
+    safemode = config.get('safemode', True) if safemode is None else safemode
 
     if not safemode:
         cur = connection.query(query, as_dict=True)


### PR DESCRIPTION
Minimal extension of existing dj.kill() to support #740 -

other more extensive reimplementation might be possible (e.g. making a full 'table' of information_schema.processlist) but would require more development effort.

Unsafe dj.kill() added to facillitate usage by automatic scripts
(e.g. job runners which need to terminate stuck/old jobs forcefully)

Also, add HOST field to display to improve usability in multi-host environments

Changes:

  - add 'safemode' argument to dj.kill

    Value defaults to Null which implies reading the value from current
    dj.config['safemode'] option, falling back to True if this is not present.

  - add safemode=False dj.kill operation mode

    This will apply the given restriction to the processlist query
    and kill all matching processes. Number of killed processes will
    be returned if no errors are encountered.