### PR TITLE
docs: extend datajoint.migrate timeline to 2.4 or 2.5

### DIFF
--- a/src/datajoint/migrate.py
+++ b/src/datajoint/migrate.py
@@ -7,8 +7,8 @@ explicit `<blob>` type declarations.
 
 .. note::
     This module is provided temporarily to assist with migration from pre-2.0.
-    It will be deprecated in DataJoint 2.1 and removed in 2.3.
-    Complete your migrations while on DataJoint 2.0.
+    It is scheduled for removal in DataJoint 2.4 or 2.5.
+    Complete your migrations while on DataJoint 2.3 or earlier.
 
 Note on Terminology
 -------------------
@@ -32,8 +32,8 @@ from .version import __version__
 # Show deprecation warning starting in 2.1
 if Version(__version__) >= Version("2.1"):
     warnings.warn(
-        "datajoint.migrate is deprecated and will be removed in DataJoint 2.3. "
-        "Complete your schema migrations before upgrading.",
+        "datajoint.migrate is deprecated and is scheduled for removal in DataJoint 2.4 or 2.5. "
+        "Complete your schema migrations while on DataJoint 2.3 or earlier.",
         DeprecationWarning,
         stacklevel=2,
     )


### PR DESCRIPTION
## Summary

The deprecation timeline in `src/datajoint/migrate.py` was still pointing at a "removed in 2.3 / migrate while on 2.0" plan that has since slipped — the module is present at 2.2.x and 2.3 is shipping with it intact. Update both the module docstring and the runtime `DeprecationWarning` text to match the current plan.

| | Was | Now |
|---|---|---|
| Removal target | 2.3 | **2.4 or 2.5** |
| Safe migration window | while on 2.0 | **while on 2.3 or earlier** |

Both the docstring `.. note::` block and the `warnings.warn(...)` message are updated together.

Pairs with [datajoint-docs#176](https://github.com/datajoint/datajoint-docs/pull/176), which makes the matching change to the `Migrate to DataJoint 2.0` how-to.

## Test plan
- [x] `python -c "import warnings; warnings.simplefilter('always'); import datajoint.migrate"` shows the new warning text
- [x] No functional/behavior change

## Note on mypy
Local pre-commit's mypy hook fails on a pre-existing unrelated error in `storage_adapter.py:98` (a typing shim for older `importlib.metadata`). Not enforced by CI (`lint.yaml` only runs codespell + ruff + ruff-format). Skipped with `SKIP=mypy git commit` per the documented pattern at the top of `.pre-commit-config.yaml`. Same workaround used in #1455.