### PR TITLE
fix: Disable semantic_check on populate antijoin (parallels #1383)

### DIFF
--- a/src/datajoint/autopopulate.py
+++ b/src/datajoint/autopopulate.py
@@ -11,6 +11,7 @@ import signal
 import traceback
 from typing import TYPE_CHECKING, Any, Generator
 
+from .condition import Not
 from .errors import DataJointError, LostConnectionError
 from .expression import AndList, QueryExpression
 
@@ -401,7 +402,12 @@ class AutoPopulate:
         """
         from tqdm import tqdm
 
-        keys = (self._jobs_to_do(restrictions) - self.proj()).keys()
+        # Disable semantic_check on the antijoin: when self has FK-inherited
+        # PK attributes, self.proj() may carry attribute lineages that don't
+        # match key_source's (same attribute, different source-table tag).
+        # The set-difference itself doesn't care about lineage — we just want
+        # rows in key_source that aren't yet in self.
+        keys = self._jobs_to_do(restrictions).restrict(Not(self.proj()), semantic_check=False).keys()
 
         logger.debug("Found %d keys to populate" % len(keys))
 
@@ -702,7 +708,8 @@ class AutoPopulate:
         if not common_attrs:
             # No common attributes - fall back to two-query method
             total = len(todo)
-            remaining = len(todo - self.proj())
+            # Same lineage caveat as in _populate_direct — disable semantic_check.
+            remaining = len(todo.restrict(Not(self.proj()), semantic_check=False))
         else:
             # Build a single query that computes both total and remaining
             # Using LEFT JOIN with COUNT(DISTINCT) to handle 1:many relationships

--- a/tests/integration/test_autopopulate.py
+++ b/tests/integration/test_autopopulate.py
@@ -236,6 +236,64 @@ def test_populate_antijoin_overlapping_attrs(prefix, connection_test):
         test_schema.drop(prompt=False)
 
 
+def test_populate_antijoin_fk_inherited_pk(prefix, connection_test):
+    """Regression test: populate antijoin on a table whose PK is fully FK-inherited.
+
+    Reproduces the lineage-mismatch failure that hits ``Imported`` or
+    ``Computed`` tables whose primary key consists entirely of attributes
+    inherited via a foreign key, with no own-table PK attributes.
+
+    Without the ``semantic_check=False`` on the populate antijoin, the
+    subtraction ``key_source - self.proj()`` raises::
+
+        DataJointError: Cannot join on attribute 'spec_id': different lineages
+        (schema.spec.spec_id vs None). Use .proj() to rename one of the attributes.
+
+    The set-difference doesn't actually need lineage matching — it just
+    asks which key_source rows aren't yet in ``self``.
+    """
+    test_schema = dj.Schema(f"{prefix}_antijoin_fk_pk", connection=connection_test)
+
+    @test_schema
+    class Spec(dj.Manual):
+        definition = """
+        spec_id : int32
+        ---
+        label : varchar(30)
+        """
+
+    @test_schema
+    class Item(dj.Imported):
+        definition = """
+        -> Spec
+        ---
+        payload : varchar(60)
+        """
+
+        def make(self, key):
+            label = (Spec & key).fetch1("label")
+            self.insert1(dict(key, payload=f"made:{label}"))
+
+    try:
+        Spec.insert([(1, "alpha"), (2, "beta"), (3, "gamma")])
+
+        # Before the fix this raised DataJointError on the antijoin.
+        Item.populate(max_calls=2)
+        assert len(Item) == 2
+
+        remaining, total = Item.progress()
+        assert total == 3
+        assert remaining == 1
+
+        Item.populate()
+        assert len(Item) == 3
+        remaining, total = Item.progress()
+        assert remaining == 0
+        assert total == 3
+    finally:
+        test_schema.drop(prompt=False)
+
+
 def test_load_dependencies(prefix, connection_test):
     schema = dj.Schema(f"{prefix}_load_dependencies_populate", connection=connection_test)
 


### PR DESCRIPTION
> **Stacked on #1452.** Base is set to that PR's branch for now; rebase to `master`
> once #1452 lands. The two PRs share no overlapping diff hunks — this PR only
> touches `autopopulate.py` and `tests/integration/test_autopopulate.py`.

## Summary

#1383 disabled `semantic_check` for the **jobs** table antijoin in `Job.refresh()`.
The same defect lives in `AutoPopulate._populate_direct`'s antijoin (and the
`progress()` fallback). This PR applies the analogous fix.

The `-` operator on a `QueryExpression` calls `.restrict(Not(...))` with default
`semantic_check=True`. For a plain set-difference (\"which rows of the LHS aren't
in the RHS?\"), the semantic check is wrong — we don't care whether the same-named
PK attribute carries the same source-table lineage tag on each side; we just want
the set difference.

## Where it bites

`dj.Imported` / `dj.Computed` tables whose PK is **fully inherited from a single
foreign key, with no own-table PK attributes**:

```python
@schema
class Spec(dj.Manual):
    definition = \"\"\"
    spec_id : int32
    ---
    label : varchar(30)
    \"\"\"

@schema
class Item(dj.Imported):
    definition = \"\"\"
    -> Spec
    ---
    payload : varchar(60)
    \"\"\"
    def make(self, key):
        self.insert1(dict(key, payload=...))

Spec.insert([(1, \"alpha\"), (2, \"beta\")])
Item.populate()   # ← DataJointError on master
```

On master:

```
DataJointError: Cannot join on attribute 'spec_id': different lineages
(test_schema.spec.spec_id vs None). Use .proj() to rename one of the attributes.
```

`Item.proj()` returns `spec_id` with `lineage=None` while the key_source's
`spec_id` carries `Spec`'s lineage. The semantic check rejects the antijoin.

## Why this didn't surface from #1405's test suite

The existing regression tests (`test_populate_antijoin_with_secondary_attrs`,
`test_populate_antijoin_overlapping_attrs`) all use tables that either have
**multiple FK parents** (so PK attributes come from multiple sources and
`proj()` lineage gets anchored) **or** extend the FK-inherited PK with own-table
attributes. Elements / SciOps pipelines almost always follow that shape.

The single-FK-inherited-PK + no-own-PK-attrs pattern is uncommon but
legitimate — \"one row downstream per parent row, no intermediate ID\".

## Changes

### `src/datajoint/autopopulate.py`
- Import `Not` from `.condition` at module top.
- `_populate_direct`: replace `(LHS - self.proj())` with
  `LHS.restrict(Not(self.proj()), semantic_check=False)`.
- `progress()`: same swap on the no-common-attrs fallback branch.

### `tests/integration/test_autopopulate.py`
- New `test_populate_antijoin_fk_inherited_pk` regression test.
  Constructs the minimal shape (`Spec(Manual) → Item(Imported)`) that
  triggers the bug. Exercises partial populate, `progress()` counts,
  full populate, and confirms no re-processing.

## Test plan

- [x] New `test_populate_antijoin_fk_inherited_pk` exercises the bug and the fix
- [x] Existing antijoin tests (`test_populate_antijoin_with_secondary_attrs`,
      `test_populate_antijoin_overlapping_attrs`) unchanged and should still pass
- [x] Pre-commit hooks (ruff, mypy, codespell) all pass
- [ ] CI integration tests against MySQL + PostgreSQL (this PR can't run locally
      — testcontainers needs Docker which isn't running on the contributor box)