### PR TITLE
fix: Use LICENSE instead of LICENSE.txt in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN ${CONDA_BIN} install --no-pin -qq -y -n base -c conda-forge \
     ${CONDA_BIN} clean -qq -afy
 ENV PATH="$PATH:/home/mambauser/.local/bin"
 
-COPY --chown=${HOST_UID:-1000}:mambauser ./pyproject.toml ./README.md ./LICENSE.txt /main/
+COPY --chown=${HOST_UID:-1000}:mambauser ./pyproject.toml ./README.md ./LICENSE /main/
 COPY --chown=${HOST_UID:-1000}:mambauser ./src/datajoint /main/src/datajoint
 
 VOLUME /src


### PR DESCRIPTION
## Summary
The license file is named `LICENSE`, not `LICENSE.txt`. This was causing the release workflow to fail during Docker build.

## Test plan
- [ ] Merge this PR
- [ ] Delete v2.0.0 tag and release
- [ ] Recreate v2.0.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)