### PR TITLE
Fix readability of tutorials in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Upcoming
 - Fixed - Fix altering a part table that uses the "master" keyword - PR [#991](https://github.com/datajoint/datajoint-python/pull/991)
-
-### 0.14.1 -- Apr 05, 2023
 - Fixed - `.ipynb` output in tutorials is not visible in dark mode ([#1078](https://github.com/datajoint/datajoint-python/issues/1078)) PR [#1080](https://github.com/datajoint/datajoint-python/pull/1080)
  
 ### 0.14.0 -- Feb 13, 2023
@@ -19,7 +17,7 @@
 - Deprecated - `table._update()` PR [#1073](https://github.com/datajoint/datajoint-python/pull/1073)
 - Deprecated - old-style foreign key syntax PR [#1073](https://github.com/datajoint/datajoint-python/pull/1073)
 - Deprecated - `dj.migrate_dj011_external_blob_storage_to_dj012()` PR [#1073](https://github.com/datajoint/datajoint-python/pull/1073)
-* Added - Method to set job keys to "ignore" status - PR [#1068](https://github.com/datajoint/datajoint-python/pull/1068)
+- Added - Method to set job keys to "ignore" status - PR [#1068](https://github.com/datajoint/datajoint-python/pull/1068)
 
 ### 0.13.8 -- Sep 21, 2022
 - Added - New documentation structure based on markdown PR [#1052](https://github.com/datajoint/datajoint-python/pull/1052)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Release notes
 
 ### 0.14.1 -- Feb 21, 2023
-- Fixed - .ipynb output in tutorials is not visible in dark mode ([#1078](https://github.com/datajoint/datajoint-python/issues/1078))
+- Fixed - .ipynb output in tutorials is not visible in dark mode ([#1078](https://github.com/datajoint/datajoint-python/issues/1078) PR [#1080](https://github.com/datajoint/datajoint-python/pull/1080))
  
 ### 0.14.0 -- Feb 13, 2023
 - Added - `json` data type ([#245](https://github.com/datajoint/datajoint-python/issues/245)) PR [#1051](https://github.com/datajoint/datajoint-python/pull/1051)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release notes
 
+### 0.14.1 -- Feb 21, 2023
+- Fixed - .ipynb output in tutorials is not visible in dark mode ([#1078](https://github.com/datajoint/datajoint-python/issues/1078))
+ 
 ### 0.14.0 -- Feb 13, 2023
 - Added - `json` data type ([#245](https://github.com/datajoint/datajoint-python/issues/245)) PR [#1051](https://github.com/datajoint/datajoint-python/pull/1051)
 - Fixed - Activating a schema requires all tables to exist even if `create_tables=False` PR [#1058](https://github.com/datajoint/datajoint-python/pull/1058)

--- a/LNX-docker-compose.yml
+++ b/LNX-docker-compose.yml
@@ -44,7 +44,7 @@ services:
       interval: 15s
   fakeservices.datajoint.io:
     <<: *net
-    image: datajoint/nginx:v0.2.4
+    image: datajoint/nginx:v0.2.5
     environment:
       - ADD_db_TYPE=DATABASE
       - ADD_db_ENDPOINT=db:3306

--- a/datajoint/version.py
+++ b/datajoint/version.py
@@ -1,3 +1,3 @@
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 
 assert len(__version__) <= 10  # The log table limits version to the 10 characters

--- a/docs/.docker/pip_requirements.txt
+++ b/docs/.docker/pip_requirements.txt
@@ -1,3 +1,4 @@
+typing-extensions
 mkdocs-material
 mkdocs-redirects
 mkdocstrings

--- a/docs/.docker/pip_requirements.txt
+++ b/docs/.docker/pip_requirements.txt
@@ -1,4 +1,3 @@
-typing-extensions
 mkdocs-material
 mkdocs-redirects
 mkdocstrings

--- a/docs/src/.overrides/assets/stylesheets/extra.css
+++ b/docs/src/.overrides/assets/stylesheets/extra.css
@@ -91,3 +91,7 @@ html a[title="YouTube"].md-social__link svg {
     /* previous/next text */
     /* --md-footer-fg-color: var(--dj-white); */
 }
+
+[data-md-color-scheme="slate"] .jupyter-wrapper .Table td {
+    color: var(--dj-primary);
+}

--- a/docs/src/.overrides/assets/stylesheets/extra.css
+++ b/docs/src/.overrides/assets/stylesheets/extra.css
@@ -15,27 +15,35 @@
 html a[title="DataJoint"].md-social__link svg {
     color: var(--dj-primary);
 }
+
 html a[title="Slack"].md-social__link svg {
     color: var(--dj-primary);
 }
+
 html a[title="LinkedIn"].md-social__link svg {
     color: var(--dj-primary);
 }
+
 html a[title="Twitter"].md-social__link svg {
     color: var(--dj-primary);
 }
+
 html a[title="GitHub"].md-social__link svg {
     color: var(--dj-primary);
 }
+
 html a[title="DockerHub"].md-social__link svg {
     color: var(--dj-primary);
 }
+
 html a[title="PyPI"].md-social__link svg {
     color: var(--dj-primary);
 }
+
 html a[title="StackOverflow"].md-social__link svg {
     color: var(--dj-primary);
 }
+
 html a[title="YouTube"].md-social__link svg {
     color: var(--dj-primary);
 }
@@ -92,6 +100,6 @@ html a[title="YouTube"].md-social__link svg {
     /* --md-footer-fg-color: var(--dj-white); */
 }
 
-[data-md-color-scheme="slate"] .jupyter-wrapper .Table td {
-    color: var(--dj-primary);
+[data-md-color-scheme="slate"] .jupyter-wrapper .Table Td {
+    color: var(--dj-black)
 }

--- a/local-docker-compose.yml
+++ b/local-docker-compose.yml
@@ -46,7 +46,7 @@ services:
       interval: 15s
   fakeservices.datajoint.io:
     <<: *net
-    image: datajoint/nginx:v0.2.4
+    image: datajoint/nginx:v0.2.5
     environment:
       - ADD_db_TYPE=DATABASE
       - ADD_db_ENDPOINT=db:3306


### PR DESCRIPTION
This PR fixes the readability of the Jupyter Notebook outputs in the `Using the json type` tutorials. This resolves [issue 1078](https://github.com/datajoint/datajoint-python/issues/1078). 

Below are the screenshots from local testing after applying changes to the code as seen in this PR: 
Dark mode - the font in the tables previously appeared white, and was therefore, not readable. See linked issue above for images.

![image](https://user-images.githubusercontent.com/52367253/220453197-d66cff9a-5480-4434-b677-a83b270ccd6c.png)

Light mode - there was no issue here previously and remains the same as before.

![image](https://user-images.githubusercontent.com/52367253/220453430-972565ef-b422-43ef-ab75-e0eed51270ab.png)
