### PR TITLE
Fix __len__() for left join QueryExpressions

### DIFF
--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -439,6 +439,14 @@ class QueryExpression:
 
     def __len__(self):
         """:return: number of elements in the result set e.g. ``len(q1)``."""
+        try:
+            if self._left[0]:
+                return self.connection.query(
+                    'SELECT distinct count(*) FROM {from_}{where}'.format(
+                        from_=self.from_clause(),
+                        where=self.where_clause())).fetchone()[0]
+        except IndexError:
+            pass
         return self.connection.query(
             'SELECT count(DISTINCT {fields}) FROM {from_}{where}'.format(
                 fields=self.heading.as_sql(self.primary_key, include_aliases=False),


### PR DESCRIPTION
Left joins in SQL have the possibility of producing entire columns of `NULL` values which leads to some difficulty when we want to know the length of a query expression that has used a left join due to the way `COUNT()` behaves.

When `COUNT()` gets any column passed to it that is entirely `NULL` it returns 0, it does not care if other columns within the parenthesis are populated with something. It is due to this that our current implementation of `__len__` does not produce correct results for certain left joins.

I have resolved this by adding a special count case for when the query expression contains a left join.

Fix #951 