### PR TITLE
fix: Add config option to skip filepath checksum on insert

### DIFF
--- a/datajoint/settings.py
+++ b/datajoint/settings.py
@@ -49,8 +49,11 @@ default = dict(
         "database.use_tls": None,
         "enable_python_native_blobs": True,  # python-native/dj0 encoding support
         "add_hidden_timestamp": False,
-        # file size limit for when to disable checksums
+        # file size limits for when to disable checksums (in bytes)
+        # filepath_checksum_size_limit: skip checksum verification on fetch for large files
         "filepath_checksum_size_limit": None,
+        # filepath_checksum_size_limit_insert: skip checksum computation on insert for large files
+        "filepath_checksum_size_limit_insert": None,
     }
 )
 


### PR DESCRIPTION
## Summary

Adds `filepath_checksum_size_limit_insert` config option to skip checksum computation on insert for files larger than the specified limit. This prevents transaction timeouts when inserting large files with filepath attributes in three-part `make()` methods.

## Problem

In three-part `make()` methods, the transaction can expire while checksums are computed for large files with `filepath` fields. This causes the entire `make()` to fail.

## Solution

| Config Option | Purpose |
|---------------|---------|
| `filepath_checksum_size_limit` | Skip checksum verification on fetch (existing) |
| `filepath_checksum_size_limit_insert` | Skip checksum computation on insert (new) |

When checksum is skipped on insert:
- A warning is logged
- `contents_hash` is stored as NULL
- Existing file verification is bypassed

## Usage

```python
import datajoint as dj

# Skip checksum on insert for files > 1GB
dj.config['filepath_checksum_size_limit_insert'] = 1024 * 1024 * 1024
```

Or via environment variable:
```bash
export DJ_FILEPATH_CHECKSUM_SIZE_LIMIT_INSERT=1073741824
```

Fixes #1386

🤖 Generated with [Claude Code](https://claude.ai/code)