### PR TITLE
Fix for docs release

### DIFF
--- a/docs/.docker/Dockerfile
+++ b/docs/.docker/Dockerfile
@@ -12,4 +12,4 @@ RUN \
 COPY --chown=anaconda:anaconda ./${PACKAGE} /main/${PACKAGE}
 COPY --chown=anaconda:anaconda ./docs/mkdocs.yaml /main/docs/mkdocs.yaml
 COPY --chown=anaconda:anaconda ./docs/src /main/docs/src
-COPY --chown=anaconda:anaconda ./CHANGELOG.md /main/docs/src/about/changelog.md
+COPY --chown=anaconda:anaconda ./CHANGELOG.md /main/docs/src/changelog.md

--- a/docs/src/.overrides/assets/stylesheets/extra.css
+++ b/docs/src/.overrides/assets/stylesheets/extra.css
@@ -11,10 +11,6 @@
     display: none
 }
 
-tr#symbol-middle {
-    vertical-align: 70%;
-}
-
 /* footer social icons */
 html a[title="DataJoint"].md-social__link svg {
     color: var(--dj-primary);
@@ -104,21 +100,6 @@ html a[title="YouTube"].md-social__link svg {
     /* --md-footer-fg-color: var(--dj-white); */
 }
 
-table {
-    border-collapse: collapse;
-}
-
-tr {
-    border-left: 1px solid var(--dj-black);
-    border-right: 1px solid var(--dj-black);
-}
-
-td, th {
-    border-top: 1px solid var(--dj-black);
-    border-bottom: 1px solid var(--dj-black);
-}
-
-[data-md-color-scheme="slate"] td, th {
-    background-color: var(--dj-white);
-    color: var(--dj-black);
+[data-md-color-scheme="slate"] .jupyter-wrapper .Table Td {
+    color: var(--dj-black)
 }

--- a/docs/src/.overrides/assets/stylesheets/extra.css
+++ b/docs/src/.overrides/assets/stylesheets/extra.css
@@ -11,6 +11,10 @@
     display: none
 }
 
+tr#symbol-middle {
+    vertical-align: 70%;
+}
+
 /* footer social icons */
 html a[title="DataJoint"].md-social__link svg {
     color: var(--dj-primary);
@@ -100,6 +104,21 @@ html a[title="YouTube"].md-social__link svg {
     /* --md-footer-fg-color: var(--dj-white); */
 }
 
-[data-md-color-scheme="slate"] .jupyter-wrapper .Table Td {
-    color: var(--dj-black)
+table {
+    border-collapse: collapse;
+}
+
+tr {
+    border-left: 1px solid var(--dj-black);
+    border-right: 1px solid var(--dj-black);
+}
+
+td, th {
+    border-top: 1px solid var(--dj-black);
+    border-bottom: 1px solid var(--dj-black);
+}
+
+[data-md-color-scheme="slate"] td, th {
+    background-color: var(--dj-white);
+    color: var(--dj-black);
 }


### PR DESCRIPTION
## Description
- In https://github.com/datajoint/datajoint-python/pull/1087, I moved `docs/src/about/changelog.md` → `docs/src/changelog.md`, but did not update the `docs/.docker/Dockerfile`.
- The docs release for version 0.14.1 failed due to the missing changelog.  See [GitHub Actions run](https://github.com/datajoint/datajoint-python/actions/runs/5160298976/jobs/9296261917#step:3:396).

## Changes
- [x] Update the `docs/.docker/Dockerfile` with the updated path of the changelog.