### PR TITLE
Added encapsulating double quotes to comply with DOT language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release notes
 
+### Upcoming
+- Fixed - Added encapsulating double quotes to comply with [DOT language](https://graphviz.org/doc/info/lang.html) - PR [#1176](https://github.com/datajoint/datajoint-python/pull/1176)
+
 ### 0.14.2 -- Aug 19, 2024
 - Added - Migrate nosetests to pytest - PR [#1142](https://github.com/datajoint/datajoint-python/pull/1142)
 - Added - Codespell GitHub Actions workflow

--- a/datajoint/diagram.py
+++ b/datajoint/diagram.py
@@ -289,7 +289,7 @@ else:
             )
             # relabel nodes to class names
             mapping = {
-                node: lookup_class_name(node, self.context) or node
+                node: f'"{lookup_class_name(node, self.context) or node}"'
                 for node in graph.nodes()
             }
             new_names = [mapping.values()]

--- a/tests_old/test_erd.py
+++ b/tests_old/test_erd.py
@@ -83,5 +83,5 @@ class TestERD:
         # https://github.com/datajoint/datajoint-python/issues/882
         erd = dj.Di(schema)
         graph = erd._make_graph()
-        assert "OutfitLaunch" in graph.nodes()
-        assert "OutfitLaunch.OutfitPiece" in graph.nodes()
+        assert '"OutfitLaunch"' in graph.nodes()
+        assert '"OutfitLaunch.OutfitPiece"' in graph.nodes()


### PR DESCRIPTION
Adds double quotes `"` needed to close #1175 and  closes #1169 and closes #1100 and closes #1072 closes #1065

Here is a truncated DOT string generated from this commit:
```
strict digraph  {
"ephys_element.QualityMetrics" [primary_key="{'insertion_number', 'paramset_idx', 'precluster_param_steps_id', 'recording_id', 'curation_id'}", distinguished=False, node_type=<class 'datajoint.user_tables.Imported'>, shape=ellipse, fontsize=12, fontcolor="#00007FA0", fontname=arial, fixedsize=false, width=0.48, height=0.48, label="ephys_element.QualityMetrics", color="#00007F40", style=filled];
}
```

Example working ERD after this fix
![example_erd](https://github.com/user-attachments/assets/06d1df37-2e8e-4bd0-87e2-270dde4c4582)

@dimitri-yatsenko  or @ethho 
Would either of you be able to get this merged fairly quickly? 

Versions:
networkx                  3.4rc0.dev0
pydot                     3.0.1

The latest dev version of networkx is required since there is [a patch](https://github.com/networkx/networkx/pull/7606) that removes a `:` check that arises if you use the latest version on `pip`. The expected `pip` release for this patch is September 27, 2024.

The error that occurs if you do not use the github version of the package `networkx`:

`ValueError: Node names and attributes should not contain ":" unless they are quoted with "".                    For example the string 'attribute:data1' should be written as '"attribute:data1"'.                    Please refer https://github.com/pydot/pydot/issues/258`