### PR TITLE
Fix default key_source

### DIFF
--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -26,7 +26,7 @@ class AutoPopulate:
     @property
     def key_source(self):
         """
-        :return: the relation whose primary key values are passed, sequentially, to the
+        :return: the query expression whose primary key values are passed, sequentially, to the
                 ``make`` method when populate() is called.
                 The default value is the join of the parent relations.
                 Users may override to change the granularity or the scope of populate() calls.
@@ -34,7 +34,7 @@ class AutoPopulate:
         def _rename_attributes(table, props):
             return (table.proj(
                 **{attr: ref for attr, ref in props['attr_map'].items() if attr != ref})
-                if props['aliased'] else table)
+                if props['aliased'] else table.proj())
 
         if self._key_source is None:
             parents = self.target.parents(primary=True, as_objects=True, foreign_key_info=True)

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -26,10 +26,10 @@ class AutoPopulate:
     @property
     def key_source(self):
         """
-        :return: the query expression whose primary key values are passed, sequentially, to the
-                ``make`` method when populate() is called.
-                The default value is the join of the parent relations.
-                Users may override to change the granularity or the scope of populate() calls.
+        :return: the query expression that yields primary key values to be passed,
+        sequentially, to the ``make`` method when populate() is called.
+        The default value is the join of the parent relations.
+        Users may override to change the granularity or the scope of populate() calls.
         """
         def _rename_attributes(table, props):
             return (table.proj(

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -55,7 +55,8 @@ class Table(QueryExpression):
     _table_name = None  # must be defined in subclass
     _log_ = None  # placeholder for the Log table object
 
-    # These properties must be set by the schema decorator (schemas.py) at class level or by FreeTable at instance level
+    # These properties must be set by the schema decorator (schemas.py) at class level
+    # or by FreeTable at instance level
     database = None
     declaration_context = None
 


### PR DESCRIPTION
* Fix issue #980

In the default key_source, the secondary attributes must be projected out before joining them. 