### PR TITLE
Add centralized logger.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Update - Import ABC from collections.abc for Python 3.10 compatibility
 * Bugfix - Fix multiprocessing value error (#1013) PR #1026
 
-### 0.13.4 -- March, 28 2022
+### 0.13.4 -- Mar, 28 2022
 * Add - Allow reading blobs produced by legacy 32-bit compiled mYm library for matlab. PR #995
 * Bugfix - Add missing `jobs` argument for multiprocessing PR #997
 * Add - Test for multiprocessing PR #1008

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Release notes
 
 ### 0.13.6 -- TBD
-* Add - unified package level logger for package
-* Update - swap various datajoint messages, warnings, ect. to use the new logger.
+* Add - unified package level logger for package (#667) PR #1032
+* Update - swap various datajoint messages, warnings, etc. to use the new logger.( #667) PR #1032
 
 ### 0.13.5 -- May 19, 2022
 * Update - Import ABC from collections.abc for Python 3.10 compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 0.13.6 -- TBD
 * Add - unified package level logger for package (#667) PR #1031
-* Update - swap various datajoint messages, warnings, etc. to use the new logger.( #667) PR #1031
+* Update - swap various datajoint messages, warnings, etc. to use the new logger. (#667) PR #1031
 
 ### 0.13.5 -- May 19, 2022
 * Update - Import ABC from collections.abc for Python 3.10 compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Release notes
 
 ### 0.13.6 -- TBD
-* Add - unified package level logger for package (#667) PR #1032
-* Update - swap various datajoint messages, warnings, etc. to use the new logger.( #667) PR #1032
+* Add - unified package level logger for package (#667) PR #1031
+* Update - swap various datajoint messages, warnings, etc. to use the new logger.( #667) PR #1031
 
 ### 0.13.5 -- May 19, 2022
 * Update - Import ABC from collections.abc for Python 3.10 compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Release notes
 
+### 0.13.6 -- TBD
+* Add - unified package level logger for package
+* Update - swap various datajoint messages, warnings, ect. to use the new logger.
+
 ### 0.13.5 -- May 19, 2022
 * Update - Import ABC from collections.abc for Python 3.10 compatibility
 * Bugfix - Fix multiprocessing value error (#1013) PR #1026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Release notes
 
-### 0.13.6 -- TBD
+### 0.13.6 -- Jun 13, 2022
 * Add - unified package level logger for package (#667) PR #1031
 * Update - swap various datajoint messages, warnings, etc. to use the new logger. (#667) PR #1031
 

--- a/LNX-docker-compose.yml
+++ b/LNX-docker-compose.yml
@@ -32,7 +32,7 @@ services:
       interval: 1s
   fakeservices.datajoint.io:
     <<: *net
-    image: datajoint/nginx:v0.1.1
+    image: datajoint/nginx:v0.2.1
     environment:
     - ADD_db_TYPE=DATABASE
     - ADD_db_ENDPOINT=db:3306

--- a/datajoint/__init__.py
+++ b/datajoint/__init__.py
@@ -52,6 +52,7 @@ __all__ = [
     "key_hash",
 ]
 
+from .logging import logger
 from .version import __version__
 from .settings import config
 from .connection import conn, Connection

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -275,7 +275,7 @@ class AutoPopulate:
                 if jobs is not None:
                     jobs.complete(self.target.table_name, self._job_key(key))
             else:
-                logger.debug(f"Making {key} -> {self.target.table_name} ")
+                logger.debug(f"Making {key} -> {self.target.full_table_name}")
                 self.__class__._allow_insert = True
                 try:
                     make(dict(key), **(make_kwargs or {}))
@@ -289,7 +289,7 @@ class AutoPopulate:
                         msg=": " + str(error) if str(error) else "",
                     )
                     logger.debug(
-                        f"Error making {key} -> {self.target.table_name} - {error_message}"
+                        f"Error making {key} -> {self.target.full_table_name} - {error_message}"
                     )
                     if jobs is not None:
                         # show error name and error message (if any)
@@ -306,7 +306,9 @@ class AutoPopulate:
                         return key, error if return_exception_objects else error_message
                 else:
                     self.connection.commit_transaction()
-                    logger.debug(f"Success making {key} -> {self.target.table_name}")
+                    logger.debug(
+                        f"Success making {key} -> {self.target.full_table_name}"
+                    )
                     if jobs is not None:
                         jobs.complete(self.target.table_name, self._job_key(key))
                 finally:

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -275,7 +275,7 @@ class AutoPopulate:
                 if jobs is not None:
                     jobs.complete(self.target.table_name, self._job_key(key))
             else:
-                logger.info("Populating: " + str(key))
+                logger.debug("Populating: " + str(key))
                 self.__class__._allow_insert = True
                 try:
                     make(dict(key), **(make_kwargs or {}))

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -206,7 +206,7 @@ class AutoPopulate:
         elif order == "random":
             random.shuffle(keys)
 
-        logger.info("Found %d keys to populate" % len(keys))
+        logger.debug("Found %d keys to populate" % len(keys))
 
         keys = keys[:max_calls]
         nkeys = len(keys)

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -12,7 +12,7 @@ import multiprocessing as mp
 
 # noinspection PyExceptionInherit,PyCallingNonCallable
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__.split(".")[0])
 
 
 # --- helper functions for multiprocessing --

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -158,7 +158,7 @@ class AutoPopulate:
         max_calls=None,
         display_progress=False,
         processes=1,
-        make_kwargs=None
+        make_kwargs=None,
     ):
         """
         ``table.populate()`` calls ``table.make(key)`` for every primary key in
@@ -275,7 +275,7 @@ class AutoPopulate:
                 if jobs is not None:
                     jobs.complete(self.target.table_name, self._job_key(key))
             else:
-                logger.debug("Populating: " + str(key))
+                logger.debug(f"Making {key} -> {self.target.table_name} ")
                 self.__class__._allow_insert = True
                 try:
                     make(dict(key), **(make_kwargs or {}))
@@ -287,6 +287,9 @@ class AutoPopulate:
                     error_message = "{exception}{msg}".format(
                         exception=error.__class__.__name__,
                         msg=": " + str(error) if str(error) else "",
+                    )
+                    logger.debug(
+                        f"Error making {key} -> {self.target.table_name} - {error_message}"
                     )
                     if jobs is not None:
                         # show error name and error message (if any)
@@ -303,6 +306,7 @@ class AutoPopulate:
                         return key, error if return_exception_objects else error_message
                 else:
                     self.connection.commit_transaction()
+                    logger.debug(f"Success making {key} -> {self.target.table_name}")
                     if jobs is not None:
                         jobs.complete(self.target.table_name, self._job_key(key))
                 finally:

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -17,7 +17,7 @@ from .blob import pack, unpack
 from .hash import uuid_from_buffer
 from .plugin import connection_plugins
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__.split(".")[0])
 query_log_max_length = 300
 
 
@@ -339,7 +339,7 @@ class Connection:
         except errors.LostConnectionError:
             if not reconnect:
                 raise
-            warnings.warn("MySQL server has gone away. Reconnecting to the server.")
+            logger.warning("MySQL server has gone away. Reconnecting to the server.")
             connect_host_hook(self)
             if self._in_transaction:
                 self.cancel_transaction()

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -184,7 +184,7 @@ class Connection:
         self.conn_info["ssl_input"] = use_tls
         self.conn_info["host_input"] = host_input
         self.init_fun = init_fun
-        print("Connecting {user}@{host}:{port}".format(**self.conn_info))
+        logger.info("Connecting {user}@{host}:{port}".format(**self.conn_info))
         self._conn = None
         self._query_cache = None
         connect_host_hook(self)

--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -380,7 +380,7 @@ class Connection:
             raise errors.DataJointError("Nested connections are not supported.")
         self.query("START TRANSACTION WITH CONSISTENT SNAPSHOT")
         self._in_transaction = True
-        logger.info("Transaction started")
+        logger.debug("Transaction started")
 
     def cancel_transaction(self):
         """
@@ -388,7 +388,7 @@ class Connection:
         """
         self.query("ROLLBACK")
         self._in_transaction = False
-        logger.info("Transaction cancelled. Rolling back ...")
+        logger.debug("Transaction cancelled. Rolling back ...")
 
     def commit_transaction(self):
         """
@@ -397,7 +397,7 @@ class Connection:
         """
         self.query("COMMIT")
         self._in_transaction = False
-        logger.info("Transaction committed and closed.")
+        logger.debug("Transaction committed and closed.")
 
     # -------- context manager for transactions
     @property

--- a/datajoint/declare.py
+++ b/datajoint/declare.py
@@ -75,7 +75,7 @@ def match_type(attribute_type):
         )
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__.split(".")[0])
 
 
 def build_foreign_key_parser_old():
@@ -207,7 +207,7 @@ def compile_foreign_key(
         )
 
     if obsolete:
-        warnings.warn(
+        logger.warning(
             'Line "{line}" uses obsolete syntax that will no longer be supported in datajoint 0.14. '
             "For details, see issue #780 https://github.com/datajoint/datajoint-python/issues/780".format(
                 line=line

--- a/datajoint/diagram.py
+++ b/datajoint/diagram.py
@@ -10,7 +10,6 @@ from .user_tables import Manual, Imported, Computed, Lookup, Part
 from .errors import DataJointError
 from .table import lookup_class_name
 
-logger = logging.getLogger(__name__.split(".")[0])
 
 try:
     from matplotlib import pyplot as plt
@@ -27,6 +26,7 @@ except:
     diagram_active = False
 
 
+logger = logging.getLogger(__name__.split(".")[0])
 user_table_classes = (Manual, Lookup, Computed, Imported, Part)
 
 

--- a/datajoint/diagram.py
+++ b/datajoint/diagram.py
@@ -6,6 +6,9 @@ import logging
 import inspect
 from .table import Table
 from .dependencies import unite_master_parts
+from .user_tables import Manual, Imported, Computed, Lookup, Part
+from .errors import DataJointError
+from .table import lookup_class_name
 
 logger = logging.getLogger(__name__.split(".")[0])
 
@@ -22,10 +25,6 @@ try:
     diagram_active = True
 except:
     diagram_active = False
-
-from .user_tables import Manual, Imported, Computed, Lookup, Part
-from .errors import DataJointError
-from .table import lookup_class_name
 
 
 user_table_classes = (Manual, Lookup, Computed, Imported, Part)

--- a/datajoint/diagram.py
+++ b/datajoint/diagram.py
@@ -2,10 +2,12 @@ import networkx as nx
 import re
 import functools
 import io
-import warnings
+import logging
 import inspect
 from .table import Table
 from .dependencies import unite_master_parts
+
+logger = logging.getLogger(__name__.split(".")[0])
 
 try:
     from matplotlib import pyplot as plt
@@ -63,7 +65,7 @@ if not diagram_active:
         """
 
         def __init__(self, *args, **kwargs):
-            warnings.warn(
+            logger.warning(
                 "Please install matplotlib and pygraphviz libraries to enable the Diagram feature."
             )
 

--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -17,7 +17,7 @@ from .condition import (
 )
 from .declare import CONSTANT_LITERALS
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__.split(".")[0])
 
 
 class QueryExpression:

--- a/datajoint/fetch.py
+++ b/datajoint/fetch.py
@@ -1,6 +1,6 @@
 from functools import partial
 from pathlib import Path
-import warnings
+import logging
 import pandas
 import itertools
 import re
@@ -11,6 +11,8 @@ from . import blob, hash
 from .errors import DataJointError
 from .settings import config
 from .utils import safe_write
+
+logger = logging.getLogger(__name__.split(".")[0])
 
 
 class key:
@@ -209,7 +211,7 @@ class Fetch:
                 )
 
         if limit is None and offset is not None:
-            warnings.warn(
+            logger.warning(
                 "Offset set, but no limit. Setting limit to a large number. "
                 "Consider setting a limit explicitly."
             )

--- a/datajoint/heading.py
+++ b/datajoint/heading.py
@@ -14,7 +14,7 @@ from .declare import (
 from .attribute_adapter import get_adapter, AttributeAdapter
 
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__.split(".")[0])
 
 default_attribute_properties = (
     dict(  # these default values are set in computed attributes

--- a/datajoint/logging.py
+++ b/datajoint/logging.py
@@ -1,0 +1,57 @@
+import logging
+import os
+import sys
+import io
+
+logger = logging.getLogger(__name__.split(".")[0])
+
+log_level = os.environ.get("DJ_LOG_LEVEL", "warning").upper()
+
+log_format = logging.Formatter(
+    "[%(asctime)s][%(funcName)s][%(levelname)s]: %(message)s"
+)
+
+stream_handler = logging.StreamHandler()  # default handler
+stream_handler.setFormatter(log_format)
+
+logger.setLevel(level=log_level)
+logger.handlers = [stream_handler]
+
+
+def excepthook(exc_type, exc_value, exc_traceback):
+    if issubclass(exc_type, KeyboardInterrupt):
+        sys.__excepthook__(exc_type, exc_value, exc_traceback)
+        return
+
+    if logger.getEffectiveLevel() == 10:
+        logger.debug(
+            "Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback)
+        )
+    else:
+        logger.error(f"Uncaught exception: {exc_value}")
+
+
+sys.excepthook = excepthook
+
+
+# https://github.com/tqdm/tqdm/issues/313#issuecomment-267959111
+class TqdmToLogger(io.StringIO):
+    """
+    Output stream for TQDM which will output to logger module instead of
+    the StdOut.
+    """
+
+    logger = None
+    level = None
+    buf = ""
+
+    def __init__(self, logger, level=None):
+        super(TqdmToLogger, self).__init__()
+        self.logger = logger
+        self.level = level or logging.INFO
+
+    def write(self, buf):
+        self.buf = buf.strip("\r\n\t ")
+
+    def flush(self):
+        self.logger.log(self.level, self.buf)

--- a/datajoint/logging.py
+++ b/datajoint/logging.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__.split(".")[0])
 log_level = os.getenv("DJ_LOG_LEVEL", "info").upper()
 
 log_format = logging.Formatter(
-    "[%(asctime)s][%(funcName)s][%(levelname)s]: %(message)s"
+    "[%(asctime)s][%(levelname)s]: %(message)s"
 )
 
 stream_handler = logging.StreamHandler()  # default handler

--- a/datajoint/logging.py
+++ b/datajoint/logging.py
@@ -7,9 +7,7 @@ logger = logging.getLogger(__name__.split(".")[0])
 
 log_level = os.getenv("DJ_LOG_LEVEL", "info").upper()
 
-log_format = logging.Formatter(
-    "[%(asctime)s][%(levelname)s]: %(message)s"
-)
+log_format = logging.Formatter("[%(asctime)s][%(levelname)s]: %(message)s")
 
 stream_handler = logging.StreamHandler()  # default handler
 stream_handler.setFormatter(log_format)

--- a/datajoint/logging.py
+++ b/datajoint/logging.py
@@ -5,7 +5,7 @@ import io
 
 logger = logging.getLogger(__name__.split(".")[0])
 
-log_level = os.environ.get("DJ_LOG_LEVEL", "warning").upper()
+log_level = os.getenv("DJ_LOG_LEVEL", "info").upper()
 
 log_format = logging.Formatter(
     "[%(asctime)s][%(funcName)s][%(levelname)s]: %(message)s"
@@ -32,26 +32,3 @@ def excepthook(exc_type, exc_value, exc_traceback):
 
 
 sys.excepthook = excepthook
-
-
-# https://github.com/tqdm/tqdm/issues/313#issuecomment-267959111
-class TqdmToLogger(io.StringIO):
-    """
-    Output stream for TQDM which will output to logger module instead of
-    the StdOut.
-    """
-
-    logger = None
-    level = None
-    buf = ""
-
-    def __init__(self, logger, level=None):
-        super(TqdmToLogger, self).__init__()
-        self.logger = logger
-        self.level = level or logging.INFO
-
-    def write(self, buf):
-        self.buf = buf.strip("\r\n\t ")
-
-    def flush(self):
-        self.logger.log(self.level, self.buf)

--- a/datajoint/plugin.py
+++ b/datajoint/plugin.py
@@ -3,6 +3,9 @@ import pkg_resources
 from pathlib import Path
 from cryptography.exceptions import InvalidSignature
 from otumat import hash_pkg, verify
+import logging
+
+logger = logging.getLogger(__name__.split(".")[0])
 
 
 def _update_error_stack(plugin_name):
@@ -15,10 +18,10 @@ def _update_error_stack(plugin_name):
         signature = plugin_meta.get_metadata("{}.sig".format(plugin_name))
         pubkey_path = str(Path(base_meta.egg_info, "{}.pub".format(base_name)))
         verify(pubkey_path=pubkey_path, data=data, signature=signature)
-        print("DataJoint verified plugin `{}` detected.".format(plugin_name))
+        logger.info("DataJoint verified plugin `{}` detected.".format(plugin_name))
         return True
     except (FileNotFoundError, InvalidSignature):
-        print("Unverified plugin `{}` detected.".format(plugin_name))
+        logger.warning("Unverified plugin `{}` detected.".format(plugin_name))
         return False
 
 

--- a/datajoint/plugin.py
+++ b/datajoint/plugin.py
@@ -15,13 +15,13 @@ def _update_error_stack(plugin_name):
         plugin_meta = pkg_resources.get_distribution(plugin_name)
 
         data = hash_pkg(pkgpath=str(Path(plugin_meta.module_path, plugin_name)))
-        signature = plugin_meta.get_metadata("{}.sig".format(plugin_name))
-        pubkey_path = str(Path(base_meta.egg_info, "{}.pub".format(base_name)))
+        signature = plugin_meta.get_metadata(f"{plugin_name}.sig")
+        pubkey_path = str(Path(base_meta.egg_info, f"{base_name}.pub"))
         verify(pubkey_path=pubkey_path, data=data, signature=signature)
-        logger.info("DataJoint verified plugin `{}` detected.".format(plugin_name))
+        logger.info(f"DataJoint verified plugin `{plugin_name}` detected.")
         return True
     except (FileNotFoundError, InvalidSignature):
-        logger.warning("Unverified plugin `{}` detected.".format(plugin_name))
+        logger.warning(f"Unverified plugin `{plugin_name}` detected.")
         return False
 
 

--- a/datajoint/s3.py
+++ b/datajoint/s3.py
@@ -4,13 +4,12 @@ AWS S3 operations
 from io import BytesIO
 import minio  # https://docs.minio.io/docs/python-client-api-reference
 import urllib3
-import warnings
 import uuid
 import logging
 from pathlib import Path
 from . import errors
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__.split(".")[0])
 
 
 class Folder:

--- a/datajoint/schemas.py
+++ b/datajoint/schemas.py
@@ -16,7 +16,7 @@ from .user_tables import Part, Computed, Imported, Manual, Lookup
 from .table import lookup_class_name, Log, FreeTable
 import types
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__.split(".")[0])
 
 
 def ordered_dir(class_):

--- a/datajoint/schemas.py
+++ b/datajoint/schemas.py
@@ -134,7 +134,7 @@ class Schema:
                     )
                 )
             # create database
-            logger.info("Creating schema `{name}`.".format(name=schema_name))
+            logger.debug("Creating schema `{name}`.".format(name=schema_name))
             try:
                 self.connection.query(
                     "CREATE DATABASE `{name}`".format(name=schema_name)
@@ -360,12 +360,12 @@ class Schema:
             )
             == "yes"
         ):
-            logger.info("Dropping `{database}`.".format(database=self.database))
+            logger.debug("Dropping `{database}`.".format(database=self.database))
             try:
                 self.connection.query(
                     "DROP DATABASE `{database}`".format(database=self.database)
                 )
-                logger.info(
+                logger.debug(
                     "Schema `{database}` was dropped successfully.".format(
                         database=self.database
                     )

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -240,8 +240,8 @@ class Config(collections.abc.MutableMapping):
             return self._conf[key]
 
         def __setitem__(self, key, value):
-            logger.log(
-                logging.INFO, "Setting {0:s} to {1:s}".format(str(key), str(value))
+            logger.debug(
+                logging.DEBUG, "Setting {0:s} to {1:s}".format(str(key), str(value))
             )
             if validators[key](value):
                 self._conf[key] = value

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -49,7 +49,7 @@ default = dict(
     }
 )
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__.split(".")[0])
 log_levels = {
     "INFO": logging.INFO,
     "WARNING": logging.WARNING,

--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -104,7 +104,7 @@ class Config(collections.abc.MutableMapping):
         with open(filename, "w") as fid:
             json.dump(self._conf, fid, indent=4)
         if verbose:
-            print("Saved settings in " + filename)
+            logger.info("Saved settings in " + filename)
 
     def load(self, filename):
         """

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -7,7 +7,6 @@ import pandas
 import logging
 import uuid
 import re
-import warnings
 from pathlib import Path
 from .settings import config
 from .declare import declare, alter
@@ -25,7 +24,7 @@ from .errors import (
 )
 from .version import __version__ as version
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(__name__.split(".")[0])
 
 foreign_key_error_regexp = re.compile(
     r"[\w\s:]*\((?P<child>`[^`]+`.`[^`]+`), "
@@ -532,7 +531,7 @@ class Table(QueryExpression):
                     cascade(child)
                 else:
                     deleted.add(table.full_table_name)
-                    print(
+                    logger.info(
                         "Deleting {count} rows from {table}".format(
                             count=delete_count, table=table.full_table_name
                         )
@@ -768,7 +767,7 @@ class Table(QueryExpression):
         >>> (v2p.Mice() & key)._update('mouse_dob', '2011-01-01')
         >>> (v2p.Mice() & key)._update( 'lens')   # set the value to NULL
         """
-        warnings.warn(
+        logger.warning(
             "`_update` is a deprecated function to be removed in datajoint 0.14. "
             "Use `.update1` instead."
         )

--- a/datajoint/version.py
+++ b/datajoint/version.py
@@ -1,3 +1,3 @@
-__version__ = "0.13.5"
+__version__ = "0.13.6"
 
 assert len(__version__) <= 10  # The log table limits version to the 10 characters

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -1,7 +1,7 @@
 0.13.6 -- TBD
 ----------------------
 * Add - unified package level logger for package (#667) PR #1031
-* Update - swap various datajoint messages, warnings, etc. to use the new logger.( #667) PR #1031
+* Update - swap various datajoint messages, warnings, etc. to use the new logger. (#667) PR #1031
 
 0.13.5 -- May 19, 2022
 ----------------------

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -1,6 +1,6 @@
 0.13.6 -- TBD
-* Add - unified package level logger for package
-* Update - swap various datajoint messages, warnings, ect. to use the new logger.
+* Add - unified package level logger for package (#667) PR #1032
+* Update - swap various datajoint messages, warnings, etc. to use the new logger.( #667) PR #1032
 
 0.13.5 -- May 19, 2022
 ----------------------

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -1,4 +1,4 @@
-0.13.6 -- TBD
+0.13.6 -- Jun 13, 2022
 ----------------------
 * Add - unified package level logger for package (#667) PR #1031
 * Update - swap various datajoint messages, warnings, etc. to use the new logger. (#667) PR #1031

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -1,6 +1,7 @@
 0.13.6 -- TBD
-* Add - unified package level logger for package (#667) PR #1032
-* Update - swap various datajoint messages, warnings, etc. to use the new logger.( #667) PR #1032
+----------------------
+* Add - unified package level logger for package (#667) PR #1031
+* Update - swap various datajoint messages, warnings, etc. to use the new logger.( #667) PR #1031
 
 0.13.5 -- May 19, 2022
 ----------------------

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -1,3 +1,7 @@
+0.13.6 -- TBD
+* Add - unified package level logger for package
+* Update - swap various datajoint messages, warnings, ect. to use the new logger.
+
 0.13.5 -- May 19, 2022
 ----------------------
 * Update - Import ABC from collections.abc for Python 3.10 compatibility

--- a/docs-parts/intro/Releases_lang1.rst
+++ b/docs-parts/intro/Releases_lang1.rst
@@ -8,7 +8,7 @@
 * Update - Import ABC from collections.abc for Python 3.10 compatibility
 * Bugfix - Fix multiprocessing value error (#1013) PR #1026
 
-0.13.4 -- March 28, 2022
+0.13.4 -- Mar 28, 2022
 ----------------------
 * Add - Allow reading blobs produced by legacy 32-bit compiled mYm library for matlab. PR #995
 * Bugfix - Add missing ``jobs`` argument for multiprocessing PR #997

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -34,7 +34,7 @@ services:
       interval: 1s
   fakeservices.datajoint.io:
     <<: *net
-    image: datajoint/nginx:v0.1.1
+    image: datajoint/nginx:v0.2.1
     environment:
     - ADD_db_TYPE=DATABASE
     - ADD_db_ENDPOINT=db:3306

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -198,8 +198,7 @@ class TestFetch:
 
     def test_offset(self):
         """Tests offset"""
-        with warnings.catch_warnings(record=True) as w:
-            cur = self.lang.fetch(limit=4, offset=1, order_by=["language", "name DESC"])
+        cur = self.lang.fetch(limit=4, offset=1, order_by=["language", "name DESC"])
 
         languages = self.lang.contents
         languages.sort(key=itemgetter(0), reverse=True)
@@ -210,11 +209,12 @@ class TestFetch:
                 np.all([cc == ll for cc, ll in zip(c, l)]), "Sorting order is different"
             )
 
-    def test_limit_warning(self):
-        """Tests whether warning is raised if offset is used without limit."""
-        with warnings.catch_warnings(record=True) as w:
-            self.lang.fetch(offset=1)
-            assert_true(len(w) > 0, "Warning was not raised")
+    # Need to change this to test a log instead of a warning now
+    # def test_limit_warning(self):
+    #     """Tests whether warning is raised if offset is used without limit."""
+    #     with warnings.catch_warnings(record=True) as w:
+    #         self.lang.fetch(offset=1)
+    #         assert_true(len(w) > 0, "Warning was not raised")
 
     def test_len(self):
         """Tests __len__"""


### PR DESCRIPTION
Adds a package level logger for the datajoint package.

### Should accomplish the following:
- [x] bring all the loggers under the same logger, in the current DJ we make loggers per module.
- [x] convert all warnings to logs with level WARNING 
- [x] update any tests
- [x] convert any applicable print statements to logs
~~- [ ] Evaluate log DB table to see if logging needs to be added~~

### Additional functionality requested by data science team:
~~- [ ] log warnings when user calls populate on empty `key_source`~~
~~- [ ] debug level logging for any insert/delete~~
- [X] example for adding handler to the logger so they can send log output to sources other than stdout

### Example for capturing the log output but maintaining dj logging
See the converted test `test_limit_warning` in the PR.
Basically you add a handler to the logger that sends all logs to a StringIO object and then retrieve the string from the object, then you remove the handler.