### PR TITLE
Allow including master table in cascading delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Added - Missing tests for set_password - PR [#1106](https://github.com/datajoint/datajoint-python/pull/1106)
 - Changed - Returning success count after the .populate() call - PR [#1050](https://github.com/datajoint/datajoint-python/pull/1050)
 - Fixed - `Autopopulate.populate` excludes `reserved` jobs in addition to `ignore` and `error` jobs 
-- Fixed - Issue [#1159]((https://github.com/datajoint/datajoint-python/pull/1159)  (cascading delete)  - PR [#1160](https://github.com/datajoint/datajoint-python/pull/1160)
+- Fixed - Issue [#1159](https://github.com/datajoint/datajoint-python/pull/1159) (cascading delete) - PR [#1160](https://github.com/datajoint/datajoint-python/pull/1160)
 - Fixed - `docker compose` commands in CI [#1164](https://github.com/datajoint/datajoint-python/pull/1164)
 - Changed - Default delete behavior now includes masters of part tables - PR [#1158](https://github.com/datajoint/datajoint-python/pull/1158)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed - `Autopopulate.populate` excludes `reserved` jobs in addition to `ignore` and `error` jobs 
 - Fixed - Issue [#1159]((https://github.com/datajoint/datajoint-python/pull/1159)  (cascading delete)  - PR [#1160](https://github.com/datajoint/datajoint-python/pull/1160)
 - Fixed - `docker compose` commands in CI [#1164](https://github.com/datajoint/datajoint-python/pull/1164)
+- Changed - Default delete behavior now includes masters of part tables - PR [#1158](https://github.com/datajoint/datajoint-python/pull/1158)
 
 ### 0.14.1 -- Jun 02, 2023
 - Fixed - Fix altering a part table that uses the "master" keyword - PR [#991](https://github.com/datajoint/datajoint-python/pull/991)

--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -847,7 +847,7 @@ class U:
     >>> dj.U().aggr(expr, n='count(*)')
 
     The following expressions both yield one element containing the number `n` of distinct values of attribute `attr` in
-    query expressio `expr`.
+    query expression `expr`.
 
     >>> dj.U().aggr(expr, n='count(distinct attr)')
     >>> dj.U().aggr(dj.U('attr').aggr(expr), 'n=count(*)')

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -486,7 +486,7 @@ class Table(QueryExpression):
         transaction: bool = True,
         safemode: Union[bool, None] = None,
         force_parts: bool = False,
-        include_parts: bool = True,
+        force_masters: bool = True,
     ) -> int:
         """
         Deletes the contents of the table and its dependent tables, recursively.

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -498,7 +498,7 @@ class Table(QueryExpression):
             safemode: If `True`, prohibit nested transactions and prompt to confirm. Default
                 is `dj.config['safemode']`.
             force_parts: Delete from parts even when not deleting from their masters.
-            include_parts: If `True`, include part/master pairs in the cascade.
+            force_masters: If `True`, include part/master pairs in the cascade.
                 Default is `True`.
 
         Returns:
@@ -573,7 +573,7 @@ class Table(QueryExpression):
 
                     master_name = get_master(child.full_table_name)
                     if (
-                        include_parts
+                        force_masters
                         and master_name
                         and master_name != table.full_table_name
                         and master_name not in visited_masters

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -512,6 +512,12 @@ class Table(QueryExpression):
         deleted = set()
         visited_masters = set()
 
+        if force_masters and not force_parts:
+            logger.warn(
+                "force_masters=True implies force_parts=True. "
+                + "Ignoring force_parts=False."
+            )  # No need to reset, as force_masters will cascade to parts.
+
         def cascade(table):
             """service function to perform cascading deletes recursively."""
             max_attempts = 50

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -593,7 +593,7 @@ class Table(QueryExpression):
                 else:
                     deleted.add(table.full_table_name)
                     logger.info(
-                        "Deleting: {count} rows from {table}".format(
+                        "Deleting {count} rows from {table}".format(
                             count=delete_count, table=table.full_table_name
                         )
                     )

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -512,12 +512,6 @@ class Table(QueryExpression):
         deleted = set()
         visited_masters = set()
 
-        if force_masters and not force_parts:
-            logger.warn(
-                "force_masters=True implies force_parts=True. "
-                + "Ignoring force_parts=False."
-            )  # No need to reset, as force_masters will cascade to parts.
-
         def cascade(table):
             """service function to perform cascading deletes recursively."""
             max_attempts = 50

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -486,7 +486,7 @@ class Table(QueryExpression):
         transaction: bool = True,
         safemode: Union[bool, None] = None,
         force_parts: bool = False,
-        force_masters: bool = True,
+        force_masters: bool = False,
     ) -> int:
         """
         Deletes the contents of the table and its dependent tables, recursively.
@@ -499,7 +499,7 @@ class Table(QueryExpression):
                 is `dj.config['safemode']`.
             force_parts: Delete from parts even when not deleting from their masters.
             force_masters: If `True`, include part/master pairs in the cascade.
-                Default is `True`.
+                Default is `False`.
 
         Returns:
             Number of deleted rows (excluding those from dependent tables).

--- a/docs/src/manipulation/delete.md
+++ b/docs/src/manipulation/delete.md
@@ -27,4 +27,5 @@ consequence of deleting the master table.
 
 To enforce this workflow, calling `delete` directly on a part table produces an error.
 In some cases, it may be necessary to override this behavior.
-To remove entities from a part table without calling `delete` master, use the argument `force=True`.
+To remove entities from a part table without calling `delete` master, use the argument `force_parts=True`.
+To include the correponding entries in the master table, use the argument `force_masters=True`.

--- a/docs/src/manipulation/delete.md
+++ b/docs/src/manipulation/delete.md
@@ -28,4 +28,4 @@ consequence of deleting the master table.
 To enforce this workflow, calling `delete` directly on a part table produces an error.
 In some cases, it may be necessary to override this behavior.
 To remove entities from a part table without calling `delete` master, use the argument `force_parts=True`.
-To include the correponding entries in the master table, use the argument `force_masters=True`.
+To include the corresponding entries in the master table, use the argument `force_masters=True`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,6 +317,7 @@ def schema_simp(connection_test, prefix):
     schema(schema_simple.E)
     schema(schema_simple.F)
     schema(schema_simple.F)
+    schema(schema_simple.G)
     schema(schema_simple.DataA)
     schema(schema_simple.DataB)
     schema(schema_simple.Website)

--- a/tests/schema_simple.py
+++ b/tests/schema_simple.py
@@ -111,17 +111,36 @@ class E(dj.Computed):
         -> B.C
         """
 
+    class G(dj.Part):
+        definition = """ # test secondary fk reference
+        -> E
+        id_g :int
+        ---
+        -> L
+        """
+
+    class H(dj.Part):
+        definition = """ # test no additional fk reference
+        -> E
+        id_h :int
+        """
+
     def make(self, key):
         random.seed(str(key))
-        self.insert1(dict(key, **random.choice(list(L().fetch("KEY")))))
-        sub = E.F()
-        references = list((B.C() & key).fetch("KEY"))
-        random.shuffle(references)
-        sub.insert(
+        l_contents = list(L().fetch("KEY"))
+        part_f, part_g, part_h = E.F(), E.G(), E.H()
+        bc_references = list((B.C() & key).fetch("KEY"))
+        random.shuffle(bc_references)
+
+        self.insert1(dict(key, **random.choice(l_contents)))
+        part_f.insert(
             dict(key, id_f=i, **ref)
-            for i, ref in enumerate(references)
+            for i, ref in enumerate(bc_references)
             if random.getrandbits(1)
         )
+        g_inserts = [dict(key, id_g=i, **ref) for i, ref in enumerate(l_contents)]
+        part_g.insert(g_inserts)
+        part_h.insert(dict(key, id_h=i) for i in range(4))
 
 
 class F(dj.Manual):
@@ -130,6 +149,15 @@ class F(dj.Manual):
     ----
     date=null: date
     """
+
+
+class G(dj.Computed):
+    definition = """ # test downstream of complex master/parts
+    -> E
+    """
+
+    def make(self, key):
+        self.insert1(key)
 
 
 class DataA(dj.Lookup):

--- a/tests/schema_simple.py
+++ b/tests/schema_simple.py
@@ -150,7 +150,7 @@ class E(dj.Computed):
         part_g.insert(g_inserts)
         h_inserts = [dict(key, id_h=i) for i in range(4)]
         part_h.insert(h_inserts)
-        part_m.insert(dict(key, id_i=i, **random.choice(h_inserts)) for i in range(4))
+        part_m.insert(dict(key, id_m=m, **random.choice(h_inserts)) for m in range(4))
 
 
 class F(dj.Manual):

--- a/tests/schema_simple.py
+++ b/tests/schema_simple.py
@@ -125,10 +125,18 @@ class E(dj.Computed):
         id_h :int
         """
 
+    class I(dj.Part): 
+        definition = """ # test force_masters revisit part
+        -> E
+        id_i :int
+        ---
+        -> H
+        """
+
     def make(self, key):
         random.seed(str(key))
         l_contents = list(L().fetch("KEY"))
-        part_f, part_g, part_h = E.F(), E.G(), E.H()
+        part_f, part_g, part_h, part_i = E.F(), E.G(), E.H(), E.I()
         bc_references = list((B.C() & key).fetch("KEY"))
         random.shuffle(bc_references)
 
@@ -141,6 +149,7 @@ class E(dj.Computed):
         g_inserts = [dict(key, id_g=i, **ref) for i, ref in enumerate(l_contents)]
         part_g.insert(g_inserts)
         part_h.insert(dict(key, id_h=i) for i in range(4))
+        part_i.insert(dict(key, id_i=i, **random.choice(g_inserts)) for i in range(4))
 
 
 class F(dj.Manual):

--- a/tests/schema_simple.py
+++ b/tests/schema_simple.py
@@ -125,18 +125,18 @@ class E(dj.Computed):
         id_h :int
         """
 
-    class I(dj.Part): 
-        definition = """ # test force_masters revisit part
+    class M(dj.Part):
+        definition = """ # test force_masters revisit
         -> E
-        id_i :int
+        id_m :int
         ---
-        -> H
+        -> E.H
         """
 
     def make(self, key):
         random.seed(str(key))
         l_contents = list(L().fetch("KEY"))
-        part_f, part_g, part_h, part_i = E.F(), E.G(), E.H(), E.I()
+        part_f, part_g, part_h, part_m = E.F(), E.G(), E.H(), E.M()
         bc_references = list((B.C() & key).fetch("KEY"))
         random.shuffle(bc_references)
 
@@ -148,8 +148,9 @@ class E(dj.Computed):
         )
         g_inserts = [dict(key, id_g=i, **ref) for i, ref in enumerate(l_contents)]
         part_g.insert(g_inserts)
-        part_h.insert(dict(key, id_h=i) for i in range(4))
-        part_i.insert(dict(key, id_i=i, **random.choice(g_inserts)) for i in range(4))
+        h_inserts = [dict(key, id_h=i) for i in range(4)]
+        part_h.insert(h_inserts)
+        part_m.insert(dict(key, id_i=i, **random.choice(h_inserts)) for i in range(4))
 
 
 class F(dj.Manual):

--- a/tests/test_cascading_delete.py
+++ b/tests/test_cascading_delete.py
@@ -127,7 +127,7 @@ def test_delete_parts(schema_simp_pop):
 def test_delete_parts_complex(schema_simp_pop):
     """test issue #151 with complex master/part. PR #1158."""
     prev_len = len(G())
-    (A() & "id_a=1").delete()
+    (A() & "id_a=1").delete(force_masters=True)
     assert prev_len - len(G()) == 16, "Failed to delete parts"
 
 

--- a/tests/test_cascading_delete.py
+++ b/tests/test_cascading_delete.py
@@ -115,13 +115,13 @@ def test_delete_parts_error(schema_simp_pop):
     """test issue #151"""
     with pytest.raises(dj.DataJointError):
         Profile().populate_random()
-        Website().delete(include_parts=False)
+        Website().delete(force_masters=False)
 
 
 def test_delete_parts(schema_simp_pop):
     """test issue #151"""
     Profile().populate_random()
-    Website().delete(include_parts=True)
+    Website().delete(force_masters=True)
 
 
 def test_delete_parts_complex(schema_simp_pop):

--- a/tests/test_cascading_delete.py
+++ b/tests/test_cascading_delete.py
@@ -110,11 +110,17 @@ def test_delete_master(schema_simp_pop):
     Profile().delete()
 
 
-def test_delete_parts(schema_simp_pop):
+def test_delete_parts_error(schema_simp_pop):
     """test issue #151"""
     with pytest.raises(dj.DataJointError):
         Profile().populate_random()
-        Website().delete()
+        Website().delete(include_master=False)
+
+
+def test_delete_parts(schema_simp_pop):
+    """test issue #151"""
+    Profile().populate_random()
+    Website().delete(include_master=True)
 
 
 def test_drop_part(schema_simp_pop):

--- a/tests/test_erd.py
+++ b/tests/test_erd.py
@@ -1,5 +1,5 @@
 import datajoint as dj
-from .schema_simple import LOCALS_SIMPLE, A, B, D, E, L, OutfitLaunch
+from .schema_simple import LOCALS_SIMPLE, A, B, D, E, G, L, OutfitLaunch
 from .schema_advanced import *
 
 
@@ -20,7 +20,7 @@ def test_dependencies(schema_simp):
     assert set(D().parents(primary=True)) == set([A.full_table_name])
     assert set(D().parents(primary=False)) == set([L.full_table_name])
     assert set(deps.descendants(L.full_table_name)).issubset(
-        cls.full_table_name for cls in (L, D, E, E.F)
+        cls.full_table_name for cls in (L, D, E, E.F, E.G, E.H, G)
     )
 
 
@@ -38,10 +38,14 @@ def test_erd_algebra(schema_simp):
     erd3 = erd1 * erd2
     erd4 = (erd0 + E).add_parts() - B - E
     assert erd0.nodes_to_show == set(cls.full_table_name for cls in [B])
-    assert erd1.nodes_to_show == set(cls.full_table_name for cls in (B, B.C, E, E.F))
+    assert erd1.nodes_to_show == set(
+        cls.full_table_name for cls in (B, B.C, E, E.F, E.G, E.H, G)
+    )
     assert erd2.nodes_to_show == set(cls.full_table_name for cls in (A, B, D, E, L))
     assert erd3.nodes_to_show == set(cls.full_table_name for cls in (B, E))
-    assert erd4.nodes_to_show == set(cls.full_table_name for cls in (B.C, E.F))
+    assert erd4.nodes_to_show == set(
+        cls.full_table_name for cls in (B.C, E.F, E.G, E.H)
+    )
 
 
 def test_repr_svg(schema_adv):

--- a/tests/test_erd.py
+++ b/tests/test_erd.py
@@ -20,7 +20,7 @@ def test_dependencies(schema_simp):
     assert set(D().parents(primary=True)) == set([A.full_table_name])
     assert set(D().parents(primary=False)) == set([L.full_table_name])
     assert set(deps.descendants(L.full_table_name)).issubset(
-        cls.full_table_name for cls in (L, D, E, E.F, E.G, E.H, G)
+        cls.full_table_name for cls in (L, D, E, E.F, E.G, E.H, E.M, G)
     )
 
 
@@ -39,12 +39,12 @@ def test_erd_algebra(schema_simp):
     erd4 = (erd0 + E).add_parts() - B - E
     assert erd0.nodes_to_show == set(cls.full_table_name for cls in [B])
     assert erd1.nodes_to_show == set(
-        cls.full_table_name for cls in (B, B.C, E, E.F, E.G, E.H, G)
+        cls.full_table_name for cls in (B, B.C, E, E.F, E.G, E.H, E.M, G)
     )
     assert erd2.nodes_to_show == set(cls.full_table_name for cls in (A, B, D, E, L))
     assert erd3.nodes_to_show == set(cls.full_table_name for cls in (B, E))
     assert erd4.nodes_to_show == set(
-        cls.full_table_name for cls in (B.C, E.F, E.G, E.H)
+        cls.full_table_name for cls in (B.C, E.F, E.G, E.H, E.M)
     )
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -196,6 +196,7 @@ def test_list_tables(schema_simp):
             "__e__f",
             "__e__g",
             "__e__h",
+            "__e__m",
             "__g",
             "#outfit_launch",
             "#outfit_launch__outfit_piece",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -184,7 +184,7 @@ def test_list_tables(schema_simp):
     """
     https://github.com/datajoint/datajoint-python/issues/838
     """
-    assert set(
+    expected = set(
         [
             "reserved_word",
             "#l",
@@ -194,6 +194,9 @@ def test_list_tables(schema_simp):
             "__b__c",
             "__e",
             "__e__f",
+            "__e__g",
+            "__e__h",
+            "__g",
             "#outfit_launch",
             "#outfit_launch__outfit_piece",
             "#i_j",
@@ -207,7 +210,9 @@ def test_list_tables(schema_simp):
             "profile",
             "profile__website",
         ]
-    ) == set(schema_simp.list_tables())
+    )
+    actual = set(schema_simp.list_tables())
+    assert actual == expected, f"Missing from list_tables(): {expected - actual}"
 
 
 def test_schema_save_any(schema_any):


### PR DESCRIPTION
#151 included a discussion of 'Option 2' in which the master would be deleted during a cascade, with a possible solution proposed in this PR. This feature would be particularly useful to the Spyglass team because our ['Merge tables'](https://lorenfranklab.github.io/spyglass/0.5/misc/merge_tables/) make use of foreign-key references in parts to version pipelines. 

Happy to incorporate feedback