### PR TITLE
Remove size_on_disk from Table and Schema

### DIFF
--- a/src/datajoint/schemas.py
+++ b/src/datajoint/schemas.py
@@ -318,26 +318,6 @@ class Schema:
     def __repr__(self):
         return "Schema `{name}`\n".format(name=self.database)
 
-    @property
-    def size_on_disk(self) -> int:
-        """
-        Return the total size of all tables in the schema.
-
-        Returns
-        -------
-        int
-            Size in bytes (data + indices).
-        """
-        self._assert_exists()
-        return int(
-            self.connection.query(
-                """
-            SELECT SUM(data_length + index_length)
-            FROM information_schema.tables WHERE table_schema='{db}'
-            """.format(db=self.database)
-            ).fetchone()[0]
-        )
-
     def make_classes(self, into: dict[str, Any] | None = None) -> None:
         """
         Create Python table classes for tables in the schema.

--- a/src/datajoint/table.py
+++ b/src/datajoint/table.py
@@ -1252,22 +1252,6 @@ class Table(QueryExpression):
                 FreeTable(self.connection, table).drop_quick()
             logger.info("Tables dropped. Restart kernel.")
 
-    @property
-    def size_on_disk(self):
-        """
-        Return the size of data and indices in bytes on the storage device.
-
-        Returns
-        -------
-        int
-            Size of data and indices in bytes.
-        """
-        ret = self.connection.query(
-            'SHOW TABLE STATUS FROM `{database}` WHERE NAME="{table}"'.format(database=self.database, table=self.table_name),
-            as_dict=True,
-        ).fetchone()
-        return ret["Data_length"] + ret["Index_length"]
-
     def describe(self, context=None, printout=False):
         """
         Return the definition string for the query using DataJoint DDL.

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -282,11 +282,5 @@ def test_table_regexp(schema_any):
             ), "Regular expression matches for {name} but should not".format(name=name)
 
 
-def test_table_size(experiment):
-    """test getting the size of the table and its indices in bytes"""
-    number_of_bytes = experiment.size_on_disk
-    assert isinstance(number_of_bytes, int) and number_of_bytes > 100
-
-
 def test_repr_html(ephys):
     assert ephys._repr_html_().strip().startswith("<style")

--- a/tests/integration/test_schema.py
+++ b/tests/integration/test_schema.py
@@ -56,11 +56,6 @@ def schema_empty(connection_test, schema_any, prefix):
     # Don't drop the schema since schema_any still needs it
 
 
-def test_schema_size_on_disk(schema_any):
-    number_of_bytes = schema_any.size_on_disk
-    assert isinstance(number_of_bytes, int)
-
-
 def test_schema_list(schema_any):
     schemas = dj.list_schemas(connection=schema_any.connection)
     assert schema_any.database in schemas


### PR DESCRIPTION
## Summary
- Remove `Table.size_on_disk` property
- Remove `Schema.size_on_disk` property
- Remove associated tests

## Rationale
- **MySQL-specific**: Uses `SHOW TABLE STATUS` and `information_schema` queries incompatible with PostgreSQL support
- **Incomplete in 2.0**: Reports only relational DB size, not object storage where large scientific data resides
- **Accuracy issues**: MySQL statistics can be stale without `ANALYZE TABLE`
- **Low utility**: Trivial for users to implement directly if needed
- **Undocumented**: No documentation in datajoint-docs

## Test plan
- [x] Removed tests for both methods
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)