### PR TITLE
docs: clarify _propagate_part_to_master materialization is delete-order, not just MySQL 1093

### DIFF
--- a/src/datajoint/diagram.py
+++ b/src/datajoint/diagram.py
@@ -935,13 +935,23 @@ class Diagram(nx.DiGraph):  # noqa: C901
         so we read props from one and skip the alias node when walking.
 
         After the walk, the master's restriction is **materialized** to a
-        literal value tuple via ``to_arrays()``. Without materialization, a
-        subsequent forward cascade from the master back down to its parts
-        would produce a self-referential subquery (MySQL error 1093, since
-        the master's restriction depends on the same Part being deleted).
-        Materializing converts the restriction into a static value set, so
-        the forward cascade generates ``WHERE ... IN (literal-list)`` rather
-        than ``WHERE ... IN (SELECT ... FROM <part>)``.
+        literal value tuple via ``to_arrays()``. This is required for
+        correctness on **every backend**, not merely to avoid MySQL error
+        1093. ``Table.delete`` executes per-table deletes in reverse
+        topological order (leaves first), so the Part is deleted *before* the
+        Master. The master's restriction is derived from that Part, so if it
+        were left as a live subquery it would evaluate to empty once the Part
+        rows are gone — and the Master would silently escape deletion,
+        reintroducing the very compositional-integrity violation this walk
+        exists to prevent. Materializing the master's primary keys to a static
+        value set at plan time (before any rows are deleted) captures them
+        while the Part still exists, so the master delete becomes
+        ``WHERE ... IN (literal-list)``.
+
+        (Secondary benefit: the literal set also sidesteps the self-referential
+        ``WHERE ... IN (SELECT ... FROM <part>)`` subquery that MySQL rejects
+        with error 1093 — but note the delete-order reason above applies to
+        PostgreSQL too, so this must not be made a MySQL-only optimization.)
 
         Limitations
         -----------


### PR DESCRIPTION
Follow-up from the 2.3.1 `dj.Diagram` review. The `_propagate_part_to_master` docstring justified the `to_arrays()` master materialization purely as a MySQL-1093 workaround. That framing is incomplete and risks a well-intentioned "PostgreSQL has no 1093, so skip it" change that would be a **silent integrity/data-loss bug**.

The real, backend-independent reason: `Table.delete` deletes per-table in reverse-topological order (`table.py:1089`), so a Part is deleted **before** its Master. The Master's restriction is derived from that Part; left as a live subquery it evaluates to empty once the Part is gone, and the Master escapes deletion — reintroducing the compositional-integrity violation the upward walk exists to prevent. Materializing the Master PKs at plan time captures them before any deletion. MySQL 1093 is a secondary consequence.

Docstring-only; no behavior change.