### PR TITLE
PLAT-143: Test compatibility with Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        py_ver: ["3.9"]
+        py_ver: ["3.9", "3.10", "3.11"]
         mysql_ver: ["8.0", "5.7"]
         include:
           - py_ver: "3.8"


### PR DESCRIPTION
Add Python 3.10 and 3.11 to the CI `strategy.matrix.py_ver`.
