### PR TITLE
fix: Handle missing SSL context in multiprocess populate

### DIFF
--- a/src/datajoint/autopopulate.py
+++ b/src/datajoint/autopopulate.py
@@ -525,7 +525,8 @@ class AutoPopulate:
                 else:
                     # spawn multiple processes
                     self.connection.close()
-                    del self.connection._conn.ctx  # SSLContext is not pickleable
+                    if hasattr(self.connection._conn, "ctx"):
+                        del self.connection._conn.ctx  # SSLContext is not pickleable
                     with (
                         mp.Pool(processes, _initialize_populate, (self, self.jobs, populate_kwargs)) as pool,
                         tqdm(desc="Processes: ", total=nkeys)


### PR DESCRIPTION
## Summary

When `use_tls=False`, the connection doesn't have an SSL context (`ctx`), causing `AttributeError` when running multiprocess populate.

## Fix

Check if `ctx` exists before deleting:
```python
if hasattr(self.connection._conn, "ctx"):
    del self.connection._conn.ctx
```

Fixes #1374

## Test plan

- [ ] Run multiprocess populate with `use_tls=False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)