### PR TITLE
Cascade restriction attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added - Missing tests for set_password - PR [#1106](https://github.com/datajoint/datajoint-python/pull/1106)
 - Changed - Returning success count after the .populate() call - PR [#1050](https://github.com/datajoint/datajoint-python/pull/1050)
 - Fixed - `Autopopulate.populate` excludes `reserved` jobs in addition to `ignore` and `error` jobs 
+- Fixed - `cascade` passes `_restriction_attributes` when passing `_restriction` - PR [#1160](https://github.com/datajoint/datajoint-python/pull/1060)
 
 ### 0.14.1 -- Jun 02, 2023
 - Fixed - Fix altering a part table that uses the "master" keyword - PR [#991](https://github.com/datajoint/datajoint-python/pull/991)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Added - Missing tests for set_password - PR [#1106](https://github.com/datajoint/datajoint-python/pull/1106)
 - Changed - Returning success count after the .populate() call - PR [#1050](https://github.com/datajoint/datajoint-python/pull/1050)
 - Fixed - `Autopopulate.populate` excludes `reserved` jobs in addition to `ignore` and `error` jobs 
-- Fixed - `cascade` passes `_restriction_attributes` when passing `_restriction` - PR [#1160](https://github.com/datajoint/datajoint-python/pull/1060)
+- Fixed - Issue [#1159]((https://github.com/datajoint/datajoint-python/pull/1159)  (cascading delete)  - PR [#1160](https://github.com/datajoint/datajoint-python/pull/1160)
 
 ### 0.14.1 -- Jun 02, 2023
 - Fixed - Fix altering a part table that uses the "master" keyword - PR [#991](https://github.com/datajoint/datajoint-python/pull/991)

--- a/datajoint/expression.py
+++ b/datajoint/expression.py
@@ -847,7 +847,7 @@ class U:
     >>> dj.U().aggr(expr, n='count(*)')
 
     The following expressions both yield one element containing the number `n` of distinct values of attribute `attr` in
-    query expressio `expr`.
+    query expression `expr`.
 
     >>> dj.U().aggr(expr, n='count(distinct attr)')
     >>> dj.U().aggr(dj.U('attr').aggr(expr), 'n=count(*)')

--- a/datajoint/table.py
+++ b/datajoint/table.py
@@ -559,6 +559,7 @@ class Table(QueryExpression):
                         and match["fk_attrs"] == match["pk_attrs"]
                     ):
                         child._restriction = table._restriction
+                        child._restriction_attributes = table.restriction_attributes
                     elif match["fk_attrs"] != match["pk_attrs"]:
                         child &= table.proj(
                             **dict(zip(match["fk_attrs"], match["pk_attrs"]))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,6 +285,8 @@ def schema_any(connection_test, prefix):
     schema_any(schema.ThingA)
     schema_any(schema.ThingB)
     schema_any(schema.ThingC)
+    schema_any(schema.ThingD)
+    schema_any(schema.ThingE)
     schema_any(schema.Parent)
     schema_any(schema.Child)
     schema_any(schema.ComplexParent)
@@ -301,6 +303,26 @@ def schema_any(connection_test, prefix):
     except DataJointError:
         pass
     schema_any.drop()
+
+
+@pytest.fixture
+def thing_tables(schema_any):
+    a = schema.ThingA()
+    b = schema.ThingB()
+    c = schema.ThingC()
+    d = schema.ThingD()
+    e = schema.ThingE()
+
+    # clear previous contents if any.
+    c.delete_quick()
+    b.delete_quick()
+    a.delete_quick()
+
+    a.insert(dict(a=a) for a in range(7))
+    b.insert1(dict(b1=1, b2=1, b3=100))
+    b.insert1(dict(b1=1, b2=2, b3=100))
+
+    yield a, b, c, d, e
 
 
 @pytest.fixture

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -345,6 +345,21 @@ class ThingC(dj.Manual):
     """
 
 
+#  Additional tables for #1159
+class ThingD(dj.Manual):
+    definition = """
+    d: int
+    ---
+    -> ThingC
+    """
+
+
+class ThingE(dj.Manual):
+    definition = """
+    -> ThingD
+    """
+
+
 class Parent(dj.Lookup):
     definition = """
     parent_id: int

--- a/tests/test_cascading_delete.py
+++ b/tests/test_cascading_delete.py
@@ -121,3 +121,16 @@ def test_drop_part(schema_simp_pop):
     """test issue #374"""
     with pytest.raises(dj.DataJointError):
         Website().drop()
+
+
+def test_delete_1159(thing_tables):
+    tbl_a, tbl_c, tbl_c, tbl_d, tbl_e = thing_tables
+
+    tbl_c.insert([dict(a=i) for i in range(6)])
+    tbl_d.insert([dict(a=i, d=i) for i in range(5)])
+    tbl_e.insert([dict(d=i) for i in range(4)])
+
+    (tbl_a & "a=3").delete()
+
+    assert len(tbl_a) == 6, "Failed to cascade restriction attributes"
+    assert len(tbl_e) == 3, "Failed to cascade restriction attributes"

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,8 +1,6 @@
-import datajoint as dj
 from datajoint import errors
 from pytest import raises
 from datajoint.dependencies import unite_master_parts
-from .schema import *
 
 
 def test_unite_master_parts():
@@ -50,22 +48,10 @@ def test_unite_master_parts():
     ]
 
 
-def test_nullable_dependency(schema_any):
+def test_nullable_dependency(thing_tables):
     """test nullable unique foreign key"""
     # Thing C has a nullable dependency on B whose primary key is composite
-    a = ThingA()
-    b = ThingB()
-    c = ThingC()
-
-    # clear previous contents if any.
-    c.delete_quick()
-    b.delete_quick()
-    a.delete_quick()
-
-    a.insert(dict(a=a) for a in range(7))
-
-    b.insert1(dict(b1=1, b2=1, b3=100))
-    b.insert1(dict(b1=1, b2=2, b3=100))
+    _, _, c, _, _ = thing_tables
 
     # missing foreign key attributes = ok
     c.insert1(dict(a=0))
@@ -79,23 +65,10 @@ def test_nullable_dependency(schema_any):
     assert len(c) == len(c.fetch()) == 5
 
 
-def test_unique_dependency(schema_any):
+def test_unique_dependency(thing_tables):
     """test nullable unique foreign key"""
-
     # Thing C has a nullable dependency on B whose primary key is composite
-    a = ThingA()
-    b = ThingB()
-    c = ThingC()
-
-    # clear previous contents if any.
-    c.delete_quick()
-    b.delete_quick()
-    a.delete_quick()
-
-    a.insert(dict(a=a) for a in range(7))
-
-    b.insert1(dict(b1=1, b2=1, b3=100))
-    b.insert1(dict(b1=1, b2=2, b3=100))
+    _, _, c, _, _ = thing_tables
 
     c.insert1(dict(a=0, b1=1, b2=1))
     # duplicate foreign key attributes = not ok


### PR DESCRIPTION
- Adds line to solve #1159 
- Adds test of edge case demonstrated in above issue
- Tests for cascading delete pass locally
- Pytests show unrelated errors related to an SSL certificate

> WARNING  urllib3.connectionpool:connectionpool.py:874 Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1002)'))': /datajoint.test
