### PR TITLE
perf: Add composite index on jobs table for efficient job fetching

### DIFF
--- a/src/datajoint/jobs.py
+++ b/src/datajoint/jobs.py
@@ -168,6 +168,7 @@ class Job(Table):
     pid=0           : int32
     connection_id=0 : int64
     version=""      : varchar(64)
+    INDEX (status, priority, scheduled_time)
     """
 
     def _get_fk_derived_pk_attrs(self) -> list[tuple[str, str]]:


### PR DESCRIPTION
## Summary

Add a composite index to the jobs table to optimize the critical job fetching query used during `populate(reserve_jobs=True)`.

## Problem

When populating with job reservation, the following query runs frequently:

```sql
SELECT ... FROM jobs
WHERE status='pending' AND scheduled_time <= NOW()
ORDER BY priority ASC, scheduled_time ASC
LIMIT N
```

Without an index, this requires a full table scan and filesort, which becomes slow with large job queues (thousands of jobs).

## Solution

Add a composite index that covers both the WHERE clause and ORDER BY:

```sql
INDEX (status, priority, scheduled_time)
```

This enables:
- Index range scan on `status='pending'`
- Filtering on `scheduled_time` within the index
- Index-ordered retrieval by `priority, scheduled_time` (no filesort needed)

## Testing

- All `test_jobs.py` tests pass
- Verified index creation in MySQL with `SHOW INDEX`

🤖 Generated with [Claude Code](https://claude.ai/code)