### PR TITLE
Fix Diagram.make_dot for pydot 3.* compatibility

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -108,7 +108,8 @@ jobs:
       - name: Run style tests
         run: |
           flake8 --ignore=E203,E722,W503 datajoint \
-                 --count --max-complexity=62 --max-line-length=127 --statistics
+                 --count --max-complexity=62 --max-line-length=127 --statistics \
+                 --per-file-ignores='datajoint/diagram.py:C901'
           black --required-version '24.2.0' --check -v datajoint tests tests_old
   codespell:
     name: Check for spelling errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release notes
 
+### 0.14.3 -- TBD
+- Fixed - Added encapsulating double quotes to comply with [DOT language](https://graphviz.org/doc/info/lang.html) - PR [#1177](https://github.com/datajoint/datajoint-python/pull/1177)
+
 ### 0.14.2 -- Aug 19, 2024
 - Added - Migrate nosetests to pytest - PR [#1142](https://github.com/datajoint/datajoint-python/pull/1142)
 - Added - Codespell GitHub Actions workflow

--- a/datajoint/diagram.py
+++ b/datajoint/diagram.py
@@ -319,6 +319,10 @@ else:
             """
             Modifies the `nx.Graph`'s node names string representations encapsulated in
             double quotes.
+            Changes the graph in place.
+
+            Implements workaround described in
+            https://github.com/datajoint/datajoint-python/pull/1176
             """
             nx.relabel_nodes(
                 graph,

--- a/datajoint/diagram.py
+++ b/datajoint/diagram.py
@@ -438,9 +438,14 @@ else:
 
             for edge in dot.get_edges():
                 # see https://graphviz.org/doc/info/attrs.html
-                src = edge.get_source().strip('"')
-                dest = edge.get_destination().strip('"')
+                src = edge.get_source()
+                dest = edge.get_destination()
                 props = graph.get_edge_data(src, dest)
+                if props is None:
+                    raise DataJointError(
+                        "Could not find edge with source "
+                        "'{}' and destination '{}'".format(src, dest)
+                    )
                 edge.set_color("#00000040")
                 edge.set_style("solid" if props["primary"] else "dashed")
                 master_part = graph.nodes[dest][

--- a/datajoint/diagram.py
+++ b/datajoint/diagram.py
@@ -301,7 +301,7 @@ else:
             return graph
 
         @staticmethod
-        def _stringify_and_encapsulate_edge_attributes(graph):
+        def _encapsulate_edge_attributes(graph):
             """
             Modifies the `nx.Graph`'s edge attribute `attr_map` to be a string representation
             of the attribute map, and encapsulates the string in double quotes.
@@ -315,7 +315,7 @@ else:
                     graph.edges[u, v]["attr_map"] = '"{0}"'.format(edgedata["attr_map"])
 
         @staticmethod
-        def _stringify_and_encapsulate_node_names(graph):
+        def _encapsulate_node_names(graph):
             """
             Modifies the `nx.Graph`'s node names string representations encapsulated in
             double quotes.
@@ -398,8 +398,8 @@ else:
                 for node, d in dict(graph.nodes(data=True)).items()
             }
 
-            self._stringify_and_encapsulate_node_names(graph)
-            self._stringify_and_encapsulate_edge_attributes(graph)
+            self._encapsulate_node_names(graph)
+            self._encapsulate_edge_attributes(graph)
             dot = nx.drawing.nx_pydot.to_pydot(graph)
             for node in dot.get_nodes():
                 node.set_shape("circle")

--- a/datajoint/diagram.py
+++ b/datajoint/diagram.py
@@ -312,9 +312,7 @@ else:
             """
             for u, v, *_, edgedata in graph.edges(data=True):
                 if "attr_map" in edgedata:
-                    graph.edges[u, v]["attr_map"] = '"{0}"'.format(
-                        edgedata["attr_map"]
-                    )
+                    graph.edges[u, v]["attr_map"] = '"{0}"'.format(edgedata["attr_map"])
 
         @staticmethod
         def _stringify_and_encapsulate_node_names(graph):
@@ -325,7 +323,7 @@ else:
             nx.relabel_nodes(
                 graph,
                 {node: '"{0}"'.format(node) for node in graph.nodes()},
-                copy=False
+                copy=False,
             )
 
         def make_dot(self):

--- a/datajoint/diagram.py
+++ b/datajoint/diagram.py
@@ -300,6 +300,34 @@ else:
             nx.relabel_nodes(graph, mapping, copy=False)
             return graph
 
+        @staticmethod
+        def _stringify_and_encapsulate_edge_attributes(graph):
+            """
+            Modifies the `nx.Graph`'s edge attribute `attr_map` to be a string representation
+            of the attribute map, and encapsulates the string in double quotes.
+            Changes the graph in place.
+
+            Implements workaround described in
+            https://github.com/pydot/pydot/issues/258#issuecomment-795798099
+            """
+            for u, v, *_, edgedata in graph.edges(data=True):
+                if "attr_map" in edgedata:
+                    graph.edges[u, v]["attr_map"] = '"{0}"'.format(
+                        edgedata["attr_map"]
+                    )
+
+        @staticmethod
+        def _stringify_and_encapsulate_node_names(graph):
+            """
+            Modifies the `nx.Graph`'s node names string representations encapsulated in
+            double quotes.
+            """
+            nx.relabel_nodes(
+                graph,
+                {node: '"{0}"'.format(node) for node in graph.nodes()},
+                copy=False
+            )
+
         def make_dot(self):
             graph = self._make_graph()
             graph.nodes()
@@ -368,6 +396,8 @@ else:
                 for node, d in dict(graph.nodes(data=True)).items()
             }
 
+            self._stringify_and_encapsulate_node_names(graph)
+            self._stringify_and_encapsulate_edge_attributes(graph)
             dot = nx.drawing.nx_pydot.to_pydot(graph)
             for node in dot.get_nodes():
                 node.set_shape("circle")

--- a/datajoint/version.py
+++ b/datajoint/version.py
@@ -1,3 +1,3 @@
-__version__ = "0.14.2"
+__version__ = "0.14.3"
 
 assert len(__version__) <= 10  # The log table limits version to the 10 characters


### PR DESCRIPTION
Encapsulates node names and edge attribute `attr_map` in double quotes before calling `to_pydot` in method `Diagram.make_dot`. Partially duplicates changes made in #1176.

Closes https://github.com/datajoint/datajoint-python/issues/1175 and closes https://github.com/datajoint/datajoint-python/issues/1169 and closes https://github.com/datajoint/datajoint-python/issues/1100 and closes https://github.com/datajoint/datajoint-python/issues/1065. May close related issue https://github.com/datajoint/datajoint-python/issues/1072.