### PR TITLE
fix: Pass make_kwargs to make_fetch in tripartite pattern

### DIFF
--- a/datajoint/autopopulate.py
+++ b/datajoint/autopopulate.py
@@ -93,7 +93,7 @@ class AutoPopulate:
                 self._key_source *= _rename_attributes(*q)
         return self._key_source
 
-    def make(self, key):
+    def make(self, key, **kwargs):
         """
         This method must be implemented by derived classes to perform automated computation.
         The method must implement the following three steps:
@@ -136,6 +136,8 @@ class AutoPopulate:
         DataJoint may programmatically enforce this separation in the future.
 
         :param key: The primary key value used to restrict the data fetching.
+        :param kwargs: Keyword arguments passed from populate(make_kwargs=...).
+            These are passed to make_fetch for the tripartite pattern.
         :raises NotImplementedError: If the derived class does not implement the required methods.
         """
 
@@ -153,7 +155,7 @@ class AutoPopulate:
         # User has implemented `_fetch`, `_compute`, and `_insert` methods instead
 
         # Step 1: Fetch data from parent tables
-        fetched_data = self.make_fetch(key)  # fetched_data is a tuple
+        fetched_data = self.make_fetch(key, **kwargs)  # fetched_data is a tuple
         computed_result = yield fetched_data  # passed as input into make_compute
 
         # Step 2: If computed result is not passed in, compute the result


### PR DESCRIPTION
## Summary
- Fix `make_kwargs` not being passed to `make_fetch` when using the tripartite (generator) pattern

## Problem
When using generator-based `make` with `make_fetch`, `make_compute`, and `make_insert`, the `make_kwargs` parameter passed to `populate()` was not forwarded to `make_fetch()`. This caused a `TypeError` when users tried to pass keyword arguments to their tripartite make implementation.

## Solution
- Updated `make(self, key)` to `make(self, key, **kwargs)`
- Forward `**kwargs` to `self.make_fetch(key, **kwargs)`

Fixes #1350

🤖 Generated with [Claude Code](https://claude.ai/code)