### PR TITLE
Rename `setuptools_certificate` dependency to `otumat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release notes
 
-### 0.13.2 -- TBD
+### 0.13.2 -- Apr 23, 2021
+* Update `setuptools_certificate` dependency to new name `otumat`
 * Bugfix - Explicit calls to `dj.Connection` throw error due to missing `host_input` (#895) PR #907
 
 ### 0.13.1 -- Apr 16, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release notes
 
-### 0.13.2 -- Apr 23, 2021
+### 0.13.2 -- May 7, 2021
 * Update `setuptools_certificate` dependency to new name `otumat`
 * Bugfix - Explicit calls to `dj.Connection` throw error due to missing `host_input` (#895) PR #907
 * Bugfix - Correct count of deleted items. (#897) PR #912

--- a/datajoint/plugin.py
+++ b/datajoint/plugin.py
@@ -11,10 +11,10 @@ def _update_error_stack(plugin_name):
         base_meta = pkg_resources.get_distribution(base_name)
         plugin_meta = pkg_resources.get_distribution(plugin_name)
 
-        data = hash_pkg(str(Path(plugin_meta.module_path, plugin_name)))
+        data = hash_pkg(pkgpath=str(Path(plugin_meta.module_path, plugin_name)))
         signature = plugin_meta.get_metadata('{}.sig'.format(plugin_name))
         pubkey_path = str(Path(base_meta.egg_info, '{}.pub'.format(base_name)))
-        verify(pubkey_path, data, signature)
+        verify(pubkey_path=pubkey_path, data=data, signature=signature)
         print('DataJoint verified plugin `{}` detected.'.format(plugin_name))
         return True
     except (FileNotFoundError, InvalidSignature):

--- a/datajoint/plugin.py
+++ b/datajoint/plugin.py
@@ -2,7 +2,7 @@ from .settings import config
 import pkg_resources
 from pathlib import Path
 from cryptography.exceptions import InvalidSignature
-from setuptools_certificate import hash_pkg, verify
+from otumat import hash_pkg, verify
 
 
 def _update_error_stack(plugin_name):

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -1,4 +1,4 @@
-0.13.2 -- Apr 23, 2021
+0.13.2 -- May 7, 2021
 ----------------------
 * Update `setuptools_certificate` dependency to new name `otumat`
 * Bugfix - Explicit calls to `dj.Connection` throw error due to missing `host_input` (#895) PR #907

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -1,5 +1,6 @@
-0.13.2 -- TBD
--------------
+0.13.2 -- Apr 23, 2021
+----------------------
+* Update `setuptools_certificate` dependency to new name `otumat`
 * Bugfix - Explicit calls to `dj.Connection` throw error due to missing `host_input` (#895) PR #907
 
 0.13.1 -- Apr 16, 2021

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ pydot
 minio>=7.0.0
 matplotlib
 cryptography
-setuptools_certificate
+otumat

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     install_requires=requirements,
     python_requires='~={}.{}'.format(*min_py_version),
-    setup_requires=['setuptools_certificate'], # maybe remove due to conflicts?
+    setup_requires=['otumat'],  # maybe remove due to conflicts?
     pubkey_path='./datajoint.pub'
 )


### PR DESCRIPTION
This rename was necessary and allows us to achieve the following:
- Prepares the `otumat` dependency to be `conda-forge` compatible.
- Prepares the `otumat` dependency to be more generic so that other utilities can be introduced (such as usage tracking)

Will follow this with a new release so that we can catch up our conda distro properly. It is currently at `0.12.9` due to several issues.
