### PR TITLE
refactor: Removed deprecation by switching to importlib.metadata

### DIFF
--- a/datajoint/condition.py
+++ b/datajoint/condition.py
@@ -1,4 +1,4 @@
-""" methods for generating SQL WHERE clauses from datajoint restriction conditions """
+"""methods for generating SQL WHERE clauses from datajoint restriction conditions"""
 
 import collections
 import datetime

--- a/datajoint/plugin.py
+++ b/datajoint/plugin.py
@@ -1,7 +1,7 @@
 import logging
+from importlib.metadata import distribution, entry_points
 from pathlib import Path
 
-import pkg_resources
 from cryptography.exceptions import InvalidSignature
 from otumat import hash_pkg, verify
 
@@ -13,12 +13,18 @@ logger = logging.getLogger(__name__.split(".")[0])
 def _update_error_stack(plugin_name):
     try:
         base_name = "datajoint"
-        base_meta = pkg_resources.get_distribution(base_name)
-        plugin_meta = pkg_resources.get_distribution(plugin_name)
+        base_meta = distribution(base_name)
+        plugin_meta = distribution(plugin_name)
 
-        data = hash_pkg(pkgpath=str(Path(plugin_meta.module_path, plugin_name)))
-        signature = plugin_meta.get_metadata(f"{plugin_name}.sig")
-        pubkey_path = str(Path(base_meta.egg_info, f"{base_name}.pub"))
+        # Get the package location - equivalent to module_path
+        plugin_location = plugin_meta.locate_file("")
+        data = hash_pkg(pkgpath=str(Path(plugin_location.parent, plugin_name)))
+
+        # Get signature metadata - equivalent to get_metadata()
+        signature = plugin_meta.read_text(f"{plugin_name}.sig")
+
+        # Get public key path - equivalent to egg_info
+        pubkey_path = str(Path(base_meta.locate_file("").parent, f"{base_name}.pub"))
         verify(pubkey_path=pubkey_path, data=data, signature=signature)
         logger.info(f"DataJoint verified plugin `{plugin_name}` detected.")
         return True
@@ -28,17 +34,25 @@ def _update_error_stack(plugin_name):
 
 
 def _import_plugins(category):
+    # Get entry points for the group - equivalent to iter_entry_points()
+    group_name = f"datajoint_plugins.{category}"
+    eps = entry_points()
+
+    # Handle both Python 3.9 and 3.10+ entry points API
+    if hasattr(eps, "select"):
+        group_eps = eps.select(group=group_name)
+    else:
+        group_eps = eps.get(group_name, [])
+
     return {
         entry_point.name: dict(
             object=entry_point,
-            verified=_update_error_stack(entry_point.module_name.split(".")[0]),
+            verified=_update_error_stack(entry_point.module.split(".")[0]),
         )
-        for entry_point in pkg_resources.iter_entry_points(
-            "datajoint_plugins.{}".format(category)
-        )
+        for entry_point in group_eps
         if "plugin" not in config
         or category not in config["plugin"]
-        or entry_point.module_name.split(".")[0] in config["plugin"][category]
+        or entry_point.module.split(".")[0] in config["plugin"][category]
     }
 
 

--- a/datajoint/preview.py
+++ b/datajoint/preview.py
@@ -1,4 +1,4 @@
-""" methods for generating previews of query expression results in python command line and Jupyter """
+"""methods for generating previews of query expression results in python command line and Jupyter"""
 
 from .settings import config
 

--- a/docs/src/design/tables/indexes.md
+++ b/docs/src/design/tables/indexes.md
@@ -35,7 +35,7 @@ To make searches faster on fields other than the primary key or a foreign key, y
 add a secondary index explicitly.
 
 Regular indexes are declared as `index(attr1, ..., attrN)` on a separate line anywhere in
-the table declration (below the primary key divide).
+the table declaration (below the primary key divide).
 
 Indexes can be declared with unique constraint as `unique index (attr1, ..., attrN)`.
 
@@ -62,7 +62,7 @@ Let’s now imagine that rats in a lab are identified by the combination of `lab
 @schema
 class Rat(dj.Manual):
     definition = """
-    lab_name : char(16) 
+    lab_name : char(16)
     rat_id : int unsigned # lab-specific ID
     ---
     date_of_birth = null : date
@@ -86,7 +86,7 @@ To speed up searches by the `rat_id` and `date_of_birth`, we can explicit indexe
 @schema
 class Rat2(dj.Manual):
     definition = """
-    lab_name : char(16) 
+    lab_name : char(16)
     rat_id : int unsigned # lab-specific ID
     ---
     date_of_birth = null : date

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,6 +1,6 @@
+from importlib.metadata import distribution
 from os import path
 
-import pkg_resources
 import pytest
 
 import datajoint.errors as djerr
@@ -10,8 +10,8 @@ import datajoint.plugin as p
 @pytest.mark.skip(reason="marked for deprecation")
 def test_check_pubkey():
     base_name = "datajoint"
-    base_meta = pkg_resources.get_distribution(base_name)
-    pubkey_meta = base_meta.get_metadata("{}.pub".format(base_name))
+    base_dist = distribution(base_name)
+    pubkey_meta = base_dist.read_text("{}.pub".format(base_name))
 
     with open(
         path.join(path.abspath(path.dirname(__file__)), "..", "datajoint.pub"), "r"


### PR DESCRIPTION
While the larger overhaul of the plugin architecture is being considered (#1251, this is a small fix to move away from `pkg_resources` and use `importlib.metadata`.

Nothing else has changed as this is solely to remove the deprecation warning when importing datajoint.

Edit: I tested it for Python 3.9 to 3.12 by doing
```zsh
for version in 3.9 3.10 3.11 3.12; do
  uv run --python $version python -c 'import datajoint as dj; print(dj.__file__); print("Datajoint import successful")'; done
```
