### PR TITLE
Update bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug, awaiting-triage'
+labels: 'bug'
 assignees: ''
 
 ---


### PR DESCRIPTION
removes the `awaiting-triage` tag from new issues made with the template.