### PR TITLE
fix issue #927

### DIFF
--- a/datajoint/dependencies.py
+++ b/datajoint/dependencies.py
@@ -26,8 +26,6 @@ def unite_master_parts(lst):
                     # move from the ith position to the (j+1)th position
                     lst[j+1:i+1] = [name] + lst[j+1:i]
                     break
-            else:
-                raise DataJointError("Found a part table {name} without its master table.".format(name=name))
     return lst
 
 

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -161,6 +161,37 @@ class TestDeclare:
                          {ephys.full_table_name})
 
     @staticmethod
+    def test_descendants_only_contain_part_table():
+        """issue #927"""
+
+        @schema
+        class A(dj.Manual):
+            definition = """
+            a: int
+            """
+
+        @schema
+        class B(dj.Manual):
+            definition = """
+            -> A
+            b: int
+            """
+
+        @schema
+        class Master(dj.Manual):
+            definition = """
+            table_master: int
+            """
+
+            class Part(dj.Part):
+                definition = """
+                -> master
+                -> B
+                """
+
+        assert A.descendants() == ['`djtest_test1`.`a`', '`djtest_test1`.`b`', '`djtest_test1`.`master__part`']
+
+    @staticmethod
     @raises(dj.DataJointError)
     def test_bad_attribute_name():
 


### PR DESCRIPTION
- Removed error throw for uniting parts with missing masters
- Added test case for #927

The `unite_master_parts` method raised an error for lists that contained a part table without its master. Removing this fixes #927 without breaking any tests.