### PR TITLE
fix: add dark mode support for table previews in Jupyter

### DIFF
--- a/src/datajoint/preview.py
+++ b/src/datajoint/preview.py
@@ -164,6 +164,34 @@ def repr_html(query_expression):
         .djtooltip:hover .djtooltiptext {
             visibility: visible;
         }
+
+        /* Dark mode support */
+        @media (prefers-color-scheme: dark) {
+            .Table th{
+                background: #4a4a4a; color: #ffffff; border:#555555 1px solid;
+            }
+            .Table td{
+                border:#555555 1px solid;
+            }
+            .Table tr:nth-child(odd){
+                background: #2d2d2d;
+                color: #e0e0e0;
+            }
+            .Table tr:nth-child(even){
+                background: #3d3d3d;
+                color: #e0e0e0;
+            }
+            .djtooltip .djtooltiptext {
+                background-color: #555555;
+                color: #ffffff;
+            }
+            #primary {
+                color: #bd93f9;
+            }
+            #nonprimary {
+                color: #e0e0e0;
+            }
+        }
     </style>
     """
     head_template = """<div class="djtooltip">


### PR DESCRIPTION
## Summary

Adds automatic dark mode support for DataJoint table previews in Jupyter Lab/Notebook using CSS `prefers-color-scheme` media query.

## Problem

Table previews were unreadable in Jupyter Lab dark mode because CSS was hardcoded for light themes (black text on white background).

**Before (dark mode):**

![black on black](https://github.com/user-attachments/assets/eeb5ca34-d2ea-43dd-9de0-b2a6129f2787)

## Solution

Added CSS media query that automatically detects dark mode preference:

```css
@media (prefers-color-scheme: dark) {
    .Table tr:nth-child(odd) {
        background: #2d2d2d;
        color: #e0e0e0;
    }
    /* ... */
}
```

### Dark mode colors:
| Element | Background | Text |
|---------|------------|------|
| Table header | #4a4a4a | #ffffff |
| Odd rows | #2d2d2d | #e0e0e0 |
| Even rows | #3d3d3d | #e0e0e0 |
| Primary key | - | #bd93f9 (purple) |
| Borders | #555555 | - |

## Benefits

- **No JavaScript required** - uses native CSS media query
- **Automatic detection** - follows system/browser dark mode setting
- **No config changes** - works out of the box
- **Backward compatible** - light mode unchanged

## Closes

- #1167

🤖 Generated with [Claude Code](https://claude.com/claude-code)