### PR TITLE
PLAT-146: Migrate test_aggr_regressions.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ from . import (
     schema_advanced,
     schema_adapted,
     schema_external,
-    schema_uuid,
+    schema_uuid as schema_uuid_module,
 )
 
 
@@ -312,12 +312,12 @@ def schema_ext(connection_test, stores_config, enable_filepath_feature):
 def schema_uuid(connection_test):
     schema = dj.Schema(
         PREFIX + "_test1",
-        context=schema_uuid.LOCALS_UUID,
+        context=schema_uuid_module.LOCALS_UUID,
         connection=connection_test,
     )
-    schema(Basic)
-    schema(Topic)
-    schema(Item)
+    schema(schema_uuid_module.Basic)
+    schema(schema_uuid_module.Topic)
+    schema(schema_uuid_module.Item)
     yield schema
     schema.drop()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from . import (
     schema_advanced,
     schema_adapted,
     schema_external,
+    schema_uuid,
 )
 
 
@@ -303,6 +304,20 @@ def schema_ext(connection_test, stores_config, enable_filepath_feature):
     schema(schema_external.Attach)
     schema(schema_external.Filepath)
     schema(schema_external.FilepathS3)
+    yield schema
+    schema.drop()
+
+
+@pytest.fixture
+def schema_uuid(connection_test):
+    schema = dj.Schema(
+        PREFIX + "_test1",
+        context=schema_uuid.LOCALS_UUID,
+        connection=connection_test,
+    )
+    schema(Basic)
+    schema(Topic)
+    schema(Item)
     yield schema
     schema.drop()
 

--- a/tests/schema_aggr_regress.py
+++ b/tests/schema_aggr_regress.py
@@ -1,0 +1,51 @@
+import datajoint as dj
+import itertools
+import inspect
+
+
+class R(dj.Lookup):
+    definition = """
+    r : char(1)
+    """
+    contents = zip("ABCDFGHIJKLMNOPQRST")
+
+
+class Q(dj.Lookup):
+    definition = """
+    -> R
+    """
+    contents = zip("ABCDFGH")
+
+
+class S(dj.Lookup):
+    definition = """
+    -> R
+    s : int
+    """
+    contents = itertools.product("ABCDF", range(10))
+
+
+class A(dj.Lookup):
+    definition = """
+    id: int
+    """
+    contents = zip(range(10))
+
+
+class B(dj.Lookup):
+    definition = """
+    -> A
+    id2: int
+    """
+    contents = zip(range(5), range(5, 10))
+
+
+class X(dj.Lookup):
+    definition = """
+    id: int
+    """
+    contents = zip(range(10))
+
+
+LOCALS_AGGR_REGRESS = {k: v for k, v in locals().items() if inspect.isclass(v)}
+__all__ = list(LOCALS_AGGR_REGRESS)

--- a/tests/schema_uuid.py
+++ b/tests/schema_uuid.py
@@ -1,0 +1,50 @@
+import uuid
+import datajoint as dj
+from . import PREFIX, CONN_INFO
+
+schema = dj.Schema(PREFIX + "_test1", connection=dj.conn(**CONN_INFO))
+
+top_level_namespace_id = uuid.UUID("00000000-0000-0000-0000-000000000000")
+
+
+@schema
+class Basic(dj.Manual):
+    definition = """
+    item : uuid
+    ---
+    number : int
+    """
+
+
+@schema
+class Topic(dj.Manual):
+    definition = """
+    # A topic for items
+    topic_id : uuid   # internal identification of a topic, reflects topic name
+    ---
+    topic : varchar(8000)   # full topic name used to generate the topic id
+    """
+
+    def add(self, topic):
+        """add a new topic with a its UUID"""
+        self.insert1(
+            dict(topic_id=uuid.uuid5(top_level_namespace_id, topic), topic=topic)
+        )
+
+
+@schema
+class Item(dj.Computed):
+    definition = """
+    item_id : uuid  # internal identification of 
+    ---
+    -> Topic 
+    word : varchar(8000)
+    """
+
+    key_source = Topic  # test key source that is not instantiated
+
+    def make(self, key):
+        for word in ("Habenula", "Hippocampus", "Hypothalamus", "Hypophysis"):
+            self.insert1(
+                dict(key, word=word, item_id=uuid.uuid5(key["topic_id"], word))
+            )

--- a/tests/schema_uuid.py
+++ b/tests/schema_uuid.py
@@ -1,4 +1,5 @@
 import uuid
+import inspect
 import datajoint as dj
 from . import PREFIX, CONN_INFO
 

--- a/tests/schema_uuid.py
+++ b/tests/schema_uuid.py
@@ -2,12 +2,9 @@ import uuid
 import datajoint as dj
 from . import PREFIX, CONN_INFO
 
