### PR TITLE
fix: handle TypeError in lookup_class_name for Diagram

### DIFF
--- a/src/datajoint/table.py
+++ b/src/datajoint/table.py
@@ -1306,8 +1306,8 @@ def lookup_class_name(name, context, depth=3):
                                 depth=node["depth"] - 1,
                             )
                         )
-                    except ImportError:
-                        pass  # could not import, so do not attempt
+                    except (ImportError, TypeError):
+                        pass  # could not inspect module members, skip
     return None
 
 


### PR DESCRIPTION
## Summary

Fixes intermittent `TypeError` when generating diagrams with `dj.Diagram(schema)`.

## Problem

`dj.Diagram(schema)` could fail with:
```
TypeError: '_ClassNamespace' object is not iterable
```

This occurred when `inspect.getmembers()` encountered modules containing objects with non-standard `__bases__` attributes (like `_ClassNamespace` from typing internals).

## Root Cause

In `lookup_class_name()`, only `ImportError` was caught:

```python
try:
    nodes.append(dict(context=dict(inspect.getmembers(member)), ...))
except ImportError:  # TypeError not caught!
    pass
```

## Fix

Catch `TypeError` in addition to `ImportError`:

```python
except (ImportError, TypeError):
    pass  # could not inspect module members, skip
```

## Impact

- **No behavior change** for working cases
- **Fixes edge cases** where unusual modules (typing, metaclasses) are in context
- **Defensive fix** - just skips problematic modules and continues search

## Closes

- #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)