### PR TITLE
fix: declare packaging as an explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "pydot",
   "fsspec>=2023.1.0",
   "pydantic-settings>=2.0.0",
+  "packaging",
 ]
 
 requires-python = ">=3.10,<3.14"


### PR DESCRIPTION
## Summary

`src/datajoint/migrate.py` imports `from packaging.version import Version`, but `packaging` is not declared in `pyproject.toml` dependencies. None of the declared deps pull it in transitively, so a fresh `pip install datajoint` into a clean Python 3.12+ venv (where the venv no longer ships setuptools by default) leaves `packaging` uninstalled and `import datajoint` raises:

```
ModuleNotFoundError: No module named 'packaging'
```

Pre-existing bug — reproduces on 2.2.2 and 2.2.3 — but became user-visible with Python 3.12's leaner venvs.

## Reproducer

```bash
python3.12 -m venv /tmp/dj-test
/tmp/dj-test/bin/pip install datajoint==2.2.3
/tmp/dj-test/bin/python -c "import datajoint as dj; print(dj.__version__)"
# ModuleNotFoundError: No module named 'packaging'
```

## Fix

Adds `packaging` to the dependencies list in `pyproject.toml`. No version pin since `migrate.py` uses only the basic `Version` class, which has been stable across the package's history.

## Release target

Candidate for 2.2.4 (patch fixing a real `import datajoint` regression in clean Python 3.12 venvs).

## Test plan

- [x] Reproduce the failure on 2.2.3 in a clean Python 3.12 venv
- [ ] After this PR's wheel is built: confirm `import datajoint` succeeds in the same reproducer
- [ ] Pre-commit hooks pass