### PR TITLE
chore: bump version.py to 2.3.0.dev + refresh RELEASE_MEMO

### DIFF
--- a/RELEASE_MEMO.md
+++ b/RELEASE_MEMO.md
@@ -4,7 +4,7 @@
 
 | Branch | Purpose | Version |
 |--------|---------|---------|
-| `master` | Main development | 2.1.x |
+| `master` | Main development | 2.3.x |
 | `maint/2.0` | Maintenance releases | 2.0.x |
 
 For 2.0.x bugfixes:

--- a/src/datajoint/version.py
+++ b/src/datajoint/version.py
@@ -1,4 +1,4 @@
 # version bump auto managed by Github Actions:
 # label_prs.yaml(prep), release.yaml(bump), post_release.yaml(edit)
 # manually set this version will be eventually overwritten by the above actions
-__version__ = "2.2.4"
+__version__ = "2.3.0.dev"


### PR DESCRIPTION
## Summary

Part of T18 (cross-cutting 2.3 release plumbing).

| File | Change |
|---|---|
| \`src/datajoint/version.py\` | \`2.2.4\` → \`2.3.0.dev\` |
| \`RELEASE_MEMO.md\` | Branch table: \`master\` version \`2.1.x\` (stale; predated the 2.1 and 2.2 release lines) → \`2.3.x\` |

The GitHub Actions release flow auto-overwrites \`version.py\` at tag time, but the dev marker matters mid-cycle: it tells anyone reading the file (including downstream tools that parse \`__version__\`) what the next release target is.

## Test plan

- [x] No behavior change; trivial value bump
- [ ] CI green (lint, test matrix, unit-tests)