### PR TITLE
fix: Atomic job reservation to prevent race condition

### DIFF
--- a/src/datajoint/jobs.py
+++ b/src/datajoint/jobs.py
@@ -449,10 +449,7 @@ class Job(Table):
         pk = self._get_pk(key)
         where = make_condition(self, pk, set())
         qi = self.adapter.quote_identifier
-        assignments = ", ".join(
-            f"{qi(k)}=%s"
-            for k in ("status", "host", "pid", "connection_id", "user", "version")
-        )
+        assignments = ", ".join(f"{qi(k)}=%s" for k in ("status", "host", "pid", "connection_id", "user", "version"))
         query = (
             f"UPDATE {self.full_table_name} "
             f"SET {assignments}, {qi('reserved_time')}=CURRENT_TIMESTAMP(3) "


### PR DESCRIPTION
## Summary
- Fixes #1398 — multiple workers could reserve the same job key simultaneously
- Replace the non-atomic SELECT → UPDATE in `Job.reserve()` with a single atomic `UPDATE ... WHERE status='pending'`, checking `cursor.rowcount` for success
- Reduces three database round-trips to one
- Works on both MySQL and PostgreSQL backends

## Root cause

The previous `reserve()` performed a SELECT to check `status='pending'`, then a separate UPDATE matching only on primary key. When concurrent workers (e.g., SLURM array jobs) hit this simultaneously, both SELECTs see `status='pending'`, both UPDATEs succeed (since the WHERE matched only on PK), and both workers proceed to call `make()` on the same key.

## Fix

A single atomic UPDATE includes `AND status='pending' AND scheduled_time <= CURRENT_TIMESTAMP(3)` in the WHERE clause. The database guarantees only one concurrent UPDATE can match; all others get `rowcount=0` and return `False`.

## Test plan
- [x] Verify existing job reservation tests pass
- [ ] Test with concurrent workers (SLURM or multiprocessing) to confirm only one worker reserves each key

🤖 Generated with [Claude Code](https://claude.com/claude-code)