### PR TITLE
fix: Make release workflow idempotent for re-runs

### DIFF
--- a/.github/workflows/post_draft_release_published.yaml
+++ b/.github/workflows/post_draft_release_published.yaml
@@ -57,7 +57,8 @@ jobs:
           # Update src in the <img> tag
           sed -i 's|\(<img id="commit-since-release-img"[^>]*src="\)[^"]*\(".*\)|\1'"$NEW_SRC"'\2|' README.md
           git add README.md
-          git commit -m "Update README.md badge to ${{ github.event.release.tag_name }}"
+          # Only commit if there are changes (handles re-runs gracefully)
+          git diff --cached --quiet README.md || git commit -m "Update README.md badge to ${{ github.event.release.tag_name }}"
       - name: Set up Python ${{matrix.py_ver}}
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- Handle the case where README.md badge is already updated from a previous partial run
- Uses conditional commit to avoid failure when there are no changes to commit

This fixes the release workflow failure for v2.0.0 where the workflow failed on re-run because the README badge commit step had "nothing to commit".

## Test plan
- [ ] Merge this PR
- [ ] Delete v2.0.0 tag and release
- [ ] Recreate v2.0.0 release (workflow will use updated workflow from new tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)