### PR TITLE
fixes for PyMySQL 10.x (fix 814)

### DIFF
--- a/LNX-docker-compose.yml
+++ b/LNX-docker-compose.yml
@@ -31,7 +31,7 @@ services:
       interval: 1s
   fakeservices.datajoint.io:
     <<: *net
-    image: raphaelguzman/nginx:v0.0.6
+    image: raphaelguzman/nginx:v0.0.10
     environment:
     - ADD_db_TYPE=DATABASE
     - ADD_db_ENDPOINT=db:3306

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -13,7 +13,9 @@ from . import errors
 from .dependencies import Dependencies
 
 
+
 logger = logging.getLogger(__name__)
+query_log_max_length = 300
 
 
 def translate_query_error(client_error, query):
@@ -207,7 +209,7 @@ class Connection:
         """
         if reconnect is None:
             reconnect = config['database.reconnect']
-        logger.debug("Executing SQL:" + query[0:300])
+        logger.debug("Executing SQL:" + query[:query_log_max_length])
         cursor_class = client.cursors.DictCursor if as_dict else client.cursors.Cursor
         cursor = self._conn.cursor(cursor=cursor_class)
         try:

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -15,9 +15,6 @@ from .dependencies import Dependencies
 
 logger = logging.getLogger(__name__)
 
-# client errors to catch
-client_errors = (client.err.InterfaceError, client.err.DatabaseError)
-
 
 def translate_query_error(client_error, query):
     """
@@ -27,37 +24,36 @@ def translate_query_error(client_error, query):
     :return: an instance of the corresponding subclass of datajoint.errors.DataJointError
     """
     logger.debug('type: {}, args: {}'.format(type(client_error), client_error.args))
+
+    err, *args = client_error.args
+
     # Loss of connection errors
-    if isinstance(client_error, client.err.InterfaceError) and client_error.args[0] == 0:
-        return errors.LostConnectionError('Server connection lost due to an interface error.', *client_error.args[1:])
-    disconnect_codes = {
-        2006: "Connection timed out",
-        2013: "Server connection lost"}
-    if isinstance(client_error, client.err.OperationalError) and client_error.args[0] in disconnect_codes:
-        return errors.LostConnectionError(disconnect_codes[client_error.args[0]], *client_error.args[1:])
+    if err in (0, "(0, '')"):
+        return errors.LostConnectionError('Server connection lost due to an interface error.', *args)
+    if err == 2006:
+        return errors.LostConnectionError("Connection timed out", *args)
+    if err == 2013:
+        return errors.LostConnectionError("Server connection lost", *args)
     # Access errors
-    if isinstance(client_error, client.err.OperationalError) and client_error.args[0] in (1044, 1142):
-        return errors.AccessError('Insufficient privileges.', client_error.args[1],  query)
+    if err in (1044, 1142):
+        return errors.AccessError('Insufficient privileges.', args[0],  query)
     # Integrity errors
-    if isinstance(client_error, client.err.IntegrityError) and client_error.args[0] == 1062:
-        return errors.DuplicateError(*client_error.args[1:])
-    if isinstance(client_error, client.err.IntegrityError) and client_error.args[0] == 1452:
-        return errors.IntegrityError(*client_error.args[1:])
+    if err == 1062:
+        return errors.DuplicateError(*args)
+    if err == 1452:
+        return errors.IntegrityError(*args)
     # Syntax errors
-    if isinstance(client_error, client.err.ProgrammingError) and client_error.args[0] == 1064:
-        return errors.QuerySyntaxError(client_error.args[1], query)
+    if err == 1064:
+        return errors.QuerySyntaxError(args[0], query)
     # Existence errors
-    if isinstance(client_error, client.err.ProgrammingError) and client_error.args[0] == 1146:
-        return errors.MissingTableError(client_error.args[1], query)
-    if isinstance(client_error, client.err.OperationalError) and client_error.args[0] == 1364:
-        return errors.MissingAttributeError(*client_error.args[1:])
-    if isinstance(client_error, client.err.OperationalError) and client_error.args[0] == 1054:
-        return errors.UnknownAttributeError(*client_error.args[1:])
+    if err == 1146:
+        return errors.MissingTableError(args[0], query)
+    if err == 1364:
+        return errors.MissingAttributeError(*args)
+    if err == 1054:
+        return errors.UnknownAttributeError(*args)
     # all the other errors are re-raised in original form
     return client_error
-
-
-
 
 
 def conn(host=None, user=None, password=None, *, init_fun=None, reset=False, use_tls=None):
@@ -196,7 +192,7 @@ class Connection:
                     # suppress all warnings arising from underlying SQL library
                     warnings.simplefilter("ignore")
                 cursor.execute(query, args)
-        except client_errors as err:
+        except client.err.Error as err:
             raise translate_query_error(err, query) from None
 
     def query(self, query, args=(), *, as_dict=False, suppress_warnings=True, reconnect=None):

--- a/datajoint/schemas.py
+++ b/datajoint/schemas.py
@@ -73,7 +73,6 @@ class Schema:
                 logger.info("Creating schema `{name}`.".format(name=schema_name))
                 try:
                     connection.query("CREATE DATABASE `{name}`".format(name=schema_name))
-                    logger.info('Creating schema `{name}`.'.format(name=schema_name))
                 except pymysql.OperationalError:
                     raise DataJointError(
                         "Schema `{name}` does not exist and could not be created. "

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -33,7 +33,7 @@ services:
       interval: 1s
   fakeservices.datajoint.io:
     <<: *net
-    image: raphaelguzman/nginx:v0.0.6
+    image: raphaelguzman/nginx:v0.0.10
     environment:
     - ADD_db_TYPE=DATABASE
     - ADD_db_ENDPOINT=db:3306

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -68,7 +68,7 @@ def test_unauthorized_database():
     """
     an attempt to create a database to which user has no privileges should raise an informative exception.
     """
-    dj.Schema('unauthorized_schema', connection=dj.conn(**CONN_INFO))
+    dj.Schema('unauthorized_schema', connection=dj.conn(reset=True, **CONN_INFO))
 
 
 def test_drop_database():


### PR DESCRIPTION
fix for #814 

so far fixed:

  tests.test_fetch:TestFetch.test_misspelled_attribute
  tests.test_reconnection:TestReconnect.test_reconnect
  tests.test_reconnection:TestReconnect.test_reconnect_throws_error_in_transaction
  tests.test_relation:TestRelation.test_no_error_suppression

remaining:

  tests.test_schema:test_unauthorized_database
    (seems to currently raise datajoint.errors.AccessError instead
     of expected dj.DataJointError; we don't seem to use more 'advanced'
     dj error heirarchy, so not sure what to resolve towards)

while here, remove spurious log message in datajoint/schemas.py

also: should probably make requirements.txt >= 10.x as part of this;
some question r.e. scheduling  therefore as a result