### PR TITLE
refactor: remove text from core types, keep as native passthrough

### DIFF
--- a/docs/src/archive/design/tables/attributes.md
+++ b/docs/src/archive/design/tables/attributes.md
@@ -34,9 +34,11 @@ Use these portable, scientist-friendly types for cross-database compatibility.
 
 -  `char(n)`: fixed-length string of exactly *n* characters.
 -  `varchar(n)`: variable-length string up to *n* characters.
--  `text`: unlimited-length text for long-form content (notes, descriptions, abstracts).
 -  `enum(...)`: one of several enumerated values, e.g., `enum("low", "medium", "high")`.
    Do not use enums in primary keys due to difficulty changing definitions.
+
+> **Note:** For unlimited text, use `varchar` with a generous limit, `json` for structured content,
+> or `<object>` for large text files. Native SQL `text` types are supported but not portable.
 
 **Encoding policy:** All strings use UTF-8 encoding (`utf8mb4` in MySQL, `UTF8` in PostgreSQL).
 Character encoding and collation are database-level configuration, not part of type definitions.

--- a/docs/src/archive/design/tables/storage-types-spec.md
+++ b/docs/src/archive/design/tables/storage-types-spec.md
@@ -75,7 +75,9 @@ MySQL and PostgreSQL backends. Users should prefer these over native database ty
 |-----------|-------------|-------|------------|
 | `char(n)` | Fixed-length | `CHAR(n)` | `CHAR(n)` |
 | `varchar(n)` | Variable-length | `VARCHAR(n)` | `VARCHAR(n)` |
-| `text` | Unlimited text | `TEXT` | `TEXT` |
+
+> **Note:** Native SQL `text` types (`text`, `tinytext`, `mediumtext`, `longtext`) are supported
+> but not portable. Prefer `varchar(n)`, `json`, or `<object>` for portable schemas.
 
 **Encoding:** All strings use UTF-8 (`utf8mb4` in MySQL, `UTF8` in PostgreSQL).
 See [Encoding and Collation Policy](#encoding-and-collation-policy) for details.

--- a/src/datajoint/declare.py
+++ b/src/datajoint/declare.py
@@ -45,8 +45,6 @@ CORE_TYPES = {
     # String types (with parameters)
     "char": (r"char\s*\(\d+\)$", None),
     "varchar": (r"varchar\s*\(\d+\)$", None),
-    # Unlimited text
-    "text": (r"text$", None),
     # Enumeration
     "enum": (r"enum\s*\(.+\)$", None),
     # Fixed-point decimal
@@ -78,7 +76,7 @@ TYPE_PATTERN = {
         STRING=r"(var)?char\s*\(.+\)$",  # Catches char/varchar not matched by core types
         TEMPORAL=r"(time|timestamp|year)(\s*\(.+\))?$",  # time, timestamp, year (not date/datetime)
         NATIVE_BLOB=r"(tiny|small|medium|long)blob$",  # Specific blob variants
-        NATIVE_TEXT=r"(tiny|small|medium|long)text$",  # Text variants (use plain 'text' instead)
+        NATIVE_TEXT=r"(tiny|small|medium|long)?text$",  # Native text types (not portable)
         # Codecs use angle brackets
         CODEC=r"<.+>$",
     ).items()


### PR DESCRIPTION
## Summary

Removes `text` from core DataJoint types. It remains available as a native SQL passthrough type (with portability warning).

## Rationale

Core types should encourage structured, bounded data:

| Need | Better Alternative |
|------|-------------------|
| Bounded strings | `varchar(n)` with explicit limit |
| Structured text | `json` |
| Large text files | `<object>` |
| Notes/descriptions | `varchar(4000)` typically sufficient |

Problems with `text` as a core type:
- No size constraint = unpredictable storage
- Behavior varies across MySQL/PostgreSQL
- Encourages dumping unstructured data
- Hurts query performance with unbounded fields

## Changes

**declare.py:**
- Remove `text` from `CORE_TYPES`
- Update `NATIVE_TEXT` pattern: `r"(tiny|small|medium|long)?text$"` (now includes plain `text`)

**Documentation:**
- Update archive docs to note text is native-only
- Add guidance on alternatives (varchar, json, object)

## Migration

Users who need text can:
```python
# Option 1: Bounded varchar (preferred)
notes : varchar(4000)

# Option 2: JSON for structured content  
config : json

# Option 3: Object storage for large text
document : <object>

# Option 4: Native text (with warning)
description : text  # Works but shows portability warning
```

## Related

- #1194 (TEXT MySQL type request) - Addressed by keeping text as native passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)