### PR TITLE
Fix #930 union join bug, Add test for union join.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release notes
 
 ### 0.13.3 -- TBD
+* Add - Expose proxy feature for S3 external stores (#961) PR #962
 * Bugfix - Dependencies not properly loaded on populate. (#902) PR #919
 * Bugfix - Replace use of numpy aliases of built-in types with built-in type. (#938) PR #939
 * Bugfix - `ExternalTable.delete` should not remove row on error (#953) PR #956

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Bugfix - Replace use of numpy aliases of built-in types with built-in type. (#938) PR #939
 * Bugfix - `ExternalTable.delete` should not remove row on error (#953) PR #956
 * Bugfix - Fix error handling of remove_object function in `s3.py` (#952) PR #955
+* Bugfix - Fix assertion error when performing a union into a join (#930) PR #967
 
 ### 0.13.2 -- May 7, 2021
 * Update `setuptools_certificate` dependency to new name `otumat`

--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -266,9 +266,11 @@ class QueryExpression:
             - join_attributes)
         # need subquery if any of the join attributes are derived
         need_subquery1 = (need_subquery1 or isinstance(self, Aggregation) or
-                          any(n in self.heading.new_attributes for n in join_attributes))
+                          any(n in self.heading.new_attributes for n in join_attributes)
+                          or isinstance(self, Union))
         need_subquery2 = (need_subquery2 or isinstance(other, Aggregation) or
-                          any(n in other.heading.new_attributes for n in join_attributes))
+                          any(n in other.heading.new_attributes for n in join_attributes)
+                          or isinstance(self, Union))
         if need_subquery1:
             self = self.make_subquery()
         if need_subquery2:

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -1,5 +1,6 @@
 0.13.3 -- TBD
 ----------------------
+* Add - Expose proxy feature for S3 external stores (#961) PR #962
 * Bugfix - Dependencies not properly loaded on populate. (#902) PR #919
 * Bugfix - Replace use of numpy aliases of built-in types with built-in type. (#938) PR #939
 * Bugfix - `ExternalTable.delete` should not remove row on error (#953) PR #956

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -4,6 +4,7 @@
 * Bugfix - Replace use of numpy aliases of built-in types with built-in type. (#938) PR #939
 * Bugfix - `ExternalTable.delete` should not remove row on error (#953) PR #956
 * Bugfix - Fix error handling of remove_object function in `s3.py` (#952) PR #955
+* Bugfix - Fix assertion error when performing a union into a join (#930) PR #967
 
 0.13.2 -- May 7, 2021
 ----------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ minio>=7.0.0
 matplotlib
 cryptography
 otumat
+urllib3

--- a/tests/test_aggr_regressions.py
+++ b/tests/test_aggr_regressions.py
@@ -93,20 +93,6 @@ class X(dj.Lookup):
     """
     contents = zip(range(10))
 
-@schema
-class TableA(dj.Manual):
-    definition = """
-    table_a: int
-    """
-
-
-@schema
-class TableB(dj.Manual):
-    definition = """
-    -> TableA
-    table_b: int
-    """
-
 
 def test_issue558_part1():
     q = (A-B).proj(id2='3')
@@ -120,9 +106,13 @@ def test_issue558_part2():
 
 def test_union_join():
     # https://github.com/datajoint/datajoint-python/issues/930
-    TableA.insert(zip([1, 2, 3, 4, 5, 6]))
-    TableB.insert([(1, 11), (2, 22), (3, 33), (4, 44)])
-    q1 = TableB & 'table_a < 3'
-    q2 = TableB & 'table_a > 3'
+    A.insert(zip([100, 200, 300, 400, 500, 600]))
+    B.insert([(100, 11), (200, 22), (300, 33), (400, 44)])
+    q1 = B & 'id < 300'
+    q2 = B & 'id > 300'
 
-    (q1 + q2) * TableA
+    expected_data = [{'id': 0, 'id2': 5}, {'id': 1, 'id2': 6}, {'id': 2, 'id2': 7},
+                     {'id': 3, 'id2': 8}, {'id': 4, 'id2': 9}, {'id': 100, 'id2': 11},
+                     {'id': 200, 'id2': 22}, {'id': 400, 'id2': 44}]
+
+    assert ((q1 + q2) * A).fetch(as_dict=True) == expected_data

--- a/tests/test_aggr_regressions.py
+++ b/tests/test_aggr_regressions.py
@@ -93,6 +93,20 @@ class X(dj.Lookup):
     """
     contents = zip(range(10))
 
+@schema
+class TableA(dj.Manual):
+    definition = """
+    table_a: int
+    """
+
+
+@schema
+class TableB(dj.Manual):
+    definition = """
+    -> TableA
+    table_b: int
+    """
+
 
 def test_issue558_part1():
     q = (A-B).proj(id2='3')
@@ -103,3 +117,12 @@ def test_issue558_part2():
     d = dict(id=3, id2=5)
     assert_equal(len(X & d), len((X & d).proj(id2='3')))
 
+
+def test_union_join():
+    # https://github.com/datajoint/datajoint-python/issues/930
+    TableA.insert(zip([1, 2, 3, 4, 5, 6]))
+    TableB.insert([(1, 11), (2, 22), (3, 33), (4, 44)])
+    q1 = TableB & 'table_a < 3'
+    q2 = TableB & 'table_a > 3'
+
+    (q1 + q2) * TableA


### PR DESCRIPTION
in 0.13.2 we are improperly forming the sql query when we perform a union and then a join, below are the `make_sql()`'s comparing 0.13.2 to 0.12.9:

```python
(q1 + q2).make_sql() #0.13.2
```
```sql
(SELECT DISTINCT `table_a`,`table_b` FROM `test`.`table_b` WHERE(table_a < 3)) 
UNION 
(SELECT DISTINCT `table_a`,`table_b` FROM `test`.`table_b` WHERE(table_a > 3))
```
```python
((q1 + q2) * TableA).make_sql() #0.13.2
```
```sql
SELECT DISTINCT `table_a`,`table_b` 
FROM (
    SELECT DISTINCT `table_a`,`table_b` 
        FROM `test`.`table_b` 
        WHERE(table_a < 3)) as `$8` 
NATURAL JOIN (
    SELECT DISTINCT `table_a`,`table_b` FROM `test`.`table_b` 
    WHERE(table_a > 3)
    ) as `$9`
```
```python
(q1 + q2).make_sql() #0.12.9
```
```sql
SELECT `table_a`,`table_b` 
FROM (
    SELECT `table_a`,`table_b` 
    FROM `test`.`table_b` WHERE (table_a < 3) 
    UNION 
    SELECT `table_a`,`table_b` 
    FROM `test`.`table_b` 
    WHERE (table_a > 3)
    ) as `_u4`
```
```python
((q1 + q2) * TableA).make_sql() #12.9
```
```sql
SELECT `table_a`,`table_b` 
FROM (
    SELECT `table_a`,`table_b` 
    FROM `test`.`table_b` 
    WHERE (table_a < 3) 
    UNION 
    SELECT `table_a`,`table_b` 
    FROM `test`.`table_b` 
    WHERE (table_a > 3)
    ) as `_u5` 
NATURAL JOIN `test`.`table_a`
```
Below is the `make_sql` after I added code to fix it
```python
((q1 + q2) * TableA).make_sql() #0.13.2 DEV
```
```sql
SELECT DISTINCT `table_a`,`table_b` 
FROM (
    (SELECT DISTINCT `table_a`,`table_b` FROM `test`.`table_b` WHERE(table_a < 3)) 
    UNION 
    (SELECT DISTINCT `table_a`,`table_b` FROM `test`.`table_b` WHERE(table_a > 3))
    ) as `$8` 
NATURAL JOIN 
(SELECT DISTINCT `table_a` FROM `test`.`table_a`) as `$9`
```
I think this solution is good but I have included all the `make_sql()`'s to ensure that my solution did not introduce any unintended consequences.

fix #930 