### PR TITLE
docs: use relative path for README pipeline image

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ conda install -c conda-forge datajoint
 
 ## Example Pipeline
 
-![pipeline](https://raw.githubusercontent.com/datajoint/datajoint-python/master/images/pipeline.png)
+![pipeline](images/pipeline.png)
 
 **Cite DataJoint:** [Yatsenko et al., 2026](https://arxiv.org/abs/2602.16585) — RRID: [SCR_014543](https://scicrunch.org/resolver/SCR_014543)
 


### PR DESCRIPTION
## Summary

- Replaces the absolute `raw.githubusercontent.com` URL with a relative path (`images/pipeline.png`) for the pipeline illustration in the README.
- Follow-up to #1448 — even though that PR refreshed `images/pipeline.png`, the rendered README on GitHub keeps serving the old image because GitHub camo caches the absolute raw URL aggressively.
- Using a relative path lets GitHub serve the image directly from the current commit, so the refreshed illustration appears immediately and future updates render without cache hiccups.

## Test plan

- [ ] View the rendered README on this PR — confirm the new pipeline illustration (calcium-imaging vocabulary, rectangles for Manual/Lookup, ovals for Imported/Computed) displays correctly.
- [ ] Confirm the image renders at the same size/position as before.