### PR TITLE
docs: cite DataJoint 2.0 manuscript and add RRID

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ conda install -c conda-forge datajoint
 
 ![pipeline](https://raw.githubusercontent.com/datajoint/datajoint-python/master/images/pipeline.png)
 
-[Yatsenko et al., bioRxiv 2021](https://doi.org/10.1101/2021.03.30.437358)
+**Cite DataJoint:** [Yatsenko et al., 2026](https://arxiv.org/abs/2602.16585) — RRID: [SCR_014543](https://scicrunch.org/resolver/SCR_014543)
 
 ## Resources
 


### PR DESCRIPTION
## Summary

- Replaces the inline citation under the README's *Example Pipeline* section. It pointed to the pre-2.0 [bioRxiv 2021 manuscript](https://doi.org/10.1101/2021.03.30.437358); now points to [Yatsenko et al., 2026 (arXiv:2602.16585)](https://arxiv.org/abs/2602.16585), matching the DOI badge in the project header.
- Adds DataJoint's RRID — [SCR_014543](https://scicrunch.org/resolver/SCR_014543) — next to the citation so the project can be unambiguously identified in scientific publications.

## Test plan

- [ ] Render the updated README on this PR — confirm the citation line displays correctly with both the manuscript link and the RRID resolver link.
- [ ] Click both links and verify they resolve (arXiv abstract page; SciCrunch resolver page).
- [ ] Confirm the citation aligns with the DOI badge near the top of the README.