### PR TITLE
feat: export AutoPopulate and Job in public API

### DIFF
--- a/src/datajoint/__init__.py
+++ b/src/datajoint/__init__.py
@@ -30,6 +30,8 @@ __all__ = [
     "list_schemas",
     "Table",
     "FreeTable",
+    "AutoPopulate",
+    "Job",
     "Manual",
     "Lookup",
     "Imported",
@@ -81,6 +83,8 @@ from .instance import Instance, _ConfigProxy, _get_singleton_connection, _global
 from .logging import logger
 from .objectref import ObjectRef
 from .schemas import _Schema, VirtualModule, list_schemas, virtual_schema
+from .autopopulate import AutoPopulate
+from .jobs import Job
 from .table import FreeTable as _FreeTable, Table, ValidationResult
 from .user_tables import Computed, Imported, Lookup, Manual, Part
 from .version import __version__


### PR DESCRIPTION
## Summary

- Export `AutoPopulate` and `Job` from `datajoint` top-level package
- Enables ecosystem packages (e.g. `datajoint-worker`) to use `dj.AutoPopulate` for isinstance checks and `dj.Job` for FreeTable progress queries without depending on internal module paths

**Motivation**: datajoint-company/datajoint-worker#1 imports `from datajoint.autopopulate import AutoPopulate` and `from datajoint.jobs import Job` -- both non-public paths. These are stable, useful abstractions that belong in the public API:
- `AutoPopulate` is the common base for `Computed`/`Imported`, defining the `.populate()`/`.make()`/`.jobs` contract
- `Job` is needed to get job progress from `FreeTable` instances (which lack the `.jobs` descriptor)

## Test plan

- [x] `python -c "import datajoint as dj; print(dj.AutoPopulate, dj.Job)"` works
- [x] All pre-commit hooks pass (ruff, mypy, codespell)
- [ ] Existing test suite passes (no behavior change, additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)