### PR TITLE
tests: fix expected ordering in relational_operand (#1205)

### DIFF
--- a/tests/test_relational_operand.py
+++ b/tests/test_relational_operand.py
@@ -630,8 +630,8 @@ class TestDjTop:
         ]
         assert key.fetch(as_dict=True) == [
             {"id": 2, "key": 6},
-            {"id": 2, "key": 5},
             {"id": 1, "key": 5},
+            {"id": 2, "key": 5},
             {"id": 0, "key": 4},
             {"id": 1, "key": 4},
             {"id": 2, "key": 4},


### PR DESCRIPTION
Fixes #1205

Adjusts the expected row ordering in test_top_restriction_with_keywords.
The failure was caused by nondeterministic fetch ordering, not library behavior.