### PR TITLE
Fix: Pin setuptools<82 for pkg_resources compatibility

### DIFF
--- a/datajoint/plugin.py
+++ b/datajoint/plugin.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 
-import pkg_resources
+import pkg_resources  # requires setuptools<82
 from cryptography.exceptions import InvalidSignature
 from otumat import hash_pkg, verify
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "faker",
   "cryptography",
   "urllib3",
-  "setuptools",
+  "setuptools<82",  # pkg_resources removed in 82.0.0
 ]
 requires-python = ">=3.9,<4.0"
 authors = [


### PR DESCRIPTION
## Summary
Pin `setuptools<82` to fix import error caused by removal of `pkg_resources` in setuptools 82.0.0.

Fixes #1394

## Root Cause
`setuptools` 82.0.0 (released Feb 10, 2026) removed `pkg_resources`. DataJoint 0.14's `plugin.py` imports it directly for plugin discovery and verification.

## Fix
Pin `setuptools<82` in runtime dependencies. This is a minimal fix appropriate for the 0.14.x maintenance line, which is approaching end of life. DataJoint 2.x properly addresses this by using `importlib.metadata` instead.

## Test plan
- [ ] CI passes
- [ ] Fresh install with Python 3.13 can `import datajoint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)