### PR TITLE
exclude "reserved" jobs in `Autopopulate.populate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added - GitHub Actions workflow to manually release docs
 - Changed - Update `datajoint/nginx` to `v0.2.6`
 - Changed - Migrate docs from `https://docs.datajoint.org/python` to `https://datajoint.com/docs/core/datajoint-python`
+- Fixed - `Autopopulate.populate` excludes `reserved` jobs in addition to `ignore` and `error` jobs 
 
 ### 0.14.1 -- Jun 02, 2023
 - Fixed - Fix altering a part table that uses the "master" keyword - PR [#991](https://github.com/datajoint/datajoint-python/pull/991)

--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -204,12 +204,12 @@ class AutoPopulate:
 
         keys = (self._jobs_to_do(restrictions) - self.target).fetch("KEY", limit=limit)
 
-        # exclude "error" or "ignore" jobs
+        # exclude "error", "ignore" or "reserved" jobs
         if reserve_jobs:
             exclude_key_hashes = (
                 jobs
                 & {"table_name": self.target.table_name}
-                & 'status in ("error", "ignore")'
+                & 'status in ("error", "ignore", "reserved")'
             ).fetch("key_hash")
             keys = [key for key in keys if key_hash(key) not in exclude_key_hashes]
 

--- a/tests_old/test_autopopulate.py
+++ b/tests_old/test_autopopulate.py
@@ -58,17 +58,19 @@ class TestPopulate:
         assert_true(self.subject, "root tables are empty")
         assert_false(self.experiment, "table already filled?")
 
-        keys = self.experiment.key_source.fetch("KEY", limit=2)
+        keys = self.experiment.key_source.fetch("KEY", limit=3)
         for idx, key in enumerate(keys):
             if idx == 0:
                 schema.schema.jobs.ignore(self.experiment.table_name, key)
-            else:
+            elif:
                 schema.schema.jobs.error(self.experiment.table_name, key, "")
+            else:
+                schema.schema.jobs.reserve(self.experiment.table_name, key)
 
         self.experiment.populate(reserve_jobs=True)
         assert_equal(
             len(self.experiment.key_source & self.experiment),
-            len(self.experiment.key_source) - 2,
+            len(self.experiment.key_source) - 3,
         )
 
     def test_allow_direct_insert(self):

--- a/tests_old/test_autopopulate.py
+++ b/tests_old/test_autopopulate.py
@@ -62,7 +62,7 @@ class TestPopulate:
         for idx, key in enumerate(keys):
             if idx == 0:
                 schema.schema.jobs.ignore(self.experiment.table_name, key)
-            elif:
+            elif idx == 1:
                 schema.schema.jobs.error(self.experiment.table_name, key, "")
             else:
                 schema.schema.jobs.reserve(self.experiment.table_name, key)


### PR DESCRIPTION
This PR is somewhat related to https://github.com/datajoint/datajoint-python/pull/1062

Currently, the `max_calls` still does not achieve the expected behavior in cases of existing `reserved` jobs.

Consider the case where there already are 2 reserved jobs (two other processes working on one table with `reserve_jobs=True`). Another call of `Table.populate(max_calls=1, reserve_jobs=True)` will exit right away, instead of working the next one job (the expected behavior). 

This is because the list of jobs to be worked on next also include the "reserved" ones, then `max_calls=1` leads to selecting the one that is already "reserved".

This PR fixes the described problem.

However, there is a bit of a redundancy here, the logic to exclude "reserved" jobs already exists in `.populate1()`, just not early enough.