### PR TITLE
ci(pre-commit): pin numpy<2.2 for mypy stub compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,4 +45,6 @@ repos:
         - types-PyMySQL
         - types-tqdm
         - pandas-stubs
-        - numpy
+        # numpy>=2.2 stubs use PEP 695 `type` statements, which mypy rejects
+        # when type-checking against python_version 3.10 (the project floor).
+        - numpy<2.2


### PR DESCRIPTION
The `mypy` pre-commit hook fails on a clean checkout:

```
numpy/__init__.pyi:737: error: Type statement is only supported in Python 3.12 and greater  [syntax]
```

## Cause
The hook’s `additional_dependencies` pull an unpinned `numpy` (currently 2.5.1). numpy ≥2.2 ships type stubs written with PEP 695 `type` statements. mypy refuses that syntax when type-checking against `python_version = "3.10"` (our support floor, per `[tool.mypy]`), so the hook errors out before checking any of our code. Bumping mypy (tested through v1.18.2) does not help — the gate is the target version, not the mypy release.

## Fix
Pin the mypy hook’s stub dependency to `numpy<2.2`. This only affects the stubs used for type-checking; runtime numpy is unaffected (unpinned elsewhere). Keeping the target at 3.10 preserves floor coverage rather than masking it by raising `python_version`.

## Verification
- `pre-commit run --all-files` → all hooks pass (mypy included).