### PR TITLE
Add fsspec as alternate file protocol

### DIFF
--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -137,7 +137,8 @@ class Config(collections.MutableMapping):
         spec['subfolding'] = spec.get('subfolding', DEFAULT_SUBFOLDING)
         spec_keys = {  # REQUIRED in uppercase and allowed in lowercase
             'file': ('PROTOCOL', 'LOCATION', 'subfolding', 'stage'),
-            's3': ('PROTOCOL', 'ENDPOINT', 'BUCKET', 'ACCESS_KEY', 'SECRET_KEY', 'LOCATION', 'secure', 'subfolding', 'stage')}
+            's3': ('PROTOCOL', 'ENDPOINT', 'BUCKET', 'ACCESS_KEY', 'SECRET_KEY', 'LOCATION', 'secure', 'subfolding', 'stage'),
+            'fsspec': ('PROTOCOL', 'LOCATION', 'subfolding', 'stage')}
 
         try:
             spec_keys = spec_keys[spec.get('protocol', '').lower()]

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -73,6 +73,8 @@ services:
       - S3_ACCESS_KEY=datajoint
       - S3_SECRET_KEY=datajoint
       - S3_BUCKET=datajoint.test
+      - AWS_ACCESS_KEY_ID=datajoint
+      - AWS_SECRET_ACCESS_KEY=datajoint 
       - PYTHON_USER=dja
       - JUPYTER_PASSWORD=datajoint
       - DISPLAY
@@ -82,6 +84,8 @@ services:
       - -c
       - |
         set -e
+        mkdir -p ~/.config/fsspec
+        echo '{"s3": {"client_kwargs": {"endpoint_url": "http://fakeservices.datajoint.io"}}}' > ~/.config/fsspec/s3.json 
         pip install --user nose nose-cov coveralls flake8 ptvsd
         pip install -e .
         pip freeze | grep datajoint

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ minio>=7.0.0
 matplotlib
 cryptography
 otumat
+fsspec[s3,gcs]

--- a/tests/schema_external.py
+++ b/tests/schema_external.py
@@ -37,7 +37,18 @@ stores_config = {
         S3_CONN_INFO,
         protocol='s3',
         location='dj/store/repo',
-        subfolding=(2, 4))
+        subfolding=(2, 4)),
+    
+    'fsspec': dict(
+        protocol='fsspec',
+        location=tempfile.mkdtemp(),
+        stage=tempfile.mkdtemp()),
+
+    'fsspec_s3': dict(
+        protocol='fsspec',
+        location='s3://datajoint.test/dj/store/fsspec',
+        stage=tempfile.mkdtemp())
+    
 }
 
 dj.config['stores'] = stores_config
@@ -62,6 +73,23 @@ class SimpleRemote(dj.Manual):
     item  : blob@share
     """
 
+
+@schema
+class SimpleFsSpec(dj.Manual):
+    definition = """
+    simple  : int
+    ---
+    item  : blob@fsspec
+    """
+
+
+@schema
+class SimpleFsSpecS3(dj.Manual):
+    definition = """
+    simple  : int
+    ---
+    item  : blob@fsspec_s3
+    """
 
 @schema
 class Seed(dj.Lookup):

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -8,6 +8,8 @@ from .schema_external import schema
 import datajoint as dj
 from .schema_external import stores_config
 from .schema_external import SimpleRemote
+from .schema_external import SimpleFsSpec
+from .schema_external import SimpleFsSpecS3
 current_location_s3 = dj.config['stores']['share']['location']
 current_location_local = dj.config['stores']['local']['location']
 
@@ -103,3 +105,15 @@ def test_file_leading_slash():
     file external storage configured with leading slash
     """
     test_s3_leading_slash(index=200, store='local')
+
+
+def test_fsspec():
+    value = np.array([1, 2, 3])
+
+    SimpleFsSpec.insert([{'simple': 0, 'item': value}])
+    assert_true(np.array_equal(
+        value, (SimpleFsSpec & 'simple=0').fetch1('item')))
+
+    SimpleFsSpecS3.insert([{'simple': 0, 'item': value}])
+    assert_true(np.array_equal(
+        value, (SimpleFsSpecS3 & 'simple=0').fetch1('item')))

--- a/tests/test_filepath.py
+++ b/tests/test_filepath.py
@@ -94,6 +94,16 @@ def test_filepath_s3():
     test_filepath(store="repo_s3")
 
 
+def test_filepath_fsspec():
+    """ test file management with fsspec """
+    test_filepath(store="fsspec")
+
+
+def test_filepath_fsspec_s3():
+    """ test file management with fsspec """
+    test_filepath(store="fsspec_s3")
+
+
 def test_duplicate_upload(store="repo"):
     ext = schema.external[store]
     stage_path = dj.config['stores'][store]['stage']


### PR DESCRIPTION
In principle, fsspec can completely subsume the current protocols (file and s3) and can provide many more.  However, since it is a new integration and getting credentialling correct can be difficult, I implemented it as an alternate protocol which people can migrate to.

Some s3fs and gcsfs dependencies (installed via fsspec[s3,gcs]) do not have wheels for alpine, so they need to be built during startup.   To correctly run the tests, the following extra install of dev packages is needed:

apk add musl-dev

Addresses #911 