### PR TITLE
Add MySQL 8 error code for cascade delete 

### DIFF
--- a/datajoint/connection.py
+++ b/datajoint/connection.py
@@ -79,6 +79,8 @@ def translate_query_error(client_error, query):
     # Integrity errors
     if err == 1062:
         return errors.DuplicateError(*args)
+    if err == 1217:  # MySQL 8 error code
+        return errors.IntegrityError(*args)
     if err == 1451:
         return errors.IntegrityError(*args)
     if err == 1452:


### PR DESCRIPTION
To address #1110, I've added this error code to the set of checks performed by `translate_query_error`. 

To protect against potential issues for MySQL 5.7 users, I checked error code manuals for both [5.7](https://dev.mysql.com/doc/mysql-errors/5.7/en/server-error-reference.html) and [8.0](https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html), which indicated that theses error codes would be categorized as `IntegrityError` across both cases.

Are additional tests required for this change? 