### PR TITLE
fix: Aggregation and Union __bool__ always returning True

### DIFF
--- a/src/datajoint/expression.py
+++ b/src/datajoint/expression.py
@@ -728,7 +728,7 @@ class QueryExpression:
         try:
             import polars
         except ImportError:
-            raise ImportError("polars is required for to_polars(). " "Install with: pip install datajoint[polars]")
+            raise ImportError("polars is required for to_polars(). Install with: pip install datajoint[polars]")
         dicts = self.to_dicts(order_by=order_by, limit=limit, offset=offset, squeeze=squeeze)
         return polars.DataFrame(dicts)
 
@@ -747,7 +747,7 @@ class QueryExpression:
         try:
             import pyarrow
         except ImportError:
-            raise ImportError("pyarrow is required for to_arrow(). " "Install with: pip install datajoint[arrow]")
+            raise ImportError("pyarrow is required for to_arrow(). Install with: pip install datajoint[arrow]")
         dicts = self.to_dicts(order_by=order_by, limit=limit, offset=offset, squeeze=squeeze)
         if not dicts:
             return pyarrow.table({})
@@ -1039,7 +1039,7 @@ class Aggregation(QueryExpression):
         ).fetchone()[0]
 
     def __bool__(self):
-        return bool(self.connection.query("SELECT EXISTS({sql})".format(sql=self.make_sql())))
+        return bool(self.connection.query("SELECT EXISTS({sql})".format(sql=self.make_sql())).fetchone()[0])
 
 
 class Union(QueryExpression):
@@ -1101,7 +1101,7 @@ class Union(QueryExpression):
         ).fetchone()[0]
 
     def __bool__(self):
-        return bool(self.connection.query("SELECT EXISTS({sql})".format(sql=self.make_sql())))
+        return bool(self.connection.query("SELECT EXISTS({sql})".format(sql=self.make_sql())).fetchone()[0])
 
 
 class U:


### PR DESCRIPTION
## Summary

Fixes the `__bool__` method for `Aggregation` and `Union` classes which always returned `True` regardless of whether the query result was empty.

## Problem

The `__bool__` methods were missing `.fetchone()[0]`:

```python
# Buggy code
def __bool__(self):
    return bool(self.connection.query("SELECT EXISTS({sql})".format(sql=self.make_sql())))
```

`self.connection.query()` returns a cursor object, and `bool(cursor)` is always `True` because the cursor object itself is truthy. The actual query result (0 or 1) was never fetched.

## Fix

```python
# Fixed code
def __bool__(self):
    return bool(
        self.connection.query(
            "SELECT EXISTS({sql})".format(sql=self.make_sql())
        ).fetchone()[0]
    )
```

## Test

```python
has_entry = A & "a_id=1"
no_entry = A & "a_id=3"

aggr_has_entry = has_entry.aggr(B, b_id="COUNT(b_id)")
aggr_no_entry = no_entry.aggr(B, b_id="COUNT(b_id)")

# Before fix: both True
# After fix: True, False (correct)
bool(aggr_has_entry)  # True
bool(aggr_no_entry)   # False
```

## Closes

- #1234

🤖 Generated with [Claude Code](https://claude.com/claude-code)