### PR TITLE
Fetch order by bug

### DIFF
--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -106,9 +106,7 @@ class QueryExpression:
         Make the SQL SELECT statement.
         :param fields: used to explicitly set the select attributes
         """
-        distinct = self.heading.names == self.primary_key
-        return 'SELECT {distinct}{fields} FROM {from_}{where}'.format(
-            distinct="DISTINCT " if distinct else "",
+        return 'SELECT {fields} FROM {from_}{where}'.format(
             fields=self.heading.as_sql(fields or self.heading.names),
             from_=self.from_clause(), where=self.where_clause())
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,7 +20,7 @@ from datajoint.utils import parse_sql
 __author__ = 'Edgar Walker, Fabian Sinz, Dimitri Yatsenko, Raphael Guzman'
 
 # turn on verbose logging
-logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.DEBUG)
 
 __all__ = ['__author__', 'PREFIX', 'CONN_INFO']
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -296,4 +296,3 @@ class TestFetch:
         # This command is confirmed to work in v0.12.9 but not in v0.13.2
 
         Parent().fetch('KEY', order_by='name')
-

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -287,3 +287,7 @@ class TestFetch:
 
         # reset cache directory state (will fail if purge was unsuccessful)
         os.rmdir(os.path.expanduser('~/dj_query_cache'))
+    
+    def test_fetch_group_by(self):
+        # nosetests -vs --tests=tests.test_fetch:TestFetch.test_fetch_group_by --nologcapture
+        schema.Parent.fetch('KEY', order_by='name')

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -6,6 +6,7 @@ import decimal
 import pandas
 import warnings
 from . import schema
+from .schema import Parent
 import datajoint as dj
 import os
 
@@ -287,7 +288,12 @@ class TestFetch:
 
         # reset cache directory state (will fail if purge was unsuccessful)
         os.rmdir(os.path.expanduser('~/dj_query_cache'))
-    
+
     def test_fetch_group_by(self):
         # nosetests -vs --tests=tests.test_fetch:TestFetch.test_fetch_group_by --nologcapture
-        schema.Parent.fetch('KEY', order_by='name')
+        # https://github.com/datajoint/datajoint-python/issues/914
+
+        # This command is confirmed to work in v0.12.9 but not in v0.13.2
+
+        Parent().fetch('KEY', order_by='name')
+


### PR DESCRIPTION
Added test based off of linked issue. It seems enforcing DISTINCT when we are making sql queries with primary keys was not useful, I have removed it for now.

fix #914 