### PR TITLE
fix(#1438): preserve json flag for MariaDB longtext-aliased columns

### DIFF
--- a/src/datajoint/heading.py
+++ b/src/datajoint/heading.py
@@ -508,8 +508,16 @@ class Heading:
                 if category == "UUID":
                     attr["uuid"] = True
                 elif category in CORE_TYPE_NAMES:
-                    # Core type alias - already resolved in DB
-                    pass
+                    # Core type alias - already resolved in DB.
+                    # MariaDB-specific recovery: MariaDB stores `json` columns
+                    # as `longtext` and reports them back that way through
+                    # information_schema, so the DB-type-based detection above
+                    # leaves attr["json"] False. The :json: comment marker
+                    # survives this aliasing, so we recover the json flag here
+                    # from the original declared type. No-op on MySQL/PostgreSQL
+                    # (attr["json"] is already True from the regex match above).
+                    if category == "JSON":
+                        attr["json"] = True
 
             # Check primary key constraints
             if attr["in_key"] and (attr["is_blob"] or attr["json"]):


### PR DESCRIPTION
## Summary

Fixes #1438. MariaDB stores `json` columns as `longtext` and reports them back through `information_schema` as `longtext`, so DataJoint's DB-type-based JSON detection in `Heading._init_from_database()` left `attr["json"]` as `False`. That silently broke insert (`json.dumps` skipped → `dict` reaches pymysql → `TypeError`) and fetch (`json.loads` skipped → caller gets the raw string).

The `:json:` comment marker is already written at declare-time (JSON is in `CORE_TYPE_NAMES` / `SPECIAL_TYPES`) and already parsed back into `attr["original_type"]` on read. Recover `attr["json"]` from that marker in the same block where UUID is already recovered.

## Behavior by backend

- **MySQL**: DB reports `json`, regex matches, `attr["json"] = True` from the existing line. The new branch reasserts the same value — no behavior change.
- **PostgreSQL**: DB reports `json`/`jsonb`, regex matches both. Same as MySQL — no-op.
- **MariaDB**: DB reports `longtext`, regex misses, `attr["json"]` was `False`. The `:json:` comment marker is intact, so `category == "JSON"` and the new branch flips it to `True`. Insert and fetch now round-trip correctly.

## Out of scope

- **Legacy MariaDB tables created without the `:json:` comment marker** (e.g. created by a non-DataJoint tool) will still fail. Adding a heuristic for bare `longtext` columns would be unsound.
- **MariaDB CI coverage.** MariaDB remains unofficially supported and will not be added to this repo's CI matrix. Downstream projects depending on MariaDB own MariaDB testing in their own pipelines.

## Test plan

- [ ] Round-trip the issue reproduction against a MariaDB container (insert `dict`, fetch back `dict`).
- [ ] `pytest tests/integration/test_json.py` against MySQL — confirm no regression.
- [ ] `pytest tests/integration/test_json.py` against PostgreSQL — confirm no regression.
- [ ] Spot-check `heading.attributes["metadata"].json is True` and `.type == "longtext"` on MariaDB after the insert succeeds.