### PR TITLE
POC: filepath GCS support

### DIFF
--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -138,7 +138,8 @@ class Config(collections.MutableMapping):
         spec['subfolding'] = spec.get('subfolding', DEFAULT_SUBFOLDING)
         spec_keys = {  # REQUIRED in uppercase and allowed in lowercase
             'file': ('PROTOCOL', 'LOCATION', 'subfolding', 'stage'),
-            's3': ('PROTOCOL', 'ENDPOINT', 'BUCKET', 'ACCESS_KEY', 'SECRET_KEY', 'LOCATION', 'secure', 'subfolding', 'stage')}
+            's3': ('PROTOCOL', 'ENDPOINT', 'BUCKET', 'ACCESS_KEY', 'SECRET_KEY', 'LOCATION', 'secure', 'subfolding', 'stage'),
+            'gcs': ('PROTOCOL', 'LOCATION', 'TOKEN', 'subfolding', 'stage')}
 
         try:
             spec_keys = spec_keys[spec.get('protocol', '').lower()]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ networkx
 pydot
 minio
 matplotlib
+gcsfs

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -45,6 +45,8 @@ S3_MIGRATE_BUCKET = [path.name for path in Path(
         Path(__file__).resolve().parent,
         'external-legacy-data', 's3').iterdir()][0]
 
+GCS_CONN_INFO = dict(token=environ.get('GOOGLE_APPLICATION_CREDENTIALS'))
+
 # Prefix for all databases used during testing
 PREFIX = environ.get('DJ_TEST_DB_PREFIX', 'djtest')
 conn_root = dj.conn(**CONN_INFO_ROOT)

--- a/tests/schema_external.py
+++ b/tests/schema_external.py
@@ -5,7 +5,7 @@ a schema for testing external attributes
 import tempfile
 import datajoint as dj
 
-from . import PREFIX, CONN_INFO, S3_CONN_INFO
+from . import PREFIX, CONN_INFO, S3_CONN_INFO, GCS_CONN_INFO
 import numpy as np
 
 schema = dj.Schema(PREFIX + '_extern', connection=dj.conn(**CONN_INFO))
@@ -27,6 +27,12 @@ stores_config = {
         S3_CONN_INFO,
         protocol='s3',
         location='dj/repo',
+        stage=tempfile.mkdtemp()),
+    
+    'repo_gcs': dict(
+        GCS_CONN_INFO,
+        protocol='gcs',
+        location='datajoint/repo',  # gs:// will be prepended
         stage=tempfile.mkdtemp()),
 
     'local': dict(
@@ -132,6 +138,16 @@ class FilepathS3(dj.Manual):
     fnum : int 
     ---
     img : filepath@repo_s3  # managed files 
+    """
+
+
+@schema
+class FilepathGcs(dj.Manual):
+    definition = """
+    # table for file management 
+    fnum : int 
+    ---
+    img : filepath@repo_gcs  # managed files 
     """
 
 dj.errors._switch_filepath_types(False)

--- a/tests/test_filepath.py
+++ b/tests/test_filepath.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 import random
 
-from .schema_external import schema, Filepath, FilepathS3, stores_config
+from .schema_external import schema, Filepath, FilepathS3, FilepathGcs, stores_config
 
 
 def setUp(self):
@@ -88,6 +88,11 @@ def test_filepath_s3():
     test_filepath(store="repo_s3")
 
 
+def test_filepath_gcs():
+    """ test file management with gcs """
+    test_filepath(store="repo_gcs")
+
+
 def test_duplicate_upload(store="repo"):
     ext = schema.external[store]
     stage_path = dj.config['stores'][store]['stage']
@@ -102,6 +107,10 @@ def test_duplicate_upload(store="repo"):
 
 def test_duplicate_upload_s3():
     test_duplicate_upload(store="repo_s3")
+
+
+def test_duplicate_upload_gcs():
+    test_duplicate_upload(store="repo_gcs")
 
 
 @raises(dj.DataJointError)
@@ -123,6 +132,10 @@ def test_duplicate_error(store="repo"):
 
 def test_duplicate_error_s3():
     test_duplicate_error(store="repo_s3")
+
+
+def test_duplicate_error_gcs():
+    test_duplicate_error(store="repo_gcs")
 
 
 def test_filepath_class(table=Filepath(), store="repo"):
@@ -176,6 +189,15 @@ def test_filepath_class_s3():
 def test_filepath_class_s3_again():
     """test_filepath_class_s3 again to deal with existing remote files"""
     test_filepath_class(FilepathS3(), "repo_s3")
+    
+    
+def test_filepath_class_gcs():
+    test_filepath_class(FilepathGcs(), "repo_gcs")
+
+
+def test_filepath_class_gcs_again():
+    """test_filepath_class_gcs again to deal with existing remote files"""
+    test_filepath_class(FilepathGcs(), "repo_gcs")
 
 
 def test_filepath_cleanup(table=Filepath(), store="repo"):
@@ -211,9 +233,15 @@ def test_filepath_cleanup(table=Filepath(), store="repo"):
 
 
 def test_filepath_cleanup_s3():
-    """test deletion of filepath entries from external table """
+    """test deletion of s3 filepath entries from external table """
     store = "repo_s3"
     test_filepath_cleanup(FilepathS3(), store)
+
+
+def test_filepath_cleanup_gcs():
+    """test deletion of gcs filepath entries from external table """
+    store = "repo_gcs"
+    test_filepath_cleanup(FilepathGcs(), store)
 
 
 def test_delete_without_files(store="repo"):


### PR DESCRIPTION
Fix #750

Use gcsfs package, based on fsspec. It provides a common interface across filesystems, so one could unifying the code across local/gcs/s3 and many others.

Different than the s3 library, the bucket is not a separate entity -- the location is 'gs://bucket/path'.  Pathlib does not like double-slashes, so I put in  hack to concat strings.

TESTED: Would need a local GCS mock.  For now, I used a test bucket with personal credentials.