### PR TITLE
deprecate: Add deprecation warning to migrate module

### DIFF
--- a/src/datajoint/migrate.py
+++ b/src/datajoint/migrate.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING
 from packaging.version import Version
 
 from .errors import DataJointError
-from . import __version__
+from .version import __version__
 
 # Show deprecation warning starting in 2.1
 if Version(__version__) >= Version("2.1"):


### PR DESCRIPTION
## Summary
- The `datajoint.migrate` module is provided temporarily to assist with migration from pre-2.0
- Deprecation warning appears only in DataJoint 2.1+
- Module will be removed in DataJoint 2.2

## Changes
- Updated docstring to clarify temporary nature and timeline
- Made deprecation warning conditional on version >= 2.1
- Updated warning message

## Test plan
- [ ] Import `datajoint.migrate` in 2.0 - no warning
- [ ] Import `datajoint.migrate` in 2.1+ - DeprecationWarning is raised
- [ ] CI tests pass

Related: datajoint-docs PR #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)