### PR TITLE
fix: Strip module prefix correctly for Part tables in diagrams

### DIFF
--- a/src/datajoint/diagram.py
+++ b/src/datajoint/diagram.py
@@ -761,7 +761,7 @@ else:
                     if schema_name and "." in name:
                         cluster_label = cluster_labels.get(schema_name)
                         if cluster_label and name.startswith(cluster_label + "."):
-                            display_name = name[len(cluster_label) + 1:]
+                            display_name = name[len(cluster_label) + 1 :]
                     node.set_label("<<u>" + display_name + "</u>>" if node.get("distinguished") == "True" else display_name)
                 node.set_color(props["color"])
                 node.set_style("filled")
@@ -960,7 +960,7 @@ else:
                         # Strip module prefix from display name if it matches the cluster label
                         display_name = node
                         if "." in node and node.startswith(label + "."):
-                            display_name = node[len(label) + 1:]
+                            display_name = node[len(label) + 1 :]
                         class_suffix = f":::{cls}" if cls else ""
                         lines.append(f"        {safe_id}{left}{display_name}{right}{class_suffix}")
                 lines.append("    end")


### PR DESCRIPTION
## Summary

- Fix Part table names displaying with module prefix in diagrams (e.g., `scan.Scans.Scan` instead of `Scans.Scan`)

## Problem

The previous logic used `rsplit(".", 1)` to strip module prefixes, which only split at the last dot. For Part tables with names like `scan.Scans.Scan`, this resulted in:
- `prefix = "scan.Scans"` 
- Comparison with cluster label `"scan"` failed
- Display name kept full `scan.Scans.Scan`

## Solution

Use `startswith()` to check if the name begins with the cluster label, then strip that prefix:
```python
if cluster_label and name.startswith(cluster_label + "."):
    display_name = name[len(cluster_label) + 1:]
```

This correctly handles both regular tables (`scan.Scans` → `Scans`) and Part tables (`scan.Scans.Scan` → `Scans.Scan`).

## Test plan

- [x] Verified fix logic with debug output
- [ ] Test with lcms-demo pipeline diagrams

Fixes #1390

🤖 Generated with [Claude Code](https://claude.com/claude-code)