### PR TITLE
datajoint/connection.py: default host_input to '' in Connection as stopgap for #895

### DIFF
--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -172,7 +172,7 @@ class Connection:
         if use_tls is not False:
             self.conn_info['ssl'] = use_tls if isinstance(use_tls, dict) else {'ssl': {}}
         self.conn_info['ssl_input'] = use_tls
-        self.conn_info['host_input'] = host_input
+        self.conn_info['host_input'] = host_input if host_input else ''
         self.init_fun = init_fun
         print("Connecting {user}@{host}:{port}".format(**self.conn_info))
         self._conn = None


### PR DESCRIPTION
fix (temporary) for #895 

still think this can be refactored to remove need for host_input (or around making full host_input string the default argument);
for now, defaulting host_input to '' will allow the test on line 25 in get_host_hook to work when host_input is not provided to Connection. Didn't change arg default in method signature to keep the current API the same until some later refactor though that could be reasonable/better as a stopgap.