### PR TITLE
Test fixes

### DIFF
--- a/tests/test_fetch_same.py
+++ b/tests/test_fetch_same.py
@@ -1,11 +1,7 @@
 from nose.tools import assert_equal
 from . import PREFIX, CONN_INFO
 import numpy as np
-import importlib
-try:
-    dj = importlib.import_module('datajoint-python.datajoint', None)
-except Exception as e:
-    import datajoint as dj
+import datajoint as dj
 
 schema = dj.Schema(PREFIX + '_fetch_same', connection=dj.conn(**CONN_INFO))
 

--- a/tests/test_fetch_same.py
+++ b/tests/test_fetch_same.py
@@ -1,11 +1,10 @@
-from nose.tools import assert_true, assert_false, assert_equal, \
-                        assert_list_equal, raises
+from nose.tools import assert_equal
 from . import PREFIX, CONN_INFO
 import numpy as np
 import importlib
 try:
     dj = importlib.import_module('datajoint-python.datajoint', None)
-except:
+except Exception as e:
     import datajoint as dj
 
 schema = dj.Schema(PREFIX + '_fetch_same', connection=dj.conn(**CONN_INFO))
@@ -22,13 +21,15 @@ class ProjData(dj.Manual):
     blah : varchar(10)
     """
 
-ProjData().insert([
-    {'id': 0, 'resp': 20.33, 'sim': 45.324, 'big': 3, 'blah': 'yes'},
-    {'id': 1, 'resp': 94.3, 'sim': 34.23,
-        'big': {'key1': np.random.randn(20, 10)}, 'blah': 'si'},
-    {'id': 2, 'resp': 1.90, 'sim': 10.23,
-        'big': np.random.randn(4, 2), 'blah': 'sim'}
-])
+
+with dj.config(enable_python_native_blobs=True):
+    ProjData().insert([
+        {'id': 0, 'resp': 20.33, 'sim': 45.324, 'big': 3, 'blah': 'yes'},
+        {'id': 1, 'resp': 94.3, 'sim': 34.23,
+            'big': {'key1': np.random.randn(20, 10)}, 'blah': 'si'},
+        {'id': 2, 'resp': 1.90, 'sim': 10.23,
+            'big': np.random.randn(4, 2), 'blah': 'sim'}
+    ])
 
 
 class TestFetchSame:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -89,7 +89,7 @@ def test_sigterm():
 
 
 def test_suppress_dj_errors():
-    """ test_suppress_dj_errors: dj errors suppressable w/o native py blobs """
+    """ test_suppress_dj_errors: dj errors suppressible w/o native py blobs """
     schema.schema.jobs.delete()
     with dj.config(enable_python_native_blobs=False):
         schema.ErrorClass.populate(reserve_jobs=True, suppress_errors=True)


### PR DESCRIPTION
Apparently nosetests, sometimes did not pass depending on the order they were invoked. This fixes one case when `enable_native_python_blobs` was required but not set in `test_fetch_same`.