### PR TITLE
fix(#1442): scan_*_references reads raw JSON metadata instead of decoded codec output

### DIFF
--- a/src/datajoint/__init__.py
+++ b/src/datajoint/__init__.py
@@ -275,6 +275,9 @@ _lazy_modules = {
     "diagram": (".diagram", None),  # Return the module itself
     # cli imports click
     "cli": (".cli", "cli"),
+    # gc — exposed lazily so `dj.gc.scan(...)` works as documented in gc.py
+    # and in the user docs (how-to/garbage-collection.md).
+    "gc": (".gc", None),  # Return the module itself
 }
 
 

--- a/src/datajoint/gc.py
+++ b/src/datajoint/gc.py
@@ -229,11 +229,14 @@ def scan_hash_references(
                     if verbose:
                         logger.info(f"  Scanning {table_name}.{attr_name}")
 
-                    # Fetch all values for this attribute
+                    # Read raw JSON metadata via cursor — bypasses decode_attribute
+                    # so we get the stored dict (PostgreSQL/JSONB) or JSON string
+                    # (MySQL), not the decoded codec output. _extract_hash_refs
+                    # handles both shapes.
                     try:
-                        values = table.to_arrays(attr_name)
-                        for value in values:
-                            for path, ref_store in _extract_hash_refs(value):
+                        cursor = table.proj(attr_name).cursor(as_dict=True)
+                        for row in cursor:
+                            for path, ref_store in _extract_hash_refs(row[attr_name]):
                                 # Filter by store if specified
                                 if store_name is None or ref_store == store_name:
                                     referenced.add(path)
@@ -291,11 +294,14 @@ def scan_schema_references(
                     if verbose:
                         logger.info(f"  Scanning {table_name}.{attr_name}")
 
-                    # Fetch all values for this attribute
+                    # Read raw JSON metadata via cursor — bypasses decode_attribute
+                    # so we get the stored dict (PostgreSQL/JSONB) or JSON string
+                    # (MySQL), not the decoded codec output. _extract_schema_refs
+                    # handles both shapes.
                     try:
-                        values = table.to_arrays(attr_name)
-                        for value in values:
-                            for path, ref_store in _extract_schema_refs(value):
+                        cursor = table.proj(attr_name).cursor(as_dict=True)
+                        for row in cursor:
+                            for path, ref_store in _extract_schema_refs(row[attr_name]):
                                 # Filter by store if specified
                                 if store_name is None or ref_store == store_name:
                                     referenced.add(path)

--- a/tests/integration/test_gc.py
+++ b/tests/integration/test_gc.py
@@ -4,10 +4,41 @@ Tests for garbage collection (gc.py).
 
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
+import datajoint as dj
 from datajoint import gc
 from datajoint.errors import DataJointError
+
+
+# Tables used by TestScanWithLiveData. Defined at module scope so dj.Schema's
+# context resolution can find them by class name; bound to a schema inside
+# each fixture (see schema(...) calls below).
+
+
+class GcBlobTest(dj.Manual):
+    definition = """
+    rid : int
+    ---
+    payload : <blob@local>
+    """
+
+
+class GcNpyTest(dj.Manual):
+    definition = """
+    rid : int
+    ---
+    waveform : <npy@local>
+    """
+
+
+class GcObjectTest(dj.Manual):
+    definition = """
+    rid : int
+    ---
+    results : <object@local>
+    """
 
 
 class TestUsesHashStorage:
@@ -347,3 +378,90 @@ class TestFormatStats:
         assert "Schema paths: 1" in result
         assert "2.00 MB" in result
         assert "Errors:      2" in result
+
+
+class TestScanWithLiveData:
+    """End-to-end tests for gc.scan() against real schemas with external storage.
+
+    Exercises the full production path:
+        scan_*_references → table.proj(attr).cursor() → raw JSON metadata.
+
+    These are the regression tests that would have caught issue #1442
+    (silent type mismatch when scan helpers iterated decoded codec outputs
+    instead of raw stored metadata).
+    """
+
+    @pytest.fixture
+    def schema_blob(self, connection_test, prefix, mock_stores):
+        schema_name = f"{prefix}_test_gc_e2e_blob"
+        schema = dj.Schema(
+            schema_name,
+            context={"GcBlobTest": GcBlobTest},
+            connection=connection_test,
+        )
+        schema(GcBlobTest)
+        yield schema
+        schema.drop()
+
+    @pytest.fixture
+    def schema_npy(self, connection_test, prefix, mock_stores):
+        schema_name = f"{prefix}_test_gc_e2e_npy"
+        schema = dj.Schema(
+            schema_name,
+            context={"GcNpyTest": GcNpyTest},
+            connection=connection_test,
+        )
+        schema(GcNpyTest)
+        yield schema
+        schema.drop()
+
+    @pytest.fixture
+    def schema_object(self, connection_test, prefix, mock_stores):
+        schema_name = f"{prefix}_test_gc_e2e_object"
+        schema = dj.Schema(
+            schema_name,
+            context={"GcObjectTest": GcObjectTest},
+            connection=connection_test,
+        )
+        schema(GcObjectTest)
+        yield schema
+        schema.drop()
+
+    def test_scan_finds_active_blob_reference(self, schema_blob):
+        """scan() must report hash_referenced >= 1 for a populated <blob@> column.
+
+        Decoded value type returned by BlobCodec.decode is numpy.ndarray, which
+        does not satisfy `_extract_hash_refs`'s dict/JSON-string check — this
+        test fails before the cursor-based fix in scan_hash_references.
+        """
+        GcBlobTest.insert1({"rid": 1, "payload": np.arange(64, dtype="uint8")})
+
+        stats = gc.scan(schema_blob, store_name="local")
+
+        assert stats["hash_referenced"] >= 1, f"scan should find the active <blob@> reference; got {stats}"
+
+    def test_scan_finds_active_npy_reference(self, schema_npy):
+        """scan() must report schema_paths_referenced >= 1 for a populated <npy@> column.
+
+        Decoded value type returned by NpyCodec.decode is NpyRef (lazy handle),
+        which does not satisfy `_extract_schema_refs`'s dict check — this test
+        fails before the cursor-based fix in scan_schema_references.
+        """
+        GcNpyTest.insert1({"rid": 1, "waveform": np.arange(64, dtype="float32")})
+
+        stats = gc.scan(schema_npy, store_name="local")
+
+        assert stats["schema_paths_referenced"] >= 1, f"scan should find the active <npy@> reference; got {stats}"
+
+    def test_scan_finds_active_object_reference(self, schema_object):
+        """scan() must report schema_paths_referenced >= 1 for a populated <object@> column.
+
+        Decoded value type returned by ObjectCodec.decode is ObjectRef (lazy
+        handle), which does not satisfy `_extract_schema_refs`'s dict check —
+        this test fails before the cursor-based fix in scan_schema_references.
+        """
+        GcObjectTest.insert1({"rid": 1, "results": b"hello-gc-test"})
+
+        stats = gc.scan(schema_object, store_name="local")
+
+        assert stats["schema_paths_referenced"] >= 1, f"scan should find the active <object@> reference; got {stats}"


### PR DESCRIPTION
## Summary

Fixes #1442. `gc.scan_hash_references` and `gc.scan_schema_references` were calling `table.to_arrays(attr_name)`, which routes through `Expression.to_dicts` → `decode_attribute` → the codec's `decode()`. For the storage codecs (`<blob@>`, `<hash@>`, `<attach@>`, `<npy@>`, `<object@>`) that returns the deserialized payload — `numpy.ndarray`, `NpyRef`, `ObjectRef`, `bytes`, or local file-path `str`. None of those satisfy `_extract_*_refs`'s `isinstance(value, dict) and "path" in value` check, so both helpers silently returned empty reference sets and `collect()` would have classified live data as orphaned.

This PR replaces the call with `table.proj(attr_name).cursor(as_dict=True)` in both helpers. The cursor yields the raw JSON column value: a Python dict on PostgreSQL (JSONB auto-decoded) or a JSON string on MySQL — both already handled by `_extract_*_refs` (`gc.py:138` string branch, `gc.py:145` dict branch). Backend-agnostic, custom-codec-safe, and turns scan into a metadata-only operation (no more downloading every external blob just to discard the deserialized result).

Also registers `gc` in `_lazy_modules` (`src/datajoint/__init__.py`) so `dj.gc.scan(...)` works as both the module docstring and the user docs at `how-to/garbage-collection.md` invoke it. Pattern matches the existing `"diagram": (".diagram", None)` entry.

## Test plan

- [x] `pytest tests/integration/test_gc.py -k "not TestScanWithLiveData"` — 26 existing mocked tests pass unchanged (orchestration coverage stays intact).
- [x] `pytest tests/integration/test_gc.py::TestScanWithLiveData -v` — 3 new non-mocked e2e tests pass with the fix:
  - `test_scan_finds_active_blob_reference` — `<blob@>` (decode → `numpy.ndarray`)
  - `test_scan_finds_active_npy_reference`  — `<npy@>`  (decode → `NpyRef`)
  - `test_scan_finds_active_object_reference` — `<object@>` (decode → `ObjectRef`)
- [x] **Regression-proven:** the same 3 e2e tests fail when `gc.py` is reverted to the buggy version. The failure mode reproduces the issue's exact symptom — `hash_referenced: 0`, `schema_paths_referenced: 0`, every file classified as orphaned.
- [x] `pre-commit run` (ruff, ruff-format, codespell) clean.

## Test gap closed

`tests/integration/test_gc.py:163-166` patches `scan_hash_references`, `scan_schema_references`, and `list_*_paths` directly, so the production path through `to_arrays` → `decode_attribute` was never exercised end-to-end. That's why this slipped through. The mocked tests stay (orchestration: composition with `list_*_paths`, dry-run vs real, stat-key shape, format strings). The new `TestScanWithLiveData` class fills the gap with one e2e test per structurally distinct decoded-value type.

## Performance side-effect (free byproduct)

Before: scan downloaded every external blob just to deserialize and discard it via the silent type mismatch — a 1 TB schema produced 1 TB of egress to report `referenced: 0`. After: scan touches only the JSON column on the database during reference enumeration.

## Custom-codec authors

Reference discovery now operates on raw stored metadata regardless of what a codec's `decode()` returns. Third-party codecs following the documented `encode`/`decode` contract get correct GC for free — no contract change required.

## Out of scope

GC remains non-transaction-safe even after this fix — there is a TOCTOU window between scan and delete during which a concurrent transaction could insert a row referencing what looks like an orphan. A two-phase retrieval/removal API (quarantine → grace window → purge) is the right remedy and will be filed as a separate enhancement issue right after this PR opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)