### PR TITLE
Fix #1150

### DIFF
--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -15,7 +15,7 @@ from .declare import declare, alter
 from .condition import make_condition
 from .expression import QueryExpression
 from . import blob
-from .utils import user_choice, get_master
+from .utils import user_choice, get_master, is_camel_case
 from .heading import Heading
 from .errors import (
     DuplicateError,

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -102,8 +102,8 @@ class Table(QueryExpression):
             raise DataJointError(
                 "Table with class name `{name}` contains an underscore. ".format(
                     name=self.class_name
-                ) +
-                "Classes defining tables should be formatted in strict CamelCase."
+                )
+                + "Classes defining tables should be formatted in strict CamelCase."
             )
         sql, external_stores = declare(self.full_table_name, self.definition, context)
         sql = sql.format(database=self.database)

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -98,9 +98,9 @@ class Table(QueryExpression):
                 "e.g. from inside a populate/make call"
             )
         # Enforce strict CamelCase #1150
-        if "_" in self.class_name:
+        if not is_camel_case(self.class_name):
             raise DataJointError(
-                "Table with class name `{name}` contains an underscore. ".format(
+                "Table class name `{name}` is invalid. Please use CamelCase. ".format(
                     name=self.class_name
                 )
                 + "Classes defining tables should be formatted in strict CamelCase."

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -76,6 +76,10 @@ class Table(QueryExpression):
         return self._table_name
 
     @property
+    def class_name(self):
+        return self.__class__.__name__
+
+    @property
     def definition(self):
         raise NotImplementedError(
             "Subclasses of Table must implement the `definition` property"
@@ -92,6 +96,14 @@ class Table(QueryExpression):
             raise DataJointError(
                 "Cannot declare new tables inside a transaction, "
                 "e.g. from inside a populate/make call"
+            )
+        # Enforce strict CamelCase #1150
+        if "_" in self.class_name:
+            raise DataJointError(
+                "Table with class name `{name}` contains an underscore. ".format(
+                    name=self.class_name
+                ) +
+                "Classes defining tables should be formatted in strict CamelCase."
             )
         sql, external_stores = declare(self.full_table_name, self.definition, context)
         sql = sql.format(database=self.database)

--- a/datajoint/utils.py
+++ b/datajoint/utils.py
@@ -53,19 +53,6 @@ def get_master(full_table_name: str) -> str:
     return match["master"] + "`" if match else ""
 
 
-def contains_non_ascii_char(s):
-    """
-    Check if a string contains non-ASCII characters.
-
-    :param s: string to check
-    :returns: True if the string contains any non-ASCII characters, False otherwise
-    Example:
-    >>> contains_non_ascii_char("Hello")  # returns False
-    >>> contains_non_ascii_char("HelloΣ")  # returns True
-    """
-    return any(ord(c) > 127 for c in s)
-
-
 def is_camel_case(s):
     """
     Check if a string is in CamelCase notation.
@@ -76,9 +63,7 @@ def is_camel_case(s):
     >>> is_camel_case("TableName")  # returns True
     >>> is_camel_case("table_name")  # returns False
     """
-    return re.match(
-        r"^[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)*$", s
-    ) is not None and not contains_non_ascii_char(s)
+    return bool(re.match(r"^[A-Z][A-Za-z0-9]*$", s))
 
 
 def to_camel_case(s):

--- a/datajoint/utils.py
+++ b/datajoint/utils.py
@@ -76,10 +76,7 @@ def is_camel_case(s):
     >>> is_camel_case("TableName")  # returns True
     >>> is_camel_case("table_name")  # returns False
     """
-    # return re.match(r"^[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)*$", s) is not None
-    return re.match(
-        r"[A-Z][a-zA-Z0-9]*", s
-    ) is not None and not contains_non_ascii_char(s)
+    return re.match(r"^[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)*$", s) is not None and not contains_non_ascii_char(s)
 
 
 def to_camel_case(s):

--- a/datajoint/utils.py
+++ b/datajoint/utils.py
@@ -77,7 +77,9 @@ def is_camel_case(s):
     >>> is_camel_case("table_name")  # returns False
     """
     # return re.match(r"^[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)*$", s) is not None
-    return re.match(r"[A-Z][a-zA-Z0-9]*", s) is not None and not contains_non_ascii_char(s)
+    return re.match(
+        r"[A-Z][a-zA-Z0-9]*", s
+    ) is not None and not contains_non_ascii_char(s)
 
 
 def to_camel_case(s):

--- a/datajoint/utils.py
+++ b/datajoint/utils.py
@@ -53,6 +53,33 @@ def get_master(full_table_name: str) -> str:
     return match["master"] + "`" if match else ""
 
 
+def contains_non_ascii_char(s):
+    """
+    Check if a string contains non-ASCII characters.
+
+    :param s: string to check
+    :returns: True if the string contains any non-ASCII characters, False otherwise
+    Example:
+    >>> contains_non_ascii_char("Hello")  # returns False
+    >>> contains_non_ascii_char("HelloΣ")  # returns True
+    """
+    return any(ord(c) > 127 for c in s)
+
+
+def is_camel_case(s):
+    """
+    Check if a string is in CamelCase notation.
+
+    :param s: string to check
+    :returns: True if the string is in CamelCase notation, False otherwise
+    Example:
+    >>> is_camel_case("TableName")  # returns True
+    >>> is_camel_case("table_name")  # returns False
+    """
+    # return re.match(r"^[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)*$", s) is not None
+    return re.match(r"[A-Z][a-zA-Z0-9]*", s) is not None and not contains_non_ascii_char(s)
+
+
 def to_camel_case(s):
     """
     Convert names with under score (_) separation into camel case names.
@@ -82,7 +109,7 @@ def from_camel_case(s):
     def convert(match):
         return ("_" if match.groups()[0] else "") + match.group(0).lower()
 
-    if not re.match(r"[A-Z][a-zA-Z0-9]*", s):
+    if not is_camel_case(s):
         raise DataJointError(
             "ClassName must be alphanumeric in CamelCase, begin with a capital letter"
         )

--- a/datajoint/utils.py
+++ b/datajoint/utils.py
@@ -76,7 +76,9 @@ def is_camel_case(s):
     >>> is_camel_case("TableName")  # returns True
     >>> is_camel_case("table_name")  # returns False
     """
-    return re.match(r"^[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)*$", s) is not None and not contains_non_ascii_char(s)
+    return re.match(
+        r"^[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+)*$", s
+    ) is not None and not contains_non_ascii_char(s)
 
 
 def to_camel_case(s):

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -356,5 +356,7 @@ def test_table_name_with_underscores(schema_any):
         """
 
     schema_any(TableNoUnderscores)
-    with pytest.raises(dj.DataJointError, match="strict CamelCase") as e:
+    with pytest.raises(
+        dj.DataJointError, match="must be alphanumeric in CamelCase"
+    ) as e:
         schema_any(Table_With_Underscores)

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -358,4 +358,3 @@ def test_table_name_with_underscores(schema_any):
     schema_any(TableNoUnderscores)
     with pytest.raises(dj.DataJointError, match="strict CamelCase") as e:
         schema_any(Table_With_Underscores)
-

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -337,3 +337,25 @@ def test_long_table_name(schema_any):
 
     with pytest.raises(dj.DataJointError):
         schema_any(WhyWouldAnyoneCreateATableNameThisLong)
+
+
+def test_table_name_with_underscores(schema_any):
+    """
+    Test issue #1150 -- Reject table names containing underscores. Tables should be in strict
+    CamelCase.
+    """
+
+    class TableNoUnderscores(dj.Manual):
+        definition = """
+        id : int
+        """
+
+    class Table_With_Underscores(dj.Manual):
+        definition = """
+        id : int
+        """
+
+    schema_any(TableNoUnderscores)
+    with pytest.raises(dj.DataJointError, match="CamelCase") as e:
+        schema_any(Table_With_Underscores)
+

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -356,6 +356,6 @@ def test_table_name_with_underscores(schema_any):
         """
 
     schema_any(TableNoUnderscores)
-    with pytest.raises(dj.DataJointError, match="CamelCase") as e:
+    with pytest.raises(dj.DataJointError, match="strict CamelCase") as e:
         schema_any(Table_With_Underscores)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,6 @@ from datajoint.utils import (
     from_camel_case,
     to_camel_case,
     is_camel_case,
-    contains_non_ascii_char,
 )
 import pytest
 
@@ -23,9 +22,7 @@ def test_is_camel_case():
     assert not is_camel_case("hello world")
     assert not is_camel_case("#baisc_names")
     assert not is_camel_case("alphaBeta")
-    non_ascii_class_name = "TestΣ"
-    assert contains_non_ascii_char(non_ascii_class_name)
-    assert not is_camel_case(non_ascii_class_name)
+    assert not is_camel_case("TestΣ")
 
 
 def test_from_camel_case():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,12 @@ Collection of test cases to test core module.
 """
 
 from datajoint import DataJointError
-from datajoint.utils import from_camel_case, to_camel_case, is_camel_case, contains_non_ascii_char
+from datajoint.utils import (
+    from_camel_case,
+    to_camel_case,
+    is_camel_case,
+    contains_non_ascii_char,
+)
 import pytest
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,9 @@ import pytest
 
 def test_is_camel_case():
     assert is_camel_case("AllGroups")
+    assert not is_camel_case("All_Groups")
+    assert not is_camel_case("All_Groups_")
+    assert not is_camel_case("_AllGroups")
     assert not is_camel_case("allGroups")
     assert not is_camel_case("repNames")
     assert not is_camel_case("10_all")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,21 @@ Collection of test cases to test core module.
 """
 
 from datajoint import DataJointError
-from datajoint.utils import from_camel_case, to_camel_case
+from datajoint.utils import from_camel_case, to_camel_case, is_camel_case, contains_non_ascii_char
 import pytest
+
+
+def test_is_camel_case():
+    assert is_camel_case("AllGroups")
+    assert not is_camel_case("allGroups")
+    assert not is_camel_case("repNames")
+    assert not is_camel_case("10_all")
+    assert not is_camel_case("hello world")
+    assert not is_camel_case("#baisc_names")
+    assert not is_camel_case("alphaBeta")
+    non_ascii_class_name = "TestΣ"
+    assert contains_non_ascii_char(non_ascii_class_name)
+    assert not is_camel_case(non_ascii_class_name)
 
 
 def test_from_camel_case():


### PR DESCRIPTION
Resolves #1150 by enforcing strict CamelCase for classes that inherit from `Table`.

## Commits

- Failing pytest reproducing #1150
- feat: enforce strict CamelCase for Table names
