### PR TITLE
docs: Fix PostgreSQL string quoting in docstring

### DIFF
--- a/src/datajoint/schemas.py
+++ b/src/datajoint/schemas.py
@@ -899,7 +899,7 @@ def virtual_schema(
     --------
     >>> lab = dj.virtual_schema('my_lab')
     >>> lab.Subject.fetch()
-    >>> lab.Session & 'subject_id="M001"'
+    >>> lab.Session & "subject_id='M001'"
 
     See Also
     --------


### PR DESCRIPTION
## Summary

Fix the `virtual_schema()` docstring example to use PostgreSQL-compatible string quoting.

## Changes

Changed:
```python
>>> lab.Session & 'subject_id="M001"'
```

To:
```python
>>> lab.Session & "subject_id='M001'"
```

PostgreSQL interprets double quotes as identifier references, not string literals. Single quotes must be used for string values in SQL restrictions.

## Related

- datajoint/datajoint-docs#137 (documentation SQL quoting fixes)

---

🤖 Generated with [Claude Code](https://claude.ai/code)