### PR TITLE
Adds proxy server to minio / aws s3 storage

### DIFF
--- a/datajoint/s3.py
+++ b/datajoint/s3.py
@@ -17,28 +17,23 @@ class Folder:
     """
     A Folder instance manipulates a flat folder of objects within an S3-compatible object store
     """
-    def __init__(self, endpoint, bucket, access_key, secret_key, *, secure=False, proxy_server=None, **_):
-        if proxy_server:
-            # from https://docs.min.io/docs/python-client-api-reference
-            http_client = urllib3.ProxyManager(
-                    proxy_server,
-                    timeout=urllib3.Timeout.DEFAULT_TIMEOUT,
-                    cert_reqs="CERT_REQUIRED",
-                    retries=urllib3.Retry(
-                        total=5,
-                        backoff_factor=0.2,
-                        status_forcelist=[500, 502, 503, 504],
-                    )
-                )
-        else:
-            http_client = None
-
+    def __init__(self, endpoint, bucket, access_key, secret_key, *, secure=False,
+                 proxy_server=None, **_):
+        # from https://docs.min.io/docs/python-client-api-reference
         self.client = minio.Minio(
             endpoint,
             access_key=access_key,
             secret_key=secret_key,
             secure=secure,
-            http_client=http_client,
+            http_client= (
+                urllib3.ProxyManager(proxy_server,
+                                     timeout=urllib3.Timeout.DEFAULT_TIMEOUT,
+                                     cert_reqs="CERT_REQUIRED",
+                                     retries=urllib3.Retry(total=5,
+                                                           backoff_factor=0.2,
+                                                           status_forcelist=[500, 502, 503,
+                                                                             504]))
+                if proxy_server else None),
             )
         self.bucket = bucket
         if not self.client.bucket_exists(bucket):

--- a/datajoint/s3.py
+++ b/datajoint/s3.py
@@ -25,7 +25,7 @@ class Folder:
             access_key=access_key,
             secret_key=secret_key,
             secure=secure,
-            http_client= (
+            http_client=(
                 urllib3.ProxyManager(proxy_server,
                                      timeout=urllib3.Timeout.DEFAULT_TIMEOUT,
                                      cert_reqs="CERT_REQUIRED",

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -137,7 +137,8 @@ class Config(collections.MutableMapping):
         spec['subfolding'] = spec.get('subfolding', DEFAULT_SUBFOLDING)
         spec_keys = {  # REQUIRED in uppercase and allowed in lowercase
             'file': ('PROTOCOL', 'LOCATION', 'subfolding', 'stage'),
-            's3': ('PROTOCOL', 'ENDPOINT', 'BUCKET', 'ACCESS_KEY', 'SECRET_KEY', 'LOCATION', 'secure', 'subfolding', 'stage', 'proxy_server')}
+            's3': ('PROTOCOL', 'ENDPOINT', 'BUCKET', 'ACCESS_KEY', 'SECRET_KEY', 'LOCATION',
+                    'secure', 'subfolding', 'stage', 'proxy_server')}
 
         try:
             spec_keys = spec_keys[spec.get('protocol', '').lower()]

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -138,7 +138,7 @@ class Config(collections.MutableMapping):
         spec_keys = {  # REQUIRED in uppercase and allowed in lowercase
             'file': ('PROTOCOL', 'LOCATION', 'subfolding', 'stage'),
             's3': ('PROTOCOL', 'ENDPOINT', 'BUCKET', 'ACCESS_KEY', 'SECRET_KEY', 'LOCATION',
-                    'secure', 'subfolding', 'stage', 'proxy_server')}
+                   'secure', 'subfolding', 'stage', 'proxy_server')}
 
         try:
             spec_keys = spec_keys[spec.get('protocol', '').lower()]


### PR DESCRIPTION
This PR adds the possibility to configure a proxy server for the mini / aws s3 storage. The PR resolves https://github.com/datajoint/datajoint-python/issues/961 .