### PR TITLE
fix: don't show preview if database connection not activated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ __main__.py
 jupyter_custom.js
 apk_requirements.txt
 .eggs
+environment.yml
+*.code-workspace

--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -1,21 +1,22 @@
-from itertools import count
-import logging
-import inspect
 import copy
+import inspect
+import logging
 import re
-from .settings import config
-from .errors import DataJointError
-from .fetch import Fetch, Fetch1
-from .preview import preview, repr_html
+from itertools import count
+
 from .condition import (
     AndList,
     Not,
-    make_condition,
+    PromiscuousOperand,
     assert_join_compatibility,
     extract_column_names,
-    PromiscuousOperand,
+    make_condition,
 )
 from .declare import CONSTANT_LITERALS
+from .errors import DataJointError
+from .fetch import Fetch, Fetch1
+from .preview import preview, repr_html
+from .settings import config
 
 logger = logging.getLogger(__name__.split(".")[0])
 
@@ -638,7 +639,7 @@ class QueryExpression:
         """
         return (
             super().__repr__()
-            if config["loglevel"].lower() == "debug"
+            if config["loglevel"].lower() == "debug" or self.database is None
             else self.preview()
         )
 

--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -639,7 +639,8 @@ class QueryExpression:
         """
         return (
             super().__repr__()
-            if config["loglevel"].lower() == "debug" or self.database is None
+            if config["loglevel"].lower() == "debug"
+            or getattr(self, "database", None) is None
             else self.preview()
         )
 


### PR DESCRIPTION
currently, the only way to not throw an error when printing class methods or attributes for an inactive UserTable is to set config to "debug"