### PR TITLE
fix: translate MySQL error 3730 to IntegrityError

### DIFF
--- a/src/datajoint/connection.py
+++ b/src/datajoint/connection.py
@@ -66,7 +66,11 @@ def translate_query_error(client_error: Exception, query: str) -> Exception:
         # Integrity errors
         case 1062:
             return errors.DuplicateError(*args)
-        case 1217 | 1451 | 1452:
+        case 1217 | 1451 | 1452 | 3730:
+            # 1217: Cannot delete parent row (FK constraint)
+            # 1451: Cannot delete/update parent row (FK constraint)
+            # 1452: Cannot add/update child row (FK constraint)
+            # 3730: Cannot drop table referenced by FK constraint
             return errors.IntegrityError(*args)
 
         # Syntax errors


### PR DESCRIPTION
## Summary

Translates MySQL error 3730 ("Cannot drop table referenced by foreign key constraint") to `datajoint.errors.IntegrityError` instead of letting it pass through as a raw `pymysql.err.OperationalError`.

## Problem

When dropping a schema or table referenced by foreign keys:

```python
dj.schema('prefix_abc').drop()
# Before: pymysql.err.OperationalError: (3730, "Cannot drop table '#a_b_c' referenced by...")
```

This raw error is:
- Hard to parse for users unfamiliar with MySQL internals
- Inconsistent with other FK errors which are already translated
- Would break external code if pymysql is replaced with another connector

## Fix

Add error code 3730 to the existing IntegrityError mapping in `translate_query_error()`:

```python
case 1217 | 1451 | 1452 | 3730:
    # 1217: Cannot delete parent row (FK constraint)
    # 1451: Cannot delete/update parent row (FK constraint)
    # 1452: Cannot add/update child row (FK constraint)
    # 3730: Cannot drop table referenced by FK constraint
    return errors.IntegrityError(*args)
```

## Result

```python
dj.schema('prefix_abc').drop()
# After: datajoint.errors.IntegrityError: Cannot drop table '#a_b_c' referenced by...
```

Users can now catch this with `except dj.errors.IntegrityError`.

## Closes

- #1032

🤖 Generated with [Claude Code](https://claude.com/claude-code)