### PR TITLE
Update graphviz attribute list site, old link 404d

### DIFF
--- a/datajoint/diagram.py
+++ b/datajoint/diagram.py
@@ -296,7 +296,7 @@ else:
                 node.set_style('filled')
 
             for edge in dot.get_edges():
-                # see http://www.graphviz.org/content/attrs
+                # see https://graphviz.org/doc/info/attrs.html
                 src = edge.get_source().strip('"')
                 dest = edge.get_destination().strip('"')
                 props = graph.get_edge_data(src, dest)


### PR DESCRIPTION
Changed a comment linking to graphviz's site. Previous link 404'd, updated with the current list of attributes.

[Archived view of old link](https://web.archive.org/web/20121003105920/http://www.graphviz.org/content/attrs) vs. [Updated link](https://graphviz.org/doc/info/attrs.html).