### PR TITLE
PLAT-149: Migrate test_autopopulate.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def connection_root(connection_root_bare):
     conn_root = connection_root_bare
     # Create MySQL users
     if version.parse(
-        connection_root.query("select @@version;").fetchone()[0]
+        conn_root.query("select @@version;").fetchone()[0]
     ) >= version.parse("8.0.0"):
         # create user if necessary on mysql8
         conn_root.query(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from os import environ, remove
 import minio
 import urllib3
 import certifi
-from distutils.version import LooseVersion
 import shutil
 import pytest
 import networkx as nx
@@ -68,9 +67,9 @@ def connection_root(connection_root_bare):
     dj.config["safemode"] = False
     conn_root = connection_root_bare
     # Create MySQL users
-    if LooseVersion(conn_root.query("select @@version;").fetchone()[0]) >= LooseVersion(
-        "8.0.0"
-    ):
+    if version.parse(
+        connection_root.query("select @@version;").fetchone()[0]
+    ) >= version.parse("8.0.0"):
         # create user if necessary on mysql8
         conn_root.query(
             """

--- a/tests/test_autopopulate.py
+++ b/tests/test_autopopulate.py
@@ -1,0 +1,158 @@
+from nose.tools import assert_equal, assert_false, assert_true, raises
+from . import schema, PREFIX
+from datajoint import DataJointError
+import datajoint as dj
+
+
+class TestPopulate:
+    """
+    Test base relations: insert, delete
+    """
+
+    def setUp(self):
+        self.user = schema.User()
+        self.subject = schema.Subject()
+        self.experiment = schema.Experiment()
+        self.trial = schema.Trial()
+        self.ephys = schema.Ephys()
+        self.channel = schema.Ephys.Channel()
+
+    def tearDown(self):
+        # delete automatic tables just in case
+        self.channel.delete_quick()
+        self.ephys.delete_quick()
+        self.trial.Condition.delete_quick()
+        self.trial.delete_quick()
+        self.experiment.delete_quick()
+
+    def test_populate(self):
+        # test simple populate
+        assert_true(self.subject, "root tables are empty")
+        assert_false(self.experiment, "table already filled?")
+        self.experiment.populate()
+        assert_true(
+            len(self.experiment)
+            == len(self.subject) * self.experiment.fake_experiments_per_subject
+        )
+
+        # test restricted populate
+        assert_false(self.trial, "table already filled?")
+        restriction = self.subject.proj(animal="subject_id").fetch("KEY")[0]
+        d = self.trial.connection.dependencies
+        d.load()
+        self.trial.populate(restriction)
+        assert_true(self.trial, "table was not populated")
+        key_source = self.trial.key_source
+        assert_equal(len(key_source & self.trial), len(key_source & restriction))
+        assert_equal(len(key_source - self.trial), len(key_source - restriction))
+
+        # test subtable populate
+        assert_false(self.ephys)
+        assert_false(self.channel)
+        self.ephys.populate()
+        assert_true(self.ephys)
+        assert_true(self.channel)
+
+    def test_populate_with_success_count(self):
+        # test simple populate
+        assert_true(self.subject, "root tables are empty")
+        assert_false(self.experiment, "table already filled?")
+        ret = self.experiment.populate()
+        success_count = ret["success_count"]
+        assert_equal(len(self.experiment.key_source & self.experiment), success_count)
+
+        # test restricted populate
+        assert_false(self.trial, "table already filled?")
+        restriction = self.subject.proj(animal="subject_id").fetch("KEY")[0]
+        d = self.trial.connection.dependencies
+        d.load()
+        ret = self.trial.populate(restriction, suppress_errors=True)
+        success_count = ret["success_count"]
+        assert_equal(len(self.trial.key_source & self.trial), success_count)
+
+    def test_populate_exclude_error_and_ignore_jobs(self):
+        # test simple populate
+        assert_true(self.subject, "root tables are empty")
+        assert_false(self.experiment, "table already filled?")
+
+        keys = self.experiment.key_source.fetch("KEY", limit=2)
+        for idx, key in enumerate(keys):
+            if idx == 0:
+                schema.schema.jobs.ignore(self.experiment.table_name, key)
+            else:
+                schema.schema.jobs.error(self.experiment.table_name, key, "")
+
+        self.experiment.populate(reserve_jobs=True)
+        assert_equal(
+            len(self.experiment.key_source & self.experiment),
+            len(self.experiment.key_source) - 2,
+        )
+
+    def test_allow_direct_insert(self):
+        assert_true(self.subject, "root tables are empty")
+        key = self.subject.fetch("KEY", limit=1)[0]
+        key["experiment_id"] = 1000
+        key["experiment_date"] = "2018-10-30"
+        self.experiment.insert1(key, allow_direct_insert=True)
+
+    def test_multi_processing(self):
+        assert self.subject, "root tables are empty"
+        assert not self.experiment, "table already filled?"
+        self.experiment.populate(processes=2)
+        assert (
+            len(self.experiment)
+            == len(self.subject) * self.experiment.fake_experiments_per_subject
+        )
+
+    def test_max_multi_processing(self):
+        assert self.subject, "root tables are empty"
+        assert not self.experiment, "table already filled?"
+        self.experiment.populate(processes=None)
+        assert (
+            len(self.experiment)
+            == len(self.subject) * self.experiment.fake_experiments_per_subject
+        )
+
+    @raises(DataJointError)
+    def test_allow_insert(self):
+        assert_true(self.subject, "root tables are empty")
+        key = self.subject.fetch("KEY")[0]
+        key["experiment_id"] = 1001
+        key["experiment_date"] = "2018-10-30"
+        self.experiment.insert1(key)
+
+    def test_load_dependencies(self):
+        schema = dj.Schema(f"{PREFIX}_load_dependencies_populate")
+
+        @schema
+        class ImageSource(dj.Lookup):
+            definition = """
+            image_source_id: int
+            """
+            contents = [(0,)]
+
+        @schema
+        class Image(dj.Imported):
+            definition = """
+            -> ImageSource
+            ---
+            image_data: longblob
+            """
+
+            def make(self, key):
+                self.insert1(dict(key, image_data=dict()))
+
+        Image.populate()
+
+        @schema
+        class Crop(dj.Computed):
+            definition = """
+            -> Image
+            ---
+            crop_image: longblob
+            """
+
+            def make(self, key):
+                self.insert1(dict(key, crop_image=dict()))
+
+        Crop.populate()

--- a/tests/test_autopopulate.py
+++ b/tests/test_autopopulate.py
@@ -23,7 +23,11 @@ class TestPopulate:
     def teardown_class(cls):
         """Delete automatic tables just in case"""
         for autopop_table in (
-            cls.channel, cls.ephys, cls.trial.Condition, cls.trial, cls.experiment
+            cls.channel,
+            cls.ephys,
+            cls.trial.Condition,
+            cls.trial,
+            cls.experiment,
         ):
             try:
                 autopop_table.delete_quick()
@@ -89,7 +93,10 @@ class TestPopulate:
                 schema_any.jobs.error(self.experiment.table_name, key, "")
 
         self.experiment.populate(reserve_jobs=True)
-        assert len(self.experiment.key_source & self.experiment) == len(self.experiment.key_source) - 2
+        assert (
+            len(self.experiment.key_source & self.experiment)
+            == len(self.experiment.key_source) - 2
+        )
 
     def test_allow_direct_insert(self, schema_any):
         assert self.subject, "root tables are empty"

--- a/tests/test_autopopulate.py
+++ b/tests/test_autopopulate.py
@@ -2,6 +2,7 @@ import pytest
 from . import schema, PREFIX
 from datajoint import DataJointError
 import datajoint as dj
+import pymysql
 
 
 class TestPopulate:
@@ -20,12 +21,15 @@ class TestPopulate:
 
     @classmethod
     def teardown_class(cls):
-        # Delete automatic tables just in case
-        cls.channel.delete_quick()
-        cls.ephys.delete_quick()
-        cls.trial.Condition.delete_quick()
-        cls.trial.delete_quick()
-        cls.experiment.delete_quick()
+        """Delete automatic tables just in case"""
+        for autopop_table in (
+            cls.channel, cls.ephys, cls.trial.Condition, cls.trial, cls.experiment
+        ):
+            try:
+                autopop_table.delete_quick()
+            except pymysql.err.OperationalError:
+                # Table doesn't exist
+                pass
 
     def test_populate(self, schema_any):
         # test simple populate

--- a/tests/test_autopopulate.py
+++ b/tests/test_autopopulate.py
@@ -59,8 +59,7 @@ class TestPopulate:
         assert self.ephys
         assert self.channel
 
-    @pytest.mark.skip(reason="temp")
-    def test_populate_with_success_count(self):
+    def test_populate_with_success_count(self, schema_any):
         # test simple populate
         assert self.subject, "root tables are empty"
         assert not self.experiment, "table already filled?"
@@ -77,8 +76,7 @@ class TestPopulate:
         success_count = ret["success_count"]
         assert len(self.trial.key_source & self.trial) == success_count
 
-    @pytest.mark.skip(reason="temp")
-    def test_populate_exclude_error_and_ignore_jobs(self):
+    def test_populate_exclude_error_and_ignore_jobs(self, schema_any):
         # test simple populate
         assert self.subject, "root tables are empty"
         assert not self.experiment, "table already filled?"
@@ -86,26 +84,21 @@ class TestPopulate:
         keys = self.experiment.key_source.fetch("KEY", limit=2)
         for idx, key in enumerate(keys):
             if idx == 0:
-                schema.schema.jobs.ignore(self.experiment.table_name, key)
+                schema_any.jobs.ignore(self.experiment.table_name, key)
             else:
-                schema.schema.jobs.error(self.experiment.table_name, key, "")
+                schema_any.jobs.error(self.experiment.table_name, key, "")
 
         self.experiment.populate(reserve_jobs=True)
-        assert (
-            len(self.experiment.key_source & self.experiment)
-            == len(self.experiment.key_source) - 2,
-        )
+        assert len(self.experiment.key_source & self.experiment) == len(self.experiment.key_source) - 2
 
-    @pytest.mark.skip(reason="temp")
-    def test_allow_direct_insert(self):
+    def test_allow_direct_insert(self, schema_any):
         assert self.subject, "root tables are empty"
         key = self.subject.fetch("KEY", limit=1)[0]
         key["experiment_id"] = 1000
         key["experiment_date"] = "2018-10-30"
         self.experiment.insert1(key, allow_direct_insert=True)
 
-    @pytest.mark.skip(reason="temp")
-    def test_multi_processing(self):
+    def test_multi_processing(self, schema_any):
         assert self.subject, "root tables are empty"
         assert not self.experiment, "table already filled?"
         self.experiment.populate(processes=2)
@@ -114,8 +107,7 @@ class TestPopulate:
             == len(self.subject) * self.experiment.fake_experiments_per_subject
         )
 
-    @pytest.mark.skip(reason="temp")
-    def test_max_multi_processing(self):
+    def test_max_multi_processing(self, schema_any):
         assert self.subject, "root tables are empty"
         assert not self.experiment, "table already filled?"
         self.experiment.populate(processes=None)
@@ -124,8 +116,7 @@ class TestPopulate:
             == len(self.subject) * self.experiment.fake_experiments_per_subject
         )
 
-    @pytest.mark.skip(reason="temp")
-    def test_allow_insert(self):
+    def test_allow_insert(self, schema_any):
         assert self.subject, "root tables are empty"
         key = self.subject.fetch("KEY")[0]
         key["experiment_id"] = 1001
@@ -133,7 +124,6 @@ class TestPopulate:
         with pytest.raises(DataJointError):
             self.experiment.insert1(key)
 
-    @pytest.mark.skip(reason="temp")
     def test_load_dependencies(self):
         schema = dj.Schema(f"{PREFIX}_load_dependencies_populate")
 

--- a/tests/test_autopopulate.py
+++ b/tests/test_autopopulate.py
@@ -4,24 +4,30 @@ from datajoint import DataJointError
 import datajoint as dj
 
 
-@pytest.fixture
-def schema_any_with_teardown(schema_any):
-    yield schema_any
-    # delete automatic tables just in case
-    schema_any.Ephys.Channel().delete_quick()
-    schema_any.Ephys().delete_quick()
-    schema_any.Trial().Condition.delete_quick()
-    schema_any.Trial().delete_quick()
-    schema_any.Experiment().delete_quick()
-
-
 class TestPopulate:
     """
     Test base relations: insert, delete
     """
 
-    def test_populate(self, schema_any_with_teardown):
-        breakpoint()
+    @classmethod
+    def setup_class(cls):
+        cls.user = schema.User()
+        cls.subject = schema.Subject()
+        cls.experiment = schema.Experiment()
+        cls.trial = schema.Trial()
+        cls.ephys = schema.Ephys()
+        cls.channel = schema.Ephys.Channel()
+
+    @classmethod
+    def teardown_class(cls):
+        # Delete automatic tables just in case
+        cls.channel.delete_quick()
+        cls.ephys.delete_quick()
+        cls.trial.Condition.delete_quick()
+        cls.trial.delete_quick()
+        cls.experiment.delete_quick()
+
+    def test_populate(self, schema_any):
         # test simple populate
         assert self.subject, "root tables are empty"
         assert not self.experiment, "table already filled?"

--- a/tests/test_autopopulate.py
+++ b/tests/test_autopopulate.py
@@ -82,8 +82,8 @@ class TestPopulate:
 
         self.experiment.populate(reserve_jobs=True)
         assert (
-            len(self.experiment.key_source & self.experiment) ==
-            len(self.experiment.key_source) - 2,
+            len(self.experiment.key_source & self.experiment)
+            == len(self.experiment.key_source) - 2,
         )
 
     @pytest.mark.skip(reason="temp")


### PR DESCRIPTION
- cp to tests
- First pass at migrating test_autopopulate
- Format with black
- Use setup and teardown class methods instead
- Teardown tolerates nonexistent table
- Migrate test_autopopulate.py
- Switch from deprecated Version classes
- Format with black
- Fix syntax error
