### PR TITLE
fix: return 0 from delete() when user cancels operation

### DIFF
--- a/src/datajoint/table.py
+++ b/src/datajoint/table.py
@@ -977,6 +977,7 @@ class Table(QueryExpression):
                     self.connection.cancel_transaction()
                 if prompt:
                     logger.warning("Delete cancelled")
+                delete_count = 0  # Reset count when delete is cancelled
         return delete_count
 
     def drop_quick(self):


### PR DESCRIPTION
## Summary

Fixes `delete()` to return 0 when the user cancels the operation at the prompt.

## Problem

When a user answered "no" to "Commit deletes?", the transaction was correctly rolled back, but `delete()` still returned the count of rows that *would have been* deleted.

```python
>>> result = MyTable().delete()
Deleting 5 rows from `schema`.`my_table`
Commit deletes? [yes, No]: no
Delete cancelled
>>> print(result)
5  # Should be 0!
```

## Fix

Reset `delete_count` to 0 when the delete is cancelled:

```python
else:
    if transaction:
        self.connection.cancel_transaction()
    if prompt:
        logger.warning("Delete cancelled")
    delete_count = 0  # Added this line
return delete_count
```

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Delete committed | N (correct) | N (unchanged) |
| Delete cancelled | N (wrong) | 0 (fixed) |
| Nothing to delete | 0 (correct) | 0 (unchanged) |

## Closes

- #1155

🤖 Generated with [Claude Code](https://claude.com/claude-code)