### PR TITLE
docs: fix code formatting on rendered codecs API page

### DIFF
--- a/src/datajoint/codecs.py
+++ b/src/datajoint/codecs.py
@@ -8,29 +8,32 @@ semantics for complex Python objects.
 Codecs auto-register when subclassed - no decorator needed (Python 3.10+).
 
 Example:
-    class GraphCodec(dj.Codec):
-        name = "graph"
 
-        def get_dtype(self, is_store: bool) -> str:
-            return "<blob>"
+```python
+class GraphCodec(dj.Codec):
+    name = "graph"
 
-        def encode(self, graph, *, key=None, store_name=None):
-            return {'nodes': list(graph.nodes()), 'edges': list(graph.edges())}
+    def get_dtype(self, is_store: bool) -> str:
+        return "<blob>"
 
-        def decode(self, stored, *, key=None):
-            import networkx as nx
-            G = nx.Graph()
-            G.add_nodes_from(stored['nodes'])
-            G.add_edges_from(stored['edges'])
-            return G
+    def encode(self, graph, *, key=None, store_name=None):
+        return {'nodes': list(graph.nodes()), 'edges': list(graph.edges())}
 
-    # Then use in table definitions:
-    class MyTable(dj.Manual):
-        definition = '''
-        id : uint16
-        ---
-        data : <graph>
-        '''
+    def decode(self, stored, *, key=None):
+        import networkx as nx
+        G = nx.Graph()
+        G.add_nodes_from(stored['nodes'])
+        G.add_edges_from(stored['edges'])
+        return G
+
+# Then use in table definitions:
+class MyTable(dj.Manual):
+    definition = '''
+    id : uint16
+    ---
+    data : <graph>
+    '''
+```
 """
 
 from __future__ import annotations
@@ -85,20 +88,24 @@ class Codec(ABC):
     ...         G.add_edges_from(stored['edges'])
     ...         return G
 
-    Use in table definitions::
+    Use in table definitions:
 
-        class Connectivity(dj.Manual):
-            definition = '''
-            id : uint16
-            ---
-            graph_data : <graph>
-            '''
+    ```python
+    class Connectivity(dj.Manual):
+        definition = '''
+        id : uint16
+        ---
+        graph_data : <graph>
+        '''
+    ```
 
-    Skip auto-registration for abstract base classes::
+    Skip auto-registration for abstract base classes:
 
-        class ExternalOnlyCodec(dj.Codec, register=False):
-            '''Abstract base - not registered.'''
-            ...
+    ```python
+    class ExternalOnlyCodec(dj.Codec, register=False):
+        '''Abstract base - not registered.'''
+        ...
+    ```
     """
 
     name: str | None = None  # Must be set by concrete subclasses
@@ -520,18 +527,26 @@ def decode_attribute(attr, data, squeeze: bool = False, connection=None):
     Decode raw database value using attribute's codec or native type handling.
 
     This is the central decode function used by all fetch methods. It handles:
-    - Codec chains (e.g., <blob@store> → <hash> → bytes)
+
+    - Codec chains (e.g., ``<blob@store>`` → ``<hash>`` → ``bytes``)
     - Native type conversions (JSON, UUID)
-    - Object storage downloads (via config["download_path"])
+    - Object storage downloads (via ``config["download_path"]``)
 
-    Args:
-        attr: Attribute from the table's heading.
-        data: Raw value fetched from the database.
-        squeeze: If True, remove singleton dimensions from numpy arrays.
-        connection: Connection instance for config access. If provided,
-            ``connection._config`` is passed to codecs via the key dict.
+    Parameters
+    ----------
+    attr : Attribute
+        Attribute from the table's heading.
+    data : any
+        Raw value fetched from the database.
+    squeeze : bool, optional
+        If True, remove singleton dimensions from numpy arrays.
+    connection : Connection, optional
+        Connection instance for config access. If provided,
+        ``connection._config`` is passed to codecs via the key dict.
 
-    Returns:
+    Returns
+    -------
+    any
         Decoded Python value.
     """
     import json


### PR DESCRIPTION
## Summary

[`https://docs.datajoint.com/api/datajoint/codecs/`](https://docs.datajoint.com/api/datajoint/codecs/) renders docstring code as plain prose in three places. The page is built by `mkdocstrings` with `docstring_style: numpy` and Markdown-flavored bodies, so reST and Google-style syntax don't get parsed.

| Where | Was | Now |
|---|---|---|
| `Codec` class docstring (two examples) | reST `::` literal blocks | Markdown fenced code blocks |
| `decode_attribute` | Google-style `Args:` / `Returns:` (parsed as paragraphs) | NumPy `Parameters` / `Returns` with dashes (renders as a parameter table) |
| Module-level `Example:` | 4-space-indented Python (worked by accident) | Markdown fenced code block |

No behavior change — docstrings only.

## Test plan
- [ ] After merge + docs rebuild, confirm `codecs` API page:
  - the two examples under `Codec` ("Use in table definitions" / "Skip auto-registration") render as Python code blocks (no literal `::`)
  - `decode_attribute` shows `attr`, `data`, `squeeze`, `connection` in a parameter table consistent with sibling functions
  - the module-level `Example:` Python sample renders as a fenced code block
- [x] `python -c "import datajoint.codecs"` still imports cleanly
- [x] `mypy src/datajoint/codecs.py` clean (pre-existing unrelated failure in `storage_adapter.py:98` was skipped on commit; CI lint doesn't gate on mypy)

## Note on the unrelated mypy failure
Local pre-commit's mypy hook fails on `storage_adapter.py:98` (a `Deprecated.get()` typing shim for older `importlib.metadata`). That error exists on master and is not enforced by CI (`.github/workflows/lint.yaml` only runs codespell + ruff + ruff-format). Skipped with `SKIP=mypy git commit` per the documented pattern at the top of `.pre-commit-config.yaml`. Happy to file a separate PR for the typing shim if you'd like.