### PR TITLE
PLAT-159: Migrate test_jobs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,11 @@ import networkx as nx
 import json
 from pathlib import Path
 from datajoint import errors
-from datajoint.errors import ADAPTED_TYPE_SWITCH, FILEPATH_FEATURE_SWITCH, DataJointError
+from datajoint.errors import (
+    ADAPTED_TYPE_SWITCH,
+    FILEPATH_FEATURE_SWITCH,
+    DataJointError,
+)
 from . import (
     PREFIX,
     CONN_INFO,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ import networkx as nx
 import json
 from pathlib import Path
 from datajoint import errors
-from datajoint.errors import ADAPTED_TYPE_SWITCH, FILEPATH_FEATURE_SWITCH
+from datajoint.errors import ADAPTED_TYPE_SWITCH, FILEPATH_FEATURE_SWITCH, DataJointError
 from . import (
     PREFIX,
     CONN_INFO,
@@ -227,6 +227,10 @@ def schema_any(connection_test):
         PREFIX + "_test1", schema.LOCALS_ANY, connection=connection_test
     )
     assert schema.LOCALS_ANY, "LOCALS_ANY is empty"
+    try:
+        schema_any.jobs.delete()
+    except DataJointError:
+        pass
     schema_any(schema.TTest)
     schema_any(schema.TTest2)
     schema_any(schema.TTest3)
@@ -263,9 +267,11 @@ def schema_any(connection_test):
     schema_any(schema.SessionDateA)
     schema_any(schema.Stimulus)
     schema_any(schema.Longblob)
-    schema_any.jobs.delete()
     yield schema_any
-    schema_any.jobs.delete()
+    try:
+        schema_any.jobs.delete()
+    except DataJointError:
+        pass
     schema_any.drop()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,7 +263,9 @@ def schema_any(connection_test):
     schema_any(schema.SessionDateA)
     schema_any(schema.Stimulus)
     schema_any(schema.Longblob)
+    schema_any.jobs.delete()
     yield schema_any
+    schema_any.jobs.delete()
     schema_any.drop()
 
 

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -258,7 +258,7 @@ class SimpleSource(dj.Lookup):
     definition = """
     id : int  # id
     """
-    contents = ((x,) for x in range(10))
+    contents = [(x,) for x in range(10)]
 
 
 class SigIntTable(dj.Computed):

--- a/tests/test_fetch_same.py
+++ b/tests/test_fetch_same.py
@@ -1,0 +1,62 @@
+from nose.tools import assert_equal
+from . import PREFIX, CONN_INFO
+import numpy as np
+import datajoint as dj
+
+schema = dj.Schema(PREFIX + "_fetch_same", connection=dj.conn(**CONN_INFO))
+
+
+class TestFetchSame:
+    @classmethod
+    def setup_class(cls):
+        @schema
+        class ProjData(dj.Manual):
+            definition = """
+            id : int
+            ---
+            resp : float
+            sim  : float
+            big : longblob
+            blah : varchar(10)
+            """
+
+        ProjData().insert(
+            [
+                {"id": 0, "resp": 20.33, "sim": 45.324, "big": 3, "blah": "yes"},
+                {
+                    "id": 1,
+                    "resp": 94.3,
+                    "sim": 34.23,
+                    "big": {"key1": np.random.randn(20, 10)},
+                    "blah": "si",
+                },
+                {
+                    "id": 2,
+                    "resp": 1.90,
+                    "sim": 10.23,
+                    "big": np.random.randn(4, 2),
+                    "blah": "sim",
+                },
+            ]
+        )
+
+        cls.projdata = ProjData()
+
+    def test_object_conversion_one(self):
+        new = self.projdata.proj(sub="resp").fetch("sub")
+        assert_equal(new.dtype, np.float64)
+
+    def test_object_conversion_two(self):
+        [sub, add] = self.projdata.proj(sub="resp", add="sim").fetch("sub", "add")
+        assert_equal(sub.dtype, np.float64)
+        assert_equal(add.dtype, np.float64)
+
+    def test_object_conversion_all(self):
+        new = self.projdata.proj(sub="resp", add="sim").fetch()
+        assert_equal(new["sub"].dtype, np.float64)
+        assert_equal(new["add"].dtype, np.float64)
+
+    def test_object_no_convert(self):
+        new = self.projdata.fetch()
+        assert_equal(new["big"].dtype, "object")
+        assert_equal(new["blah"].dtype, "object")

--- a/tests/test_fetch_same.py
+++ b/tests/test_fetch_same.py
@@ -1,62 +1,72 @@
-from nose.tools import assert_equal
+import pytest
 from . import PREFIX, CONN_INFO
 import numpy as np
 import datajoint as dj
 
-schema = dj.Schema(PREFIX + "_fetch_same", connection=dj.conn(**CONN_INFO))
+
+class ProjData(dj.Manual):
+    definition = """
+    id : int
+    ---
+    resp : float
+    sim  : float
+    big : longblob
+    blah : varchar(10)
+    """
+
+
+@pytest.fixture
+def schema_fetch_same(connection_root):
+    schema = dj.Schema(
+        PREFIX + "_fetch_same",
+        context=dict(ProjData=ProjData),
+        connection=connection_root,
+    )
+    schema(ProjData)
+    ProjData().insert(
+        [
+            {"id": 0, "resp": 20.33, "sim": 45.324, "big": 3, "blah": "yes"},
+            {
+                "id": 1,
+                "resp": 94.3,
+                "sim": 34.23,
+                "big": {"key1": np.random.randn(20, 10)},
+                "blah": "si",
+            },
+            {
+                "id": 2,
+                "resp": 1.90,
+                "sim": 10.23,
+                "big": np.random.randn(4, 2),
+                "blah": "sim",
+            },
+        ]
+    )
+    yield schema
+    schema.drop()
+
+
+@pytest.fixture
+def projdata():
+    yield ProjData()
 
 
 class TestFetchSame:
-    @classmethod
-    def setup_class(cls):
-        @schema
-        class ProjData(dj.Manual):
-            definition = """
-            id : int
-            ---
-            resp : float
-            sim  : float
-            big : longblob
-            blah : varchar(10)
-            """
+    def test_object_conversion_one(self, schema_fetch_same, projdata):
+        new = projdata.proj(sub="resp").fetch("sub")
+        assert new.dtype == np.float64
 
-        ProjData().insert(
-            [
-                {"id": 0, "resp": 20.33, "sim": 45.324, "big": 3, "blah": "yes"},
-                {
-                    "id": 1,
-                    "resp": 94.3,
-                    "sim": 34.23,
-                    "big": {"key1": np.random.randn(20, 10)},
-                    "blah": "si",
-                },
-                {
-                    "id": 2,
-                    "resp": 1.90,
-                    "sim": 10.23,
-                    "big": np.random.randn(4, 2),
-                    "blah": "sim",
-                },
-            ]
-        )
+    def test_object_conversion_two(self, schema_fetch_same, projdata):
+        [sub, add] = projdata.proj(sub="resp", add="sim").fetch("sub", "add")
+        assert sub.dtype == np.float64
+        assert add.dtype == np.float64
 
-        cls.projdata = ProjData()
+    def test_object_conversion_all(self, schema_fetch_same, projdata):
+        new = projdata.proj(sub="resp", add="sim").fetch()
+        assert new["sub"].dtype == np.float64
+        assert new["add"].dtype == np.float64
 
-    def test_object_conversion_one(self):
-        new = self.projdata.proj(sub="resp").fetch("sub")
-        assert_equal(new.dtype, np.float64)
-
-    def test_object_conversion_two(self):
-        [sub, add] = self.projdata.proj(sub="resp", add="sim").fetch("sub", "add")
-        assert_equal(sub.dtype, np.float64)
-        assert_equal(add.dtype, np.float64)
-
-    def test_object_conversion_all(self):
-        new = self.projdata.proj(sub="resp", add="sim").fetch()
-        assert_equal(new["sub"].dtype, np.float64)
-        assert_equal(new["add"].dtype, np.float64)
-
-    def test_object_no_convert(self):
-        new = self.projdata.fetch()
-        assert_equal(new["big"].dtype, "object")
-        assert_equal(new["blah"].dtype, "object")
+    def test_object_no_convert(self, schema_fetch_same, projdata):
+        new = projdata.fetch()
+        assert new["big"].dtype == "object"
+        assert new["blah"].dtype == "object"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,168 @@
+from nose.tools import assert_true, assert_false, assert_equals
+from . import schema
+from datajoint.jobs import ERROR_MESSAGE_LENGTH, TRUNCATION_APPENDIX
+import random
+import string
+import datajoint as dj
+
+subjects = schema.Subject()
+
+
+def test_reserve_job():
+    schema.schema.jobs.delete()
+    assert_true(subjects)
+    table_name = "fake_table"
+
+    # reserve jobs
+    for key in subjects.fetch("KEY"):
+        assert_true(
+            schema.schema.jobs.reserve(table_name, key), "failed to reserve a job"
+        )
+
+    # refuse jobs
+    for key in subjects.fetch("KEY"):
+        assert_false(
+            schema.schema.jobs.reserve(table_name, key), "failed to respect reservation"
+        )
+
+    # complete jobs
+    for key in subjects.fetch("KEY"):
+        schema.schema.jobs.complete(table_name, key)
+    assert_false(schema.schema.jobs, "failed to free jobs")
+
+    # reserve jobs again
+    for key in subjects.fetch("KEY"):
+        assert_true(
+            schema.schema.jobs.reserve(table_name, key), "failed to reserve new jobs"
+        )
+
+    # finish with error
+    for key in subjects.fetch("KEY"):
+        schema.schema.jobs.error(table_name, key, "error message")
+
+    # refuse jobs with errors
+    for key in subjects.fetch("KEY"):
+        assert_false(
+            schema.schema.jobs.reserve(table_name, key), "failed to ignore error jobs"
+        )
+
+    # clear error jobs
+    (schema.schema.jobs & dict(status="error")).delete()
+    assert_false(schema.schema.jobs, "failed to clear error jobs")
+
+
+def test_restrictions():
+    jobs = schema.schema.jobs
+    jobs.delete()
+    jobs.reserve("a", {"key": "a1"})
+    jobs.reserve("a", {"key": "a2"})
+    jobs.reserve("b", {"key": "b1"})
+    jobs.error("a", {"key": "a2"}, "error")
+    jobs.error("b", {"key": "b1"}, "error")
+
+    assert_true(len(jobs & {"table_name": "a"}) == 2)
+    assert_true(len(jobs & {"status": "error"}) == 2)
+    assert_true(len(jobs & {"table_name": "a", "status": "error"}) == 1)
+    jobs.delete()
+
+
+def test_sigint():
+    # clear out job table
+    schema.schema.jobs.delete()
+    try:
+        schema.SigIntTable().populate(reserve_jobs=True)
+    except KeyboardInterrupt:
+        pass
+
+    status, error_message = schema.schema.jobs.fetch1("status", "error_message")
+    assert_equals(status, "error")
+    assert_equals(error_message, "KeyboardInterrupt")
+    schema.schema.jobs.delete()
+
+
+def test_sigterm():
+    # clear out job table
+    schema.schema.jobs.delete()
+    try:
+        schema.SigTermTable().populate(reserve_jobs=True)
+    except SystemExit:
+        pass
+
+    status, error_message = schema.schema.jobs.fetch1("status", "error_message")
+    assert_equals(status, "error")
+    assert_equals(error_message, "SystemExit: SIGTERM received")
+    schema.schema.jobs.delete()
+
+
+def test_suppress_dj_errors():
+    """test_suppress_dj_errors: dj errors suppressible w/o native py blobs"""
+    schema.schema.jobs.delete()
+    with dj.config(enable_python_native_blobs=False):
+        schema.ErrorClass.populate(reserve_jobs=True, suppress_errors=True)
+    assert_true(len(schema.DjExceptionName()) == len(schema.schema.jobs) > 0)
+
+
+def test_long_error_message():
+    # clear out jobs table
+    schema.schema.jobs.delete()
+
+    # create long error message
+    long_error_message = "".join(
+        random.choice(string.ascii_letters) for _ in range(ERROR_MESSAGE_LENGTH + 100)
+    )
+    short_error_message = "".join(
+        random.choice(string.ascii_letters) for _ in range(ERROR_MESSAGE_LENGTH // 2)
+    )
+    assert_true(subjects)
+    table_name = "fake_table"
+
+    key = subjects.fetch("KEY")[0]
+
+    # test long error message
+    schema.schema.jobs.reserve(table_name, key)
+    schema.schema.jobs.error(table_name, key, long_error_message)
+    error_message = schema.schema.jobs.fetch1("error_message")
+    assert_true(
+        len(error_message) == ERROR_MESSAGE_LENGTH,
+        "error message is longer than max allowed",
+    )
+    assert_true(
+        error_message.endswith(TRUNCATION_APPENDIX),
+        "appropriate ending missing for truncated error message",
+    )
+    schema.schema.jobs.delete()
+
+    # test long error message
+    schema.schema.jobs.reserve(table_name, key)
+    schema.schema.jobs.error(table_name, key, short_error_message)
+    error_message = schema.schema.jobs.fetch1("error_message")
+    assert_true(error_message == short_error_message, "error messages do not agree")
+    assert_false(
+        error_message.endswith(TRUNCATION_APPENDIX),
+        "error message should not be truncated",
+    )
+    schema.schema.jobs.delete()
+
+
+def test_long_error_stack():
+    # clear out jobs table
+    schema.schema.jobs.delete()
+
+    # create long error stack
+    STACK_SIZE = (
+        89942  # Does not fit into small blob (should be 64k, but found to be higher)
+    )
+    long_error_stack = "".join(
+        random.choice(string.ascii_letters) for _ in range(STACK_SIZE)
+    )
+    assert subjects
+    table_name = "fake_table"
+
+    key = subjects.fetch("KEY")[0]
+
+    # test long error stack
+    schema.schema.jobs.reserve(table_name, key)
+    schema.schema.jobs.error(table_name, key, "error message", long_error_stack)
+    error_stack = schema.schema.jobs.fetch1("error_stack")
+    assert error_stack == long_error_stack, "error stacks do not agree"
+    schema.schema.jobs.delete()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,50 +1,53 @@
-from nose.tools import assert_true, assert_false, assert_equals
+import pytest
 from . import schema
 from datajoint.jobs import ERROR_MESSAGE_LENGTH, TRUNCATION_APPENDIX
 import random
 import string
 import datajoint as dj
 
-subjects = schema.Subject()
+
+@pytest.fixture
+def subjects():
+    yield schema.Subject()
 
 
-def test_reserve_job():
-    schema.schema.jobs.delete()
+def test_reserve_job(schema_any, subjects):
+    schema_any.jobs.delete()
     assert subjects
     table_name = "fake_table"
 
     # reserve jobs
     for key in subjects.fetch("KEY"):
-        assert schema.schema.jobs.reserve(table_name, key), "failed to reserve a job"
+        assert schema_any.jobs.reserve(table_name, key), "failed to reserve a job"
 
     # refuse jobs
     for key in subjects.fetch("KEY"):
-        assert not schema.schema.jobs.reserve(table_name, key), "failed to respect reservation"
+        assert not schema_any.jobs.reserve(table_name, key), "failed to respect reservation"
 
     # complete jobs
     for key in subjects.fetch("KEY"):
-        schema.schema.jobs.complete(table_name, key)
-    assert not schema.schema.jobs, "failed to free jobs"
+        schema_any.jobs.complete(table_name, key)
+    assert not schema_any.jobs, "failed to free jobs"
 
     # reserve jobs again
     for key in subjects.fetch("KEY"):
-        assert schema.schema.jobs.reserve(table_name, key), "failed to reserve new jobs"
+        assert schema_any.jobs.reserve(table_name, key), "failed to reserve new jobs"
 
     # finish with error
     for key in subjects.fetch("KEY"):
-        schema.schema.jobs.error(table_name, key, "error message")
+        schema_any.jobs.error(table_name, key, "error message")
 
     # refuse jobs with errors
     for key in subjects.fetch("KEY"):
-        assert not schema.schema.jobs.reserve(table_name, key), "failed to ignore error jobs"
+        assert not schema_any.jobs.reserve(table_name, key), "failed to ignore error jobs"
 
     # clear error jobs
-    (schema.schema.jobs & dict(status="error")).delete()
-    assert not schema.schema.jobs, "failed to clear error jobs"
+    (schema_any.jobs & dict(status="error")).delete()
+    assert not schema_any.jobs, "failed to clear error jobs"
 
 
-def test_restrictions():
-    jobs = schema.schema.jobs
+def test_restrictions(schema_any, subjects):
+    jobs = schema_any.jobs
     jobs.delete()
     jobs.reserve("a", {"key": "a1"})
     jobs.reserve("a", {"key": "a2"})
@@ -58,45 +61,45 @@ def test_restrictions():
     jobs.delete()
 
 
-def test_sigint():
+def test_sigint(schema_any, subjects):
     # clear out job table
-    schema.schema.jobs.delete()
+    schema_any.jobs.delete()
     try:
         schema.SigIntTable().populate(reserve_jobs=True)
     except KeyboardInterrupt:
         pass
 
-    status, error_message = schema.schema.jobs.fetch1("status", "error_message")
+    status, error_message = schema_any.jobs.fetch1("status", "error_message")
     assert status == "error"
     assert error_message == "KeyboardInterrupt"
-    schema.schema.jobs.delete()
+    schema_any.jobs.delete()
 
 
-def test_sigterm():
+def test_sigterm(schema_any, subjects):
     # clear out job table
-    schema.schema.jobs.delete()
+    schema_any.jobs.delete()
     try:
         schema.SigTermTable().populate(reserve_jobs=True)
     except SystemExit:
         pass
 
-    status, error_message = schema.schema.jobs.fetch1("status", "error_message")
+    status, error_message = schema_any.jobs.fetch1("status", "error_message")
     assert status == "error"
     assert error_message == "SystemExit: SIGTERM received"
-    schema.schema.jobs.delete()
+    schema_any.jobs.delete()
 
 
-def test_suppress_dj_errors():
+def test_suppress_dj_errors(schema_any, subjects):
     """test_suppress_dj_errors: dj errors suppressible w/o native py blobs"""
-    schema.schema.jobs.delete()
+    schema_any.jobs.delete()
     with dj.config(enable_python_native_blobs=False):
         schema.ErrorClass.populate(reserve_jobs=True, suppress_errors=True)
-    assert len(schema.DjExceptionName()) == len(schema.schema.jobs) > 0
+    assert len(schema.DjExceptionName()) == len(schema_any.jobs) > 0
 
 
-def test_long_error_message():
+def test_long_error_message(schema_any, subjects):
     # clear out jobs table
-    schema.schema.jobs.delete()
+    schema_any.jobs.delete()
 
     # create long error message
     long_error_message = "".join(
@@ -111,34 +114,25 @@ def test_long_error_message():
     key = subjects.fetch("KEY")[0]
 
     # test long error message
-    schema.schema.jobs.reserve(table_name, key)
-    schema.schema.jobs.error(table_name, key, long_error_message)
-    error_message = schema.schema.jobs.fetch1("error_message")
-    assert_true(
-        len(error_message) == ERROR_MESSAGE_LENGTH,
-        "error message is longer than max allowed",
-    )
-    assert_true(
-        error_message.endswith(TRUNCATION_APPENDIX),
-        "appropriate ending missing for truncated error message",
-    )
-    schema.schema.jobs.delete()
+    schema_any.jobs.reserve(table_name, key)
+    schema_any.jobs.error(table_name, key, long_error_message)
+    error_message = schema_any.jobs.fetch1("error_message")
+    assert len(error_message) == ERROR_MESSAGE_LENGTH, "error message is longer than max allowed"
+    assert error_message.endswith(TRUNCATION_APPENDIX), "appropriate ending missing for truncated error message"
+    schema_any.jobs.delete()
 
     # test long error message
-    schema.schema.jobs.reserve(table_name, key)
-    schema.schema.jobs.error(table_name, key, short_error_message)
-    error_message = schema.schema.jobs.fetch1("error_message")
+    schema_any.jobs.reserve(table_name, key)
+    schema_any.jobs.error(table_name, key, short_error_message)
+    error_message = schema_any.jobs.fetch1("error_message")
     assert error_message == short_error_message, "error messages do not agree"
-    assert_false(
-        error_message.endswith(TRUNCATION_APPENDIX),
-        "error message should not be truncated",
-    )
-    schema.schema.jobs.delete()
+    assert not error_message.endswith(TRUNCATION_APPENDIX), "error message should not be truncated"
+    schema_any.jobs.delete()
 
 
-def test_long_error_stack():
+def test_long_error_stack(schema_any, subjects):
     # clear out jobs table
-    schema.schema.jobs.delete()
+    schema_any.jobs.delete()
 
     # create long error stack
     STACK_SIZE = (
@@ -153,8 +147,8 @@ def test_long_error_stack():
     key = subjects.fetch("KEY")[0]
 
     # test long error stack
-    schema.schema.jobs.reserve(table_name, key)
-    schema.schema.jobs.error(table_name, key, "error message", long_error_stack)
-    error_stack = schema.schema.jobs.fetch1("error_stack")
+    schema_any.jobs.reserve(table_name, key)
+    schema_any.jobs.error(table_name, key, "error message", long_error_stack)
+    error_stack = schema_any.jobs.fetch1("error_stack")
     assert error_stack == long_error_stack, "error stacks do not agree"
-    schema.schema.jobs.delete()
+    schema_any.jobs.delete()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -49,7 +49,7 @@ def test_reserve_job(schema_any, subjects):
     assert not schema_any.jobs, "failed to clear error jobs"
 
 
-def test_restrictions(schema_any, subjects):
+def test_restrictions(schema_any):
     jobs = schema_any.jobs
     jobs.delete()
     jobs.reserve("a", {"key": "a1"})
@@ -64,7 +64,7 @@ def test_restrictions(schema_any, subjects):
     jobs.delete()
 
 
-def test_sigint(schema_any, subjects):
+def test_sigint(schema_any):
     try:
         schema.SigIntTable().populate(reserve_jobs=True)
     except KeyboardInterrupt:
@@ -76,7 +76,7 @@ def test_sigint(schema_any, subjects):
     assert error_message == "KeyboardInterrupt"
 
 
-def test_sigterm(schema_any, subjects):
+def test_sigterm(schema_any):
     try:
         schema.SigTermTable().populate(reserve_jobs=True)
     except SystemExit:
@@ -88,7 +88,7 @@ def test_sigterm(schema_any, subjects):
     assert error_message == "SystemExit: SIGTERM received"
 
 
-def test_suppress_dj_errors(schema_any, subjects):
+def test_suppress_dj_errors(schema_any):
     """test_suppress_dj_errors: dj errors suppressible w/o native py blobs"""
     with dj.config(enable_python_native_blobs=False):
         schema.ErrorClass.populate(reserve_jobs=True, suppress_errors=True)
@@ -131,7 +131,7 @@ def test_long_error_message(schema_any, subjects):
     schema_any.jobs.delete()
 
 
-def test_long_error_stack(schema_any, subjects):
+def test_long_error_stack(schema_any):
     # create long error stack
     STACK_SIZE = (
         89942  # Does not fit into small blob (should be 64k, but found to be higher)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -82,7 +82,7 @@ def test_sigterm(schema_any):
     except SystemExit:
         pass
 
-    assert len(schema_any.jobs.fetch()), "SigTermjobs table is empty"
+    assert len(schema_any.jobs.fetch()), "SigTerm jobs table is empty"
     status, error_message = schema_any.jobs.fetch1("status", "error_message")
     assert status == "error"
     assert error_message == "SystemExit: SIGTERM received"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -131,7 +131,7 @@ def test_long_error_message(schema_any, subjects):
     schema_any.jobs.delete()
 
 
-def test_long_error_stack(schema_any):
+def test_long_error_stack(schema_any, subjects):
     # create long error stack
     STACK_SIZE = (
         89942  # Does not fit into small blob (should be 64k, but found to be higher)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -21,7 +21,9 @@ def test_reserve_job(schema_any, subjects):
 
     # refuse jobs
     for key in subjects.fetch("KEY"):
-        assert not schema_any.jobs.reserve(table_name, key), "failed to respect reservation"
+        assert not schema_any.jobs.reserve(
+            table_name, key
+        ), "failed to respect reservation"
 
     # complete jobs
     for key in subjects.fetch("KEY"):
@@ -38,7 +40,9 @@ def test_reserve_job(schema_any, subjects):
 
     # refuse jobs with errors
     for key in subjects.fetch("KEY"):
-        assert not schema_any.jobs.reserve(table_name, key), "failed to ignore error jobs"
+        assert not schema_any.jobs.reserve(
+            table_name, key
+        ), "failed to ignore error jobs"
 
     # clear error jobs
     (schema_any.jobs & dict(status="error")).delete()
@@ -108,8 +112,12 @@ def test_long_error_message(schema_any, subjects):
     schema_any.jobs.reserve(table_name, key)
     schema_any.jobs.error(table_name, key, long_error_message)
     error_message = schema_any.jobs.fetch1("error_message")
-    assert len(error_message) == ERROR_MESSAGE_LENGTH, "error message is longer than max allowed"
-    assert error_message.endswith(TRUNCATION_APPENDIX), "appropriate ending missing for truncated error message"
+    assert (
+        len(error_message) == ERROR_MESSAGE_LENGTH
+    ), "error message is longer than max allowed"
+    assert error_message.endswith(
+        TRUNCATION_APPENDIX
+    ), "appropriate ending missing for truncated error message"
     schema_any.jobs.delete()
 
     # test long error message
@@ -117,7 +125,9 @@ def test_long_error_message(schema_any, subjects):
     schema_any.jobs.error(table_name, key, short_error_message)
     error_message = schema_any.jobs.fetch1("error_message")
     assert error_message == short_error_message, "error messages do not agree"
-    assert not error_message.endswith(TRUNCATION_APPENDIX), "error message should not be truncated"
+    assert not error_message.endswith(
+        TRUNCATION_APPENDIX
+    ), "error message should not be truncated"
     schema_any.jobs.delete()
 
 


### PR DESCRIPTION
- Changes from #1129
- Changes from #1130
- cp to tests
- nose2pytest test_jobs
- All but two test_jobs passing
- Clean jobs table in fixture
- Change from generator to list
- Tolerate error when cleaning up schema_any.jobs
- Format with black
