### PR TITLE
Update set_password to work on MySQL 8

### DIFF
--- a/datajoint/admin.py
+++ b/datajoint/admin.py
@@ -15,7 +15,7 @@ def set_password(new_password=None, connection=None, update_config=None):
         new_password = getpass("New password: ")
         confirm_password = getpass("Confirm password: ")
         if new_password != confirm_password:
-            logger.warn("Failed to confirm the password! Aborting password change.")
+            logger.warning("Failed to confirm the password! Aborting password change.")
             return
 
     if version.parse(

--- a/datajoint/admin.py
+++ b/datajoint/admin.py
@@ -1,5 +1,6 @@
 import pymysql
 from getpass import getpass
+from packaging import version
 from .connection import conn
 from .settings import config
 from .utils import user_choice
@@ -16,7 +17,14 @@ def set_password(new_password=None, connection=None, update_config=None):
         if new_password != confirm_password:
             logger.warn("Failed to confirm the password! Aborting password change.")
             return
-    connection.query("SET PASSWORD = PASSWORD('%s')" % new_password)
+
+    if version.parse(
+        connection.query("select @@version;").fetchone()[0]
+    ) >= version.parse("5.7"):
+        # SET PASSWORD is deprecated as of MySQL 5.7 and removed in 8+
+        connection.query("ALTER USER user() IDENTIFIED BY '%s';" % new_password)
+    else:
+        connection.query("SET PASSWORD = PASSWORD('%s')" % new_password)
     logger.info("Password updated.")
 
     if update_config or (

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,53 +1,152 @@
 """
-Collection of test cases to test connection module.
+Collection of test cases to test admin module.
 """
 
 import datajoint as dj
-from datajoint import DataJointError
-import numpy as np
-from . import CONN_INFO_ROOT, connection_root, connection_test
-
-from . import PREFIX
+import os
 import pymysql
 import pytest
 
+from . import CONN_INFO_ROOT
 
-def test_set_password_prompt_match(monkeypatch):
+
+@pytest.fixture()
+def user_alice() -> dict:
+    # set up - reset config, log in as root, and create a new user alice
+    # reset dj.config manually because its state may be changed by these tests
+    if os.path.exists(dj.settings.LOCALCONFIG):
+        os.remove(dj.settings.LOCALCONFIG)
+    dj.config["database.password"] = os.getenv("DJ_PASS")
+    root_conn = dj.conn(**CONN_INFO_ROOT, reset=True)
+    new_credentials = dict(
+        host=CONN_INFO_ROOT["host"],
+        user="alice",
+        password="oldpass",
+    )
+    root_conn.query(f"DROP USER IF EXISTS '{new_credentials['user']}'@'%%';")
+    root_conn.query(
+        f"CREATE USER '{new_credentials['user']}'@'%%' "
+        f"IDENTIFIED BY '{new_credentials['password']}';"
+    )
+
+    # test the connection
+    dj.Connection(**new_credentials)
+
+    # return alice's credentials
+    yield new_credentials
+
+    # tear down - delete the user and the local config file
+    root_conn.query(f"DROP USER '{new_credentials['user']}'@'%%';")
+    if os.path.exists(dj.settings.LOCALCONFIG):
+        os.remove(dj.settings.LOCALCONFIG)
+
+
+def test_set_password_prompt_match(monkeypatch, user_alice: dict):
     """
     Should be able to change the password using user prompt
     """
-    c = dj.conn(**CONN_INFO_ROOT)
-    c.query("CREATE USER 'alice'@'%' IDENTIFIED BY 'pass';")
-    # prompt responses: new password / confirm password / update local setting?
-    responses = ["newpass", "newpass", "yes"]
-    monkeypatch.setattr('getpass.getpass', lambda _: next(responses)) 
-    monkeypatch.setattr('input', lambda _: next(responses)) 
+    # reset the connection to use alice's credentials
+    dj.conn(**user_alice, reset=True)
 
+    # prompts: new password / confirm password
+    password_resp = iter(["newpass", "newpass"])
+    # NOTE: because getpass.getpass is imported in datajoint.admin and used as
+    # getpass in that module, we need to patch datajoint.admin.getpass
+    # instead of getpass.getpass
+    monkeypatch.setattr("datajoint.admin.getpass", lambda _: next(password_resp))
+
+    # respond no to prompt to update local config
+    monkeypatch.setattr("builtins.input", lambda _: "no")
+
+    # reset password of user of current connection (alice)
     dj.set_password()
 
+    # should not be able to connect with old credentials
     with pytest.raises(pymysql.err.OperationalError):
-        # should not be able to log in with old credentials
-        dj.conn(host=CONN_INFO_ROOT["host"], user="alice", password="pass")
+        dj.Connection(**user_alice)
 
-    # should be able to log in with new credentials
-    dj.conn(host=CONN_INFO_ROOT["host"], user="alice", password="newpass")
+    # should be able to connect with new credentials
+    dj.Connection(host=user_alice["host"], user=user_alice["user"], password="newpass")
 
-    assert dj.config["database.password"] == "newpass"
+    # check that local config is not updated
+    assert dj.config["database.password"] == os.getenv("DJ_PASS")
+    assert not os.path.exists(dj.settings.LOCALCONFIG)
 
-def test_set_password_prompt_mismatch(monkeypatch):
+
+def test_set_password_prompt_mismatch(monkeypatch, user_alice: dict):
     """
     Should not be able to change the password when passwords do not match
     """
-    pass
+    # reset the connection to use alice's credentials
+    dj.conn(**user_alice, reset=True)
 
-def test_set_password_arg(monkeypatch):
+    # prompts: new password / confirm password
+    password_resp = iter(["newpass", "wrong"])
+    # NOTE: because getpass.getpass is imported in datajoint.admin and used as
+    # getpass in that module, we need to patch datajoint.admin.getpass
+    # instead of getpass.getpass
+    monkeypatch.setattr("datajoint.admin.getpass", lambda _: next(password_resp))
+
+    # reset password of user of current connection (alice)
+    # should be nop
+    dj.set_password()
+
+    # should be able to connect with old credentials
+    dj.Connection(**user_alice)
+
+
+def test_set_password_args(user_alice: dict):
     """
     Should be able to change the password with an argument
     """
-    pass
+    # reset the connection to use alice's credentials
+    dj.conn(**user_alice, reset=True)
 
-def test_set_password_no_update_config(monkeypatch):
+    # reset password of user of current connection (alice)
+    dj.set_password(new_password="newpass", update_config=False)
+
+    # should be able to connect with new credentials
+    dj.Connection(host=user_alice["host"], user=user_alice["user"], password="newpass")
+
+
+def test_set_password_update_config(monkeypatch, user_alice: dict):
     """
-    Should be able to change the password without updating local config
+    Should be able to change the password and update local config
     """
-    pass
+    # reset the connection to use alice's credentials
+    dj.conn(**user_alice, reset=True)
+
+    # respond yes to prompt to update local config
+    monkeypatch.setattr("builtins.input", lambda _: "yes")
+
+    # reset password of user of current connection (alice)
+    dj.set_password(new_password="newpass")
+
+    # should be able to connect with new credentials
+    dj.Connection(host=user_alice["host"], user=user_alice["user"], password="newpass")
+
+    # check that local config is updated
+    # NOTE: the global config state is changed unless dj modules are reloaded
+    # NOTE: this test is a bit unrealistic because the config user does not match
+    # the user whose password is being updated, so the config credentials
+    # will be invalid after update...
+    assert dj.config["database.password"] == "newpass"
+    assert os.path.exists(dj.settings.LOCALCONFIG)
+
+
+def test_set_password_conn(user_alice: dict):
+    """
+    Should be able to change the password using a given connection
+    """
+    # create a connection with alice's credentials
+    conn_alice = dj.Connection(**user_alice)
+
+    # reset password of user of alice's connection (alice) and do not update config
+    dj.set_password(new_password="newpass", connection=conn_alice, update_config=False)
+
+    # should be able to connect with new credentials
+    dj.Connection(host=user_alice["host"], user=user_alice["user"], password="newpass")
+
+    # check that local config is not updated
+    assert dj.config["database.password"] == os.getenv("DJ_PASS")
+    assert not os.path.exists(dj.settings.LOCALCONFIG)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,53 @@
+"""
+Collection of test cases to test connection module.
+"""
+
+import datajoint as dj
+from datajoint import DataJointError
+import numpy as np
+from . import CONN_INFO_ROOT, connection_root, connection_test
+
+from . import PREFIX
+import pymysql
+import pytest
+
+
+def test_set_password_prompt_match(monkeypatch):
+    """
+    Should be able to change the password using user prompt
+    """
+    c = dj.conn(**CONN_INFO_ROOT)
+    c.query("CREATE USER 'alice'@'%' IDENTIFIED BY 'pass';")
+    # prompt responses: new password / confirm password / update local setting?
+    responses = ["newpass", "newpass", "yes"]
+    monkeypatch.setattr('getpass.getpass', lambda _: next(responses)) 
+    monkeypatch.setattr('input', lambda _: next(responses)) 
+
+    dj.set_password()
+
+    with pytest.raises(pymysql.err.OperationalError):
+        # should not be able to log in with old credentials
+        dj.conn(host=CONN_INFO_ROOT["host"], user="alice", password="pass")
+
+    # should be able to log in with new credentials
+    dj.conn(host=CONN_INFO_ROOT["host"], user="alice", password="newpass")
+
+    assert dj.config["database.password"] == "newpass"
+
+def test_set_password_prompt_mismatch(monkeypatch):
+    """
+    Should not be able to change the password when passwords do not match
+    """
+    pass
+
+def test_set_password_arg(monkeypatch):
+    """
+    Should be able to change the password with an argument
+    """
+    pass
+
+def test_set_password_no_update_config(monkeypatch):
+    """
+    Should be able to change the password without updating local config
+    """
+    pass


### PR DESCRIPTION
- Updated `set_password` to work on MySQL 8
- Added missing tests for `set_password` (not sure how to test different MySQL versions though)
- Updated `logger.warn` -> `logger.warning` because `logger.warn` is deprecated