### PR TITLE
ci: test MySQL 8.0 and 8.4 (LTS) in the matrix; parameterize MySQL image

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,11 +30,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Exercise both ends of the supported range (requires-python
-        # >=3.10,<3.15). The version-pinned pixi environments are defined in
-        # pyproject.toml under [tool.pixi.environments].
+        # Python: exercise both ends of the supported range (requires-python
+        # >=3.10,<3.15); version-pinned pixi environments live in pyproject.toml
+        # under [tool.pixi.environments].
         environment: [test-py310, test-py314]
-    name: test (${{ matrix.environment }})
+        # MySQL: exercise both LTS lines we support / that AWS RDS runs. 8.0 uses
+        # the datajoint image (SSL configured); 8.4 uses the official image (TLS
+        # tests already skip outside external containers). See #1497.
+        mysql-image: ["datajoint/mysql:8.0", "mysql:8.4"]
+    name: test (${{ matrix.environment }}, mysql=${{ matrix.mysql-image }})
     steps:
       - uses: actions/checkout@v4
 
@@ -46,6 +50,8 @@ jobs:
           environments: ${{ matrix.environment }}
 
       - name: Run tests
+        env:
+          DJ_TEST_MYSQL_IMAGE: ${{ matrix.mysql-image }}
         run: pixi run -e ${{ matrix.environment }} test-cov
 
   # Unit tests run without containers (faster feedback)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,7 +114,10 @@ def mysql_container():
     from testcontainers.mysql import MySqlContainer
 
     container = MySqlContainer(
-        image="datajoint/mysql:8.0",  # Use datajoint image which has SSL configured
+        # Default: the datajoint image (SSL configured, for TLS tests under
+        # external containers). CI overrides via DJ_TEST_MYSQL_IMAGE to exercise
+        # multiple supported server versions (e.g. the 8.4 LTS line). See #1497.
+        image=os.environ.get("DJ_TEST_MYSQL_IMAGE", "datajoint/mysql:8.0"),
         username="root",
         password="password",
         dbname="test",


### PR DESCRIPTION
Closes the gap where CI only tested MySQL 8.0 while AWS RDS runs the **8.4 LTS** line (see #1497).

**Change:**
- `tests/conftest.py`: MySQL testcontainer image is now read from `DJ_TEST_MYSQL_IMAGE` (default `datajoint/mysql:8.0` — no local behavior change).
- `.github/workflows/test.yaml`: adds a `mysql-image` matrix axis — `datajoint/mysql:8.0` and official `mysql:8.4` — crossed with the existing Python axis (3.10/3.14).

**Why official `mysql:8.4`:** there is no `datajoint/mysql:8.4` image published; the only thing the datajoint image adds is SSL certs for the TLS tests, and those already `skipif` outside external containers — so they skip in the testcontainers matrix on both legs regardless. Behavioral (SQL/type/cascade) coverage on 8.4 — the RDS-critical part — runs fully.

**Follow-ups (not blocking):**
- Publish a `datajoint/mysql:8.4` image if we want TLS parity on the 8.4 leg.
- Once this lands, flip the "Tested in CI" cell in datajoint-docs#209 from "8.0 (8.4 in progress)" to "8.0, 8.4".
- Matrix is a full 2×2; can be trimmed with `exclude` if CI minutes are a concern.

Refs #1497. **Scoped out:** MySQL 9.x (Innovation, non-LTS, not RDS).