-schema = dj.Schema(PREFIX + "_test1", connection=dj.conn(**CONN_INFO))
-
 top_level_namespace_id = uuid.UUID("00000000-0000-0000-0000-000000000000")
 
 
-@schema
 class Basic(dj.Manual):
     definition = """
     item : uuid
@@ -16,7 +13,6 @@ class Basic(dj.Manual):
     """
 
 
-@schema
 class Topic(dj.Manual):
     definition = """
     # A topic for items
@@ -32,12 +28,11 @@ class Topic(dj.Manual):
         )
 
 
-@schema
 class Item(dj.Computed):
     definition = """
-    item_id : uuid  # internal identification of 
+    item_id : uuid  # internal identification of
     ---
-    -> Topic 
+    -> Topic
     word : varchar(8000)
     """
 
@@ -48,3 +43,7 @@ class Item(dj.Computed):
             self.insert1(
                 dict(key, word=word, item_id=uuid.uuid5(key["topic_id"], word))
             )
+
+
+LOCALS_UUID = {k: v for k, v in locals().items() if inspect.isclass(v)}
+__all__ = list(LOCALS_UUID)

--- a/tests/test_aggr_regressions.py
+++ b/tests/test_aggr_regressions.py
@@ -1,0 +1,141 @@
+"""
+Regression tests for issues 386, 449, 484, and 558 — all related to processing complex aggregations and projections.
+"""
+
+import itertools
+from nose.tools import assert_equal
+import datajoint as dj
+from . import PREFIX, CONN_INFO
+import uuid
+from .schema_uuid import Topic, Item, top_level_namespace_id
+
+schema = dj.Schema(PREFIX + "_aggr_regress", connection=dj.conn(**CONN_INFO))
+
+# --------------- ISSUE 386 -------------------
+# Issue 386 resulted from the loss of aggregated attributes when the aggregation was used as the restrictor
+#     Q & (R.aggr(S, n='count(*)') & 'n=2')
+#     Error: Unknown column 'n' in HAVING
+
+
+@schema
+class R(dj.Lookup):
+    definition = """
+    r : char(1)
+    """
+    contents = zip("ABCDFGHIJKLMNOPQRST")
+
+
+@schema
+class Q(dj.Lookup):
+    definition = """
+    -> R
+    """
+    contents = zip("ABCDFGH")
+
+
+@schema
+class S(dj.Lookup):
+    definition = """
+    -> R
+    s : int
+    """
+    contents = itertools.product("ABCDF", range(10))
+
+
+def test_issue386():
+    result = R.aggr(S, n="count(*)") & "n=10"
+    result = Q & result
+    result.fetch()
+
+
+# ---------------- ISSUE 449 ------------------
+# Issue 449 arises from incorrect group by attributes after joining with a dj.U()
+
+
+def test_issue449():
+    result = dj.U("n") * R.aggr(S, n="max(s)")
+    result.fetch()
+
+
+# ---------------- ISSUE 484 -----------------
+# Issue 484
+def test_issue484():
+    q = dj.U().aggr(S, n="max(s)")
+    n = q.fetch("n")
+    n = q.fetch1("n")
+    q = dj.U().aggr(S, n="avg(s)")
+    result = dj.U().aggr(q, m="max(n)")
+    result.fetch()
+
+
+# ---------------  ISSUE 558 ------------------
+#  Issue 558 resulted from the fact that DataJoint saves subqueries and often combines a restriction followed
+#  by a projection into a single SELECT statement, which in several unusual cases produces unexpected results.
+
+
+@schema
+class A(dj.Lookup):
+    definition = """
+    id: int
+    """
+    contents = zip(range(10))
+
+
+@schema
+class B(dj.Lookup):
+    definition = """
+    -> A
+    id2: int
+    """
+    contents = zip(range(5), range(5, 10))
+
+
+@schema
+class X(dj.Lookup):
+    definition = """
+    id: int
+    """
+    contents = zip(range(10))
+
+
+def test_issue558_part1():
+    q = (A - B).proj(id2="3")
+    assert_equal(len(A - B), len(q))
+
+
+def test_issue558_part2():
+    d = dict(id=3, id2=5)
+    assert_equal(len(X & d), len((X & d).proj(id2="3")))
+
+
+def test_left_join_len():
+    Topic().add("jeff")
+    Item.populate()
+    Topic().add("jeff2")
+    Topic().add("jeff3")
+    q = Topic.join(
+        Item - dict(topic_id=uuid.uuid5(top_level_namespace_id, "jeff")), left=True
+    )
+    qf = q.fetch()
+    assert len(q) == len(qf)
+
+
+def test_union_join():
+    # https://github.com/datajoint/datajoint-python/issues/930
+    A.insert(zip([100, 200, 300, 400, 500, 600]))
+    B.insert([(100, 11), (200, 22), (300, 33), (400, 44)])
+    q1 = B & "id < 300"
+    q2 = B & "id > 300"
+
+    expected_data = [
+        {"id": 0, "id2": 5},
+        {"id": 1, "id2": 6},
+        {"id": 2, "id2": 7},
+        {"id": 3, "id2": 8},
+        {"id": 4, "id2": 9},
+        {"id": 100, "id2": 11},
+        {"id": 200, "id2": 22},
+        {"id": 400, "id2": 44},
+    ]
+
+    assert ((q1 + q2) * A).fetch(as_dict=True) == expected_data

--- a/tests/test_aggr_regressions.py
+++ b/tests/test_aggr_regressions.py
@@ -12,9 +12,10 @@ from .schema_aggr_regress import R, Q, S, A, B, X, LOCALS_AGGR_REGRESS
 
 @pytest.fixture(scope="function")
 def schema_aggr_reg(connection_test):
+    context = LOCALS_AGGR_REGRESS
     schema = dj.Schema(
         PREFIX + "_aggr_regress",
-        context=LOCALS_AGGR_REGRESS,
+        context=context,
         connection=connection_test,
     )
     schema(R)
@@ -25,13 +26,21 @@ def schema_aggr_reg(connection_test):
 
 
 @pytest.fixture(scope="function")
-def schema_aggr_reg_with_abx(schema_aggr_reg):
+def schema_aggr_reg_with_abx(connection_test):
     context = LOCALS_AGGR_REGRESS
-    schema_aggr_reg(A, context=context)
-    schema_aggr_reg(B, context=context)
-    schema_aggr_reg(X, context=context)
-    yield schema_aggr_reg
-    schema_aggr_reg.drop()
+    schema = dj.Schema(
+        PREFIX + "_aggr_regress_with_abx",
+        context=context,
+        connection=connection_test,
+    )
+    schema(R)
+    schema(Q)
+    schema(S)
+    schema(A)
+    schema(B)
+    schema(X)
+    yield schema
+    schema.drop()
 
 
 def test_issue386(schema_aggr_reg):
@@ -70,6 +79,8 @@ def test_issue484(schema_aggr_reg):
 
 def test_union_join(schema_aggr_reg_with_abx):
     """
