### PR TITLE
feat: export StorageAdapter and get_storage_adapter at top level

### DIFF
--- a/src/datajoint/__init__.py
+++ b/src/datajoint/__init__.py
@@ -51,6 +51,9 @@ __all__ = [
     "get_codec",
     "ObjectRef",
     "NpyRef",
+    # Storage Adapter API
+    "StorageAdapter",
+    "get_storage_adapter",
     # Other
     "errors",
     "migrate",
@@ -82,6 +85,7 @@ from .expression import AndList, Not, Top, U
 from .instance import Instance, _ConfigProxy, _get_singleton_connection, _global_config, _check_thread_safe
 from .logging import logger
 from .objectref import ObjectRef
+from .storage_adapter import StorageAdapter, get_storage_adapter
 from .schemas import _Schema, VirtualModule, list_schemas, virtual_schema
 from .autopopulate import AutoPopulate
 from .jobs import Job


### PR DESCRIPTION
## Summary

The Storage Adapter spec ([datajoint-docs#172](https://github.com/datajoint/datajoint-docs/pull/172)) documents `dj.StorageAdapter` as the public base class and `dj.get_storage_adapter()` as the lookup helper, but they were not exposed via the top-level namespace in 2.2.3 — plugin authors following the spec literally hit:

```
AttributeError: module 'datajoint' has no attribute 'StorageAdapter'
```

Surfaced by Milagros in her review of #172 (item #1).

## Fix

Adds the two public symbols to `src/datajoint/__init__.py` (both `__all__` and the import line):

- `StorageAdapter` — ABC defined in `src/datajoint/storage_adapter.py`
- `get_storage_adapter(protocol)` — lookup helper

The private `_discover_adapters` helper is intentionally not exported.

## Smoke test

```bash
python -c "import datajoint as dj; print(dj.StorageAdapter, dj.get_storage_adapter)"
# <class 'datajoint.storage_adapter.StorageAdapter'>
# <function get_storage_adapter at 0x...>
```

## Release target

Candidate for 2.2.4 (alongside #1461 settings.py marker refresh, #1462 packaging dep fix).

## Test plan

- [x] `import datajoint as dj; dj.StorageAdapter` returns the class
- [x] `dj.get_storage_adapter` is callable
- [x] Pre-commit hooks (ruff, ruff-format, mypy, codespell) pass