### PR TITLE
ci(release-drafter): escape @ and # in release-note PR titles

### DIFF
--- a/.github/release_drafter.yaml
+++ b/.github/release_drafter.yaml
@@ -28,7 +28,7 @@ categories:
   - title: '📝 Documentation'
     label: 'documentation'
 change-template: '- $TITLE(#$NUMBER)@$AUTHOR'
-change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+change-title-escapes: '\<*_&@#' # escape @ and # so decorator/issue refs in PR titles (e.g. `@schema`) don't render as spurious mentions/links in release notes.
 template: |
   $CHANGES
 


### PR DESCRIPTION
### Problem
On the drafted **v2.3.0** release notes, `@schema` from PR #1467's title (*"refresh ~lineage on every `@schema` decoration"*) rendered as a live GitHub user mention, so **"Schema" showed up as a contributor/co-author** on the release. Same mechanism auto-links the `#1425`/`#1429`/… issue refs inside conventional-commit titles.

### Cause
`release_drafter.yaml`'s `change-title-escapes` was `'\<*_&'` — it omits `@` and `#`, so mention/issue text inside PR **titles** renders live. The config comment already notes: *"You can add # and @ to disable mentions."*

### Fix
`change-title-escapes: '\<*_&@#'`. Title text stays literal; the template's real `@$AUTHOR` credit and the `(#$NUMBER)` PR link are unaffected (those come from the template, not the escaped title).

Takes effect the next time the draft workflow runs. The current v2.3.0 draft body was hand-corrected separately for this release.