### PR TITLE
docs(#1484): document pair-keyed part-to-master invariant in _propagate_restrictions

### DIFF
--- a/src/datajoint/diagram.py
+++ b/src/datajoint/diagram.py
@@ -696,6 +696,12 @@ class Diagram(nx.DiGraph):  # noqa: C901
         Walks the dependency graph in topological order, applying
         propagation rules at each edge. Only processes descendants of
         start_node to avoid duplicate propagation when chaining.
+
+        Invariant (``part_integrity="cascade"``): each restricted Part fires
+        its own upward walk to its Master exactly once — deduplicated per
+        ``(part, master)`` pair (``visited_part_master_pairs``), not per
+        master — so a Master reached through several restricted Parts is
+        restricted from every one of them.
         """
 
         sorted_nodes = topo_sort(self)


### PR DESCRIPTION
Addresses @MilagrosMarin's review note on #1484: the `_propagate_restrictions` method docstring didn't mention the pair-keyed dedup invariant — only the inline comment on `visited_part_master_pairs` did. This adds a one-line docstring note that under `part_integrity="cascade"` each restricted Part fires its own upward walk to its Master exactly once, deduplicated per `(part, master)` pair (not per master).

Docstring-only; no behavior change.