### PR TITLE
fix(URL): broken routing and redirects on docs.datajoint.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ DataJoint (<https://datajoint.com>).
 
 - [Interactive Tutorials](https://github.com/datajoint/datajoint-tutorials) on GitHub Codespaces
 
-- [DataJoint Elements](https://docs.datajoint.com/elements/) - Catalog of example pipelines for neuroscience experiments
+- [DataJoint Elements](https://docs.datajoint.com/datajoint-docs/elements/) - Catalog of example pipelines for neuroscience experiments
 
 - Contribute
   - [Contribution Guidelines](https://docs.datajoint.com/about/contribute/)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ DataJoint (<https://datajoint.com>).
      pip install datajoint
      ```
 
-- [Documentation & Tutorials](https://docs.datajoint.com/core/datajoint-python/)
+- [Documentation & Tutorials](https://docs.datajoint.com/datajoint-python/)
 
 - [Interactive Tutorials](https://github.com/datajoint/datajoint-tutorials) on GitHub Codespaces
 
@@ -140,4 +140,4 @@ DataJoint (<https://datajoint.com>).
 - Contribute
   - [Contribution Guidelines](https://docs.datajoint.com/about/contribute/)
 
-  - [Developer Guide](https://docs.datajoint.com/core/datajoint-python/latest/develop/)
+  - [Developer Guide](https://docs.datajoint.com/datajoint-python/latest/develop/) 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,6 @@ DataJoint (<https://datajoint.com>).
 - [DataJoint Elements](https://docs.datajoint.com/datajoint-docs/elements/) - Catalog of example pipelines for neuroscience experiments
 
 - Contribute
-  - [Contribution Guidelines](https://docs.datajoint.com/about/contribute/)
+  - [Contribution Guidelines](https://docs.datajoint.com/datajoint-docs/about/contribute/)
 
   - [Developer Guide](https://docs.datajoint.com/datajoint-python/latest/develop/) 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Contribute to DataJoint Documentation
 
-This is the home for DataJoint software documentation as hosted at https://docs.datajoint.com/core/datajoint-python/latest/.
+This is the home for DataJoint software documentation as hosted at https://docs.datajoint.com/datajoint-python/latest/.
 
 ## VSCode Linter Extensions and Settings
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -41,4 +41,4 @@ Presently, the primary developer of DataJoint open-source software is the compan
 - Contribute
   - [Development Environment](./develop)
 
-  - [Guidelines](https://docs.datajoint.com/about/contribute/)
+  - [Guidelines](https://docs.datajoint.com/datajoint-docs/about/contribute/)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,7 +36,7 @@ Presently, the primary developer of DataJoint open-source software is the compan
 
 - [Interactive Tutorials](https://github.com/datajoint/datajoint-tutorials){:target="_blank"} on GitHub Codespaces
 
-- [DataJoint Elements](https://docs.datajoint.com/elements/) - Catalog of example pipelines for neuroscience experiments
+- [DataJoint Elements](https://docs.datajoint.com/datajoint-docs/elements/) - Catalog of example pipelines for neuroscience experiments
 
 - Contribute
   - [Development Environment](./develop)

--- a/docs/src/query/operators.md
+++ b/docs/src/query/operators.md
@@ -392,4 +392,4 @@ dj.U().aggr(Session, n="max(session)") # (3)
 
 `dj.U()`, as shown in the last example above, is often useful for integer IDs.
 For an example of this process, see the source code for
-[Element Array Electrophysiology's `insert_new_params`](https://docs.datajoint.com/elements/element-array-ephys/latest/api/element_array_ephys/ephys_acute/#element_array_ephys.ephys_acute.ClusteringParamSet.insert_new_params).
+[Element Array Electrophysiology's `insert_new_params`](https://docs.datajoint.com/datajoint-docs/elements/element-array-ephys/latest/api/element_array_ephys/ephys_acute/#element_array_ephys.ephys_acute.ClusteringParamSet.insert_new_params).

--- a/docs/src/tutorials/dj-top.ipynb
+++ b/docs/src/tutorials/dj-top.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First you will need to [install](../../getting-started/#installation) and [connect](../../getting-started/#connection) to a DataJoint [data pipeline](https://docs.datajoint.com/core/datajoint-python/latest/concepts/data-pipelines/#what-is-a-data-pipeline).\n",
+    "First you will need to [install](../../getting-started/#installation) and [connect](../../getting-started/#connection) to a DataJoint [data pipeline](https://docs.datajoint.com/datajoint-python/latest/concepts/data-pipelines/#what-is-a-data-pipeline).\n",
     "\n",
     "Now let's start by importing the `datajoint` client."
    ]

--- a/docs/src/tutorials/json.ipynb
+++ b/docs/src/tutorials/json.ipynb
@@ -27,7 +27,7 @@
    "id": "67cf93d2",
    "metadata": {},
    "source": [
-    "First you will need to [install](../../getting-started/#installation) and [connect](../../getting-started/#connection) to a DataJoint [data pipeline](https://docs.datajoint.com/core/datajoint-python/latest/concepts/data-pipelines/#what-is-a-data-pipeline).\n",
+    "First you will need to [install](../../getting-started/#installation) and [connect](../../getting-started/#connection) to a DataJoint [data pipeline](https://docs.datajoint.com/datajoint-python/latest/concepts/data-pipelines/#what-is-a-data-pipeline).\n",
     "\n",
     "Now let's start by importing the `datajoint` client."
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ maintainers = [
   {name = "Dimitri Yatsenko", email = "dimitri@datajoint.com"},
   {name = "DataJoint Contributors", email = "support@datajoint.com"},
 ]
-# manually sync here: https://docs.datajoint.com/core/datajoint-python/latest/#welcome-to-datajoint-for-python
+# manually sync here: https://docs.datajoint.com/datajoint-python/latest/#welcome-to-datajoint-for-python
 description = "DataJoint for Python is a framework for scientific workflow management based on relational principles. DataJoint is built on the foundation of the relational data model and prescribes a consistent method for organizing, populating, computing, and querying data."
 readme = "README.md"
 license = {file = "LICENSE.txt"}


### PR DESCRIPTION
This PR updates proposed URLs. **Note**: new links aren't functional yet, please consider before merging.

- [x] `https://docs.datajoint.com/core/datajoint-python/latest` ==> removes core --> `https://docs.datajoint.com/datajoint-python/latest/` (5 updates in [fix(URL): remove core in docs.datajoint.com/core/datajoint-python](https://github.com/datajoint/datajoint-python/commit/7a0fe5aff8a59277d1e12e72d27dd8373e7f53b0)) 
- [x]  `https://docs.datajoint.com/elements`  ==> inserts `datajoint-docs` --> `https://docs.datajoint.com/datajoint-docs/elements/` (3 updates in [fix(URL): add datajoint-docs before elements](https://github.com/datajoint/datajoint-python/pull/1238/commits/b42c3051db1fa853f9180a3b115f81a67ed62763))
- [x]   `https://docs.datajoint.com/support-events`  ==> inserts `datajoint-docs` --> `https://docs.datajoint.com/datajoint-docs/support-events` (no updates to be done)
- [x] `https://docs.datajoint.com/additional-resources`  ==> inserts `datajoint-docs` --> `https://docs.datajoint.com/datajoint-docs/additional-resources` (no updates to be done)
- [x] `https://docs.datajoint.com/projects`  ==> inserts `datajoint-docs` --> `https://docs.datajoint.com/datajoint-docs/projects` (no updates to be done)
- [x] `https://docs.datajoint.com/partnerships/dandi`  ==> inserts `datajoint-docs` --> `https://docs.datajoint.com/datajoint-docs/partnerships/dandi` (no updates to be done)
- [x] `https://docs.datajoint.com/partnerships/facemap`  ==> inserts `datajoint-docs` --> `https://docs.datajoint.com/datajoint-docs/partnerships/facemap`(no updates to be done)
- [x] `https://docs.datajoint.com/partnerships/incf`  ==> inserts `datajoint-docs` --> `https://docs.datajoint.com/datajoint-docs/partnerships/incf` (no updates to be done)
 - [x] `https://docs.datajoint.com/partnerships/nwb`  ==> inserts `datajoint-docs` --> `https://docs.datajoint.com/datajoint-docs/partnerships/nwb` (no updates to be done)
 - [x] `https://docs.datajoint.com/partnerships/openephysgui`  ==> inserts `datajoint-docs` --> `https://docs.datajoint.com/datajoint-docs/partnerships/openephysgui` (no updates to be done)
 - [x] `https://docs.datajoint.com/partnerships/suite2p`  ==> inserts `datajoint-docs` --> `https://docs.datajoint.com/datajoint-docs/partnerships/suite2p`(no updates to be done)
 - [x] `https://docs.datajoint.com/about/citation/`  ==> inserts `datajoint-docs` --> `https://docs.datajoint.com/datajoint-docs/about/citation/` (no updates to be done)
 - [x] `https://docs.datajoint.com/about/contribute/`  ==> inserts `datajoint-docs` --> `https://docs.datajoint.com/datajoint-docs/about/contribute/` (2 updates in [fix(URL): add datajoint-docs before contribute](https://github.com/datajoint/datajoint-python/pull/1238/commits/9781d6e47348175925027298bb4ed5bcbc6498a2))



