### PR TITLE
bump python version in docker compose to ensure that tests pass

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        PY_VER: ${PY_VER:-3.8}
+        PY_VER: ${PY_VER:-3.9}
         HOST_UID: ${HOST_UID:-1000}
     depends_on:
       db:


### PR DESCRIPTION
the python version declared in the top-level `docker-compose.yaml` file (3.8) is inconsistent with the minimum python version declared in `pyproject.toml` (3.9). 

This PR updates the `docker-compose.yaml` file.

@dimitri-yatsenko I'm opening this PR against `master`, lmk if there's a better branch for this fix.