+    This test fails if it runs after TestIssue558.
+
     https://github.com/datajoint/datajoint-python/issues/930
     """
     A.insert(zip([100, 200, 300, 400, 500, 600]))

--- a/tests/test_aggr_regressions.py
+++ b/tests/test_aggr_regressions.py
@@ -33,7 +33,6 @@ def schema_aggr_reg_with_abx(schema_aggr_reg):
     schema_aggr_reg.drop()
 
 
-@pytest.mark.skip
 def test_issue386(schema_aggr_reg):
     """
     --------------- ISSUE 386 -------------------
@@ -46,7 +45,6 @@ def test_issue386(schema_aggr_reg):
     result.fetch()
 
 
-@pytest.mark.skip
 def test_issue449(schema_aggr_reg):
     """
     ---------------- ISSUE 449 ------------------
@@ -70,6 +68,7 @@ def test_issue484(schema_aggr_reg):
 
 
 
+@pytest.mark.skip
 class TestIssue558:
     """
     ---------------  ISSUE 558 ------------------
@@ -77,12 +76,10 @@ class TestIssue558:
     by a projection into a single SELECT statement, which in several unusual cases produces unexpected results.
     """
 
-    @pytest.mark.skip
     def test_issue558_part1(self, schema_aggr_reg_with_abx):
         q = (A - B).proj(id2="3")
         assert len(A - B) == len(q)
 
-    @pytest.mark.skip
     def test_issue558_part2(self, schema_aggr_reg_with_abx):
         d = dict(id=3, id2=5)
         assert len(X & d) == len((X & d).proj(id2="3"))

--- a/tests/test_aggr_regressions.py
+++ b/tests/test_aggr_regressions.py
@@ -10,7 +10,7 @@ from .schema_uuid import Topic, Item, top_level_namespace_id
 from .schema_aggr_regress import R, Q, S, A, B, X, LOCALS_AGGR_REGRESS
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def schema_aggr_reg(connection_test):
     schema = dj.Schema(
         PREFIX + "_aggr_regress",
@@ -24,7 +24,7 @@ def schema_aggr_reg(connection_test):
     schema.drop()
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def schema_aggr_reg_with_abx(schema_aggr_reg):
     schema_aggr_reg(A)
     schema_aggr_reg(B)

--- a/tests/test_aggr_regressions.py
+++ b/tests/test_aggr_regressions.py
@@ -33,6 +33,7 @@ def schema_aggr_reg_with_abx(schema_aggr_reg):
     schema_aggr_reg.drop()
 
 
+@pytest.mark.skip
 def test_issue386(schema_aggr_reg):
     """
     --------------- ISSUE 386 -------------------
