### PR TITLE
fix: fetch('column') returns array instead of list of dicts

### DIFF
--- a/src/datajoint/expression.py
+++ b/src/datajoint/expression.py
@@ -639,11 +639,12 @@ class QueryExpression:
 
         # Handle specific attributes requested
         if attrs:
-            if as_dict or as_dict is None:
-                # fetch('col1', 'col2', as_dict=True) or fetch('col1', 'col2')
+            if as_dict is True:
+                # fetch('col1', 'col2', as_dict=True) -> list of dicts
                 return self.proj(*attrs).to_dicts(order_by=order_by, limit=limit, offset=offset, squeeze=squeeze)
             else:
-                # fetch('col1', 'col2', as_dict=False) -> tuple of arrays
+                # fetch('col1', 'col2') or fetch('col1', 'col2', as_dict=False) -> tuple of arrays
+                # This matches DJ 1.x behavior where fetch('col') returns array(['alpha', 'beta'])
                 return self.to_arrays(*attrs, order_by=order_by, limit=limit, offset=offset, squeeze=squeeze)
 
         # Handle as_dict=True -> to_dicts()

--- a/tests/unit/test_fetch_compat.py
+++ b/tests/unit/test_fetch_compat.py
@@ -53,11 +53,22 @@ class TestFetchBackwardCompat:
 
         mock_expression.to_dicts.assert_called_once_with(order_by=None, limit=None, offset=None, squeeze=False)
 
-    def test_fetch_with_attrs_returns_dicts(self, mock_expression):
-        """fetch('col1', 'col2') should call proj().to_dicts()."""
+    def test_fetch_with_attrs_returns_arrays(self, mock_expression):
+        """fetch('col1', 'col2') should call to_arrays() - matches DJ 1.x behavior."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             mock_expression.fetch("col1", "col2")
+
+        # DJ 1.x: fetch('col') returns array(['alpha', 'beta']), not list of dicts
+        mock_expression.to_arrays.assert_called_once_with(
+            "col1", "col2", order_by=None, limit=None, offset=None, squeeze=False
+        )
+
+    def test_fetch_with_attrs_as_dict_true(self, mock_expression):
+        """fetch('col1', 'col2', as_dict=True) should call proj().to_dicts()."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            mock_expression.fetch("col1", "col2", as_dict=True)
 
         mock_expression.proj.assert_called_once_with("col1", "col2")
         mock_expression.to_dicts.assert_called_once()


### PR DESCRIPTION
## Summary

Fix `fetch('column')` to return an array like DJ 1.x, not a list of dicts.

## Problem

```python
# DJ 1.x behavior (expected):
names = Table().fetch("name")  # array(['alpha', 'beta'])
"alpha" in names  # True

# DJ 2.0 broken behavior:
names = Table().fetch("name")  # [{'name': 'alpha'}, {'name': 'beta'}]
"alpha" in names  # False  ← breaks existing code!
```

## Root Cause

In `expression.py:642`, the condition:
```python
if as_dict or as_dict is None:
```
Treats unspecified `as_dict` the same as `True`, returning dicts instead of arrays.

## Fix

Change to:
```python
if as_dict is True:
```

So that unspecified `as_dict` defaults to array output, matching DJ 1.x.

## Behavior After Fix

| Pattern | Returns |
|---------|---------|
| `fetch('col')` | array (DJ 1.x compatible) |
| `fetch('col', as_dict=False)` | array |
| `fetch('col', as_dict=True)` | list of dicts |

## Testing

- Updated `test_fetch_with_attrs_returns_arrays` to verify correct behavior
- Added `test_fetch_with_attrs_as_dict_true` for explicit dict case
- All 10 fetch compat tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)