### PR TITLE
fix: fetch(attrs, as_dict=True) excludes unrequested primary key

### DIFF
--- a/src/datajoint/expression.py
+++ b/src/datajoint/expression.py
@@ -716,7 +716,7 @@ class QueryExpression:
         import warnings
 
         warnings.warn(
-            "fetch() is deprecated in DataJoint 2.0. " "Use to_dicts(), to_pandas(), to_arrays(), or keys() instead.",
+            "fetch() is deprecated in DataJoint 2.0. Use to_dicts(), to_pandas(), to_arrays(), or keys() instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -748,7 +748,10 @@ class QueryExpression:
                         proj_attrs.extend(self.primary_key)
                     else:
                         proj_attrs.append(attr)
-                return self.proj(*proj_attrs).to_dicts(order_by=order_by, limit=limit, offset=offset, squeeze=squeeze)
+                dicts = self.proj(*proj_attrs).to_dicts(order_by=order_by, limit=limit, offset=offset, squeeze=squeeze)
+                # Filter to only requested attributes (proj always includes primary key)
+                requested = set(proj_attrs)
+                return [{k: v for k, v in d.items() if k in requested} for d in dicts]
             else:
                 # fetch('col1', 'col2') or fetch('col1', 'col2', as_dict=False) -> tuple of arrays
                 # This matches DJ 1.x behavior where fetch('col') returns array(['alpha', 'beta'])


### PR DESCRIPTION
## Summary

Restores 0.14.x behavior where `fetch('col1', 'col2', as_dict=True)` returned dicts containing **only** the requested attributes.

In 2.x, `proj()` always includes primary key attributes, so the returned dicts contained extra keys the caller didn't ask for. This breaks downstream code that concats the result with an existing DataFrame that already has the primary key column — the concat creates duplicate columns and subsequent groupby fails.

The fix filters each dict after `to_dicts()` to include only the requested attributes. This is safe regardless of row order because we are removing keys from individual dicts, not rearranging rows.

## Reproducing the issue

```python
# Table with primary key (dataset) and secondary attrs (heading_dir, head_angle)

# 0.14.x — only requested attrs:
Table.fetch('heading_dir', 'head_angle', as_dict=True)
# [{'heading_dir': ..., 'head_angle': ...}, ...]

# 2.1.0 — primary key leaks in:
Table.fetch('heading_dir', 'head_angle', as_dict=True)
# [{'dataset': ..., 'heading_dir': ..., 'head_angle': ...}, ...]
# pd.concat with a df that already has 'dataset' creates duplicates
```

## Test plan

- [ ] `fetch('attr', as_dict=True)` returns dicts without primary key
- [ ] `fetch('KEY', 'attr', as_dict=True)` still includes primary key (explicitly requested)
- [ ] Integration tests pass