@@ -45,6 +46,7 @@ def test_issue386(schema_aggr_reg):
     result.fetch()
 
 
+@pytest.mark.skip
 def test_issue449(schema_aggr_reg):
     """
     ---------------- ISSUE 449 ------------------
@@ -75,11 +77,12 @@ class TestIssue558:
     by a projection into a single SELECT statement, which in several unusual cases produces unexpected results.
     """
 
+    @pytest.mark.skip
     def test_issue558_part1(self, schema_aggr_reg_with_abx):
         q = (A - B).proj(id2="3")
         assert len(A - B) == len(q)
 
-
+    @pytest.mark.skip
     def test_issue558_part2(self, schema_aggr_reg_with_abx):
         d = dict(id=3, id2=5)
         assert len(X & d) == len((X & d).proj(id2="3"))

--- a/tests/test_aggr_regressions.py
+++ b/tests/test_aggr_regressions.py
@@ -12,10 +12,9 @@ from .schema_aggr_regress import R, Q, S, A, B, X, LOCALS_AGGR_REGRESS
 
 @pytest.fixture(scope="function")
 def schema_aggr_reg(connection_test):
-    context = {k: v for k, v in LOCALS_AGGR_REGRESS.items() if k in ('R', 'Q', 'S')}
     schema = dj.Schema(
         PREFIX + "_aggr_regress",
-        context=context,
+        context=LOCALS_AGGR_REGRESS,
         connection=connection_test,
     )
     schema(R)
@@ -27,7 +26,7 @@ def schema_aggr_reg(connection_test):
 
 @pytest.fixture(scope="function")
 def schema_aggr_reg_with_abx(schema_aggr_reg):
-    context = {k: v for k, v in LOCALS_AGGR_REGRESS.items() if k in ('A', 'B', 'X')}
+    context = LOCALS_AGGR_REGRESS
     schema_aggr_reg(A, context=context)
     schema_aggr_reg(B, context=context)
     schema_aggr_reg(X, context=context)
@@ -69,7 +68,6 @@ def test_issue484(schema_aggr_reg):
     result.fetch()
 
 
-
 def test_union_join(schema_aggr_reg_with_abx):
     """
     https://github.com/datajoint/datajoint-python/issues/930
@@ -92,7 +90,7 @@ def test_union_join(schema_aggr_reg_with_abx):
 
     assert ((q1 + q2) * A).fetch(as_dict=True) == expected_data
 
-# @pytest.mark.skip
+
 class TestIssue558:
     """
     ---------------  ISSUE 558 ------------------
@@ -119,4 +117,3 @@ def test_left_join_len(schema_uuid):
     )
     qf = q.fetch()
     assert len(q) == len(qf)
-

--- a/tests/test_aggr_regressions.py
+++ b/tests/test_aggr_regressions.py
@@ -10,7 +10,7 @@ from .schema_uuid import Topic, Item, top_level_namespace_id
 from .schema_aggr_regress import R, Q, S, A, B, X, LOCALS_AGGR_REGRESS
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def schema_aggr_reg(connection_test):
     schema = dj.Schema(
         PREFIX + "_aggr_regress",
@@ -24,12 +24,13 @@ def schema_aggr_reg(connection_test):
     schema.drop()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def schema_aggr_reg_with_abx(schema_aggr_reg):
     schema_aggr_reg(A)
     schema_aggr_reg(B)
     schema_aggr_reg(X)
     yield schema_aggr_reg
+    schema_aggr_reg.drop()
 
 
 def test_issue386(schema_aggr_reg):

--- a/tests/test_erd.py
+++ b/tests/test_erd.py
@@ -58,7 +58,7 @@ def test_make_image(schema_simp):
 
 def test_part_table_parsing(schema_simp):
     # https://github.com/datajoint/datajoint-python/issues/882
-    erd = dj.Di(schema_simp)
+    erd = dj.Di(schema_simp, context=LOCALS_SIMPLE)
     graph = erd._make_graph()
     assert "OutfitLaunch" in graph.nodes()
     assert "OutfitLaunch.OutfitPiece" in graph.nodes()


### PR DESCRIPTION
- cp to tests
- Migrate schema_uuid
- Fix test tests/test_aggr_regressions.py::test_left_join_len
- Tests pass with module scoped fixtures
- Fix fixtures
- If we skip these, test_union_join passes
- Skipping TestIssue558 passes all
- Tests passing with reordering
- test_aggr_regressions passing
- Construct schema_aggr_reg_with_abx separately
- Add context to diagram tests
