### PR TITLE
docs(diagram): document restrict is downstream-only (no part->master walk-up)

### DIFF
--- a/src/datajoint/diagram.py
+++ b/src/datajoint/diagram.py
@@ -663,6 +663,13 @@ class Diagram(nx.DiGraph):  # noqa: C901
 
         Cannot be called on a Diagram produced by ``Diagram.cascade()``.
 
+        Propagation is strictly downstream. Unlike ``cascade``'s
+        ``part_integrity="cascade"``, ``restrict`` never walks upward from a
+        Part to its Master: an export is seeded at root entities and flows
+        down, so a Master (with all of its Parts) is always included before
+        its Parts and no Part foreign key dangles. Use :meth:`trace` for
+        upstream / ancestor closure.
+
         Parameters
         ----------
         table_expr : QueryExpression
@@ -796,6 +803,14 @@ class Diagram(nx.DiGraph):  # noqa: C901
                         # which assumed shared PK attribute names. See #1429.
                         # Deduped per (part, master) pair — every restricted Part
                         # of a master contributes its own master rows.
+                        #
+                        # This upward walk is intentionally exclusive to cascade
+                        # delete. `restrict` (mode="restrict") is downstream-only by
+                        # design: export is seeded at roots and flows down, so a
+                        # Master is always included (with all its Parts) before its
+                        # Parts and no Part FK dangles — a read-only slice has no
+                        # compositional-atomicity obligation. Do not enable this for
+                        # restrict.
                         if part_integrity == "cascade" and mode == "cascade":
                             master_name = extract_master(target)
                             if (


### PR DESCRIPTION
From the 2.3.1 `dj.Diagram` review (master-part focus). Makes explicit — in the `restrict` docstring and at the upward-walk guard in `_propagate_restrictions` — that `restrict` is **downstream-only** and never walks up from a Part to its Master.

Rationale: the part→master upward walk is exclusive to `cascade` delete, which **mutates** and must be compositionally atomic regardless of seed. `restrict` reads a slice seeded at roots and flows down, so a Master is always included (with all its Parts) before its Parts — no Part FK dangles, and no atomicity obligation. Upstream/ancestor closure is `trace`'s job.

**No behavior change** — the `mode=="cascade"` guard already enforced this. The added comment prevents it from being accidentally enabled for restrict in a future change. Docstring + comment only.