### PR TITLE
fix(#1433): clear error for leading-underscore attribute names

### DIFF
--- a/src/datajoint/declare.py
+++ b/src/datajoint/declare.py
@@ -147,7 +147,7 @@ def build_attribute_parser() -> pp.ParserElement:
     """
     quoted = pp.QuotedString('"') ^ pp.QuotedString("'")
     colon = pp.Literal(":").suppress()
-    attribute_name = pp.Word(pp.srange("[a-z]"), pp.srange("[a-z0-9_]")).set_results_name("name")
+    attribute_name = pp.Word(pp.srange("[_a-z]"), pp.srange("[a-z0-9_]")).set_results_name("name")
     data_type = (
         pp.Combine(pp.Word(pp.alphas) + pp.SkipTo("#", ignore=quoted))
         ^ pp.QuotedString("<", end_quote_char=">", unquote_results=False)

--- a/src/datajoint/declare.py
+++ b/src/datajoint/declare.py
@@ -147,7 +147,7 @@ def build_attribute_parser() -> pp.ParserElement:
     """
     quoted = pp.QuotedString('"') ^ pp.QuotedString("'")
     colon = pp.Literal(":").suppress()
-    attribute_name = pp.Word(pp.srange("[_a-z]"), pp.srange("[a-z0-9_]")).set_results_name("name")
+    attribute_name = pp.Word(pp.srange("[a-z]"), pp.srange("[a-z0-9_]")).set_results_name("name")
     data_type = (
         pp.Combine(pp.Word(pp.alphas) + pp.SkipTo("#", ignore=quoted))
         ^ pp.QuotedString("<", end_quote_char=">", unquote_results=False)
@@ -855,6 +855,14 @@ def compile_attribute(
     DataJointError
         If syntax is invalid, primary key is nullable, or blob has invalid default.
     """
+    if line.lstrip().startswith("_"):
+        raise DataJointError(
+            f'Attribute name in line "{line}" starts with an underscore. '
+            "Names with leading underscore are reserved for platform-managed "
+            "columns (e.g. _job_start_time, _singleton). Use a regular "
+            "attribute name; if you need to control visibility at the call "
+            "site, use proj()."
+        )
     try:
         match = attribute_parser.parse_string(line + "#", parse_all=True)
     except pp.ParseException as err:

--- a/tests/unit/test_declare_hidden_attribute.py
+++ b/tests/unit/test_declare_hidden_attribute.py
@@ -1,0 +1,44 @@
+"""Unit tests for hidden attribute names (leading underscore) in table declarations.
+
+Regression coverage for issue #1433: the declaration parser previously rejected
+attribute names starting with ``_``, even though hidden-attribute semantics
+(``is_hidden = name.startswith("_")``) were already implemented in ``Heading``.
+"""
+
+import pytest
+
+from datajoint.declare import attribute_parser
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "_hidden: bool",
+        "_params_hash: varchar(32)",
+        "_job_start_time=null: datetime(3)",
+        "_a: int",
+    ],
+)
+def test_parser_accepts_leading_underscore(line):
+    match = attribute_parser.parse_string(line + "#", parse_all=True)
+    assert match["name"].startswith("_")
+
+
+def test_parser_still_accepts_plain_names():
+    match = attribute_parser.parse_string("name: varchar(40)#", parse_all=True)
+    assert match["name"] == "name"
+
+
+def test_parser_rejects_digit_start():
+    """Numeric leading char remains invalid (preserved behavior)."""
+    import pyparsing as pp
+
+    with pytest.raises(pp.ParseException):
+        attribute_parser.parse_string("1bad: int#", parse_all=True)
+
+
+def test_parser_extracts_hidden_name_for_is_hidden_dispatch():
+    """The parsed name is what Heading uses to set is_hidden via name.startswith('_')."""
+    match = attribute_parser.parse_string("_secret: int#", parse_all=True)
+    name = match["name"]
+    assert name.startswith("_")

--- a/tests/unit/test_declare_hidden_attribute.py
+++ b/tests/unit/test_declare_hidden_attribute.py
@@ -1,13 +1,19 @@
-"""Unit tests for hidden attribute names (leading underscore) in table declarations.
+"""Unit tests for the leading-underscore guard in attribute declarations.
 
-Regression coverage for issue #1433: the declaration parser previously rejected
-attribute names starting with ``_``, even though hidden-attribute semantics
-(``is_hidden = name.startswith("_")``) were already implemented in ``Heading``.
+Regression coverage for issue #1433: declarations like ``_hidden: bool``
+previously failed with a cryptic ``pyparsing.ParseException``. The framework
+intentionally does not support user-defined hidden attributes — those names
+are reserved for platform-managed columns (e.g. ``_job_start_time``,
+``_singleton``) which DataJoint injects programmatically after parsing.
+
+This test ensures the user gets a clear ``DataJointError`` pointing to the
+right alternative, not a parser-internals error.
 """
 
 import pytest
 
-from datajoint.declare import attribute_parser
+from datajoint.declare import attribute_parser, compile_attribute
+from datajoint.errors import DataJointError
 
 
 @pytest.mark.parametrize(
@@ -15,13 +21,21 @@ from datajoint.declare import attribute_parser
     [
         "_hidden: bool",
         "_params_hash: varchar(32)",
-        "_job_start_time=null: datetime(3)",
-        "_a: int",
+        "  _leading_whitespace: int32",
     ],
 )
-def test_parser_accepts_leading_underscore(line):
-    match = attribute_parser.parse_string(line + "#", parse_all=True)
-    assert match["name"].startswith("_")
+def test_compile_attribute_rejects_leading_underscore(line):
+    """The leading-underscore guard fires before the parser, so adapter is unused."""
+    with pytest.raises(DataJointError, match="reserved for platform-managed"):
+        compile_attribute(line, in_key=False, foreign_key_sql=[], context={}, adapter=None)
+
+
+def test_parser_still_rejects_leading_underscore():
+    """Parser regex itself remains strict; the helpful error fires before the parser."""
+    import pyparsing as pp
+
+    with pytest.raises(pp.ParseException):
+        attribute_parser.parse_string("_hidden: bool#", parse_all=True)
 
 
 def test_parser_still_accepts_plain_names():
@@ -34,11 +48,4 @@ def test_parser_rejects_digit_start():
     import pyparsing as pp
 
     with pytest.raises(pp.ParseException):
-        attribute_parser.parse_string("1bad: int#", parse_all=True)
-
-
-def test_parser_extracts_hidden_name_for_is_hidden_dispatch():
-    """The parsed name is what Heading uses to set is_hidden via name.startswith('_')."""
-    match = attribute_parser.parse_string("_secret: int#", parse_all=True)
-    name = match["name"]
-    assert name.startswith("_")
+        attribute_parser.parse_string("1bad: int32#", parse_all=True)


### PR DESCRIPTION
## Summary

Fixes #1433 by replacing the cryptic \`pyparsing.ParseException\` that users hit when declaring \`_hidden: bool\` with a clear \`DataJointError\` that explains the constraint and points to the alternative.

## Design decision: don't allow user-defined hidden attributes

Earlier drafts of this PR loosened the parser to accept leading underscores, on the assumption that users should be able to declare hidden attributes the same way the framework does. On reflection, that's wrong:

- Hidden attributes are filtered out of every public API surface — \`fetch()\`, dict restrictions, joins, \`insert\`/\`update1\`, \`describe()\`. The filter is intentional and reflects the platform-bookkeeping intent.
- Platform-managed hidden columns (\`_job_start_time\`, \`_job_duration\`, \`_job_version\`, \`_singleton\`) are injected programmatically *after* parsing and populated via raw SQL during the \`populate()\` lifecycle (autopopulate.py). The parser never sees them.
- Allowing users to declare hidden attributes would expose a feature with no public-API write path, no \`describe()\` round-trip, and silent filtering on dict restrictions and \`insert(ignore_extra_fields=True)\`. That's a footgun.
- The cases users reach for hidden attributes — most commonly an index-backing derived column like \`params_hash\` — are better solved with a regular attribute. Backing a unique index isn't sufficient reason to hide a column. If application code computes, inserts, or queries the column, it should be a regular attribute.

So this PR keeps the parser strict and improves the error message instead.

## Fix

Pre-flight check in \`compile_attribute\` (declare.py:858) that detects a leading underscore and raises a \`DataJointError\` before the parser is invoked:

\`\`\`
Attribute name in line "_hidden: bool" starts with an underscore.
Names with leading underscore are reserved for platform-managed
columns (e.g. _job_start_time, _singleton). Use a regular attribute
name; if you need to control visibility at the call site, use proj().
\`\`\`

The parser regex is unchanged from master. Platform code is unaffected because \`_job_*\` and \`_singleton\` bypass \`compile_attribute\` entirely.

## Companion docs PR

datajoint/datajoint-docs#162 — reworked to reflect the new design. The §3.4 section is now framed as platform-only, the \`_params_hash\` user-defined example is removed, and the table of behaviors is preserved as a reference for the platform-managed columns.

## Test plan

- [x] \`tests/unit/test_declare_hidden_attribute.py\` — 6 tests: \`compile_attribute\` rejects \`_hidden\`, \`_params_hash\`, and leading-whitespace variants with the helpful message; parser still rejects leading \`_\`; parser still accepts plain names; parser still rejects digit-start.
- [x] Full unit test suite (255 tests) — all pass, no regressions.
- [x] \`ruff check\` and \`ruff format\` clean.