### PR TITLE
chore(release-flow): stale doc pointers, RELEASE_MEMO cleanup, and dead badge step

### DIFF
--- a/.github/workflows/post_draft_release_published.yaml
+++ b/.github/workflows/post_draft_release_published.yaml
@@ -47,18 +47,6 @@ jobs:
           git add src/datajoint/version.py
           git commit -m "Update version.py to $VERSION"
           echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
-      - name: Update README.md badge
-        run: |
-          # commits since the last release
-          NEW_HREF="https://github.com/datajoint/datajoint-python/compare/${{ github.event.release.tag_name }}...master"
-          NEW_SRC="https://img.shields.io/github/commits-since/datajoint/datajoint-python/${{ github.event.release.tag_name }}?color=red"
-          # Update href in the <a> tag
-          sed -i 's|\(<a id="commit-since-release-link"[^>]*href="\)[^"]*\(".*\)|\1'"$NEW_HREF"'\2|' README.md
-          # Update src in the <img> tag
-          sed -i 's|\(<img id="commit-since-release-img"[^>]*src="\)[^"]*\(".*\)|\1'"$NEW_SRC"'\2|' README.md
-          git add README.md
-          # Only commit if there are changes (handles re-runs gracefully)
-          git diff --cached --quiet README.md || git commit -m "Update README.md badge to ${{ github.event.release.tag_name }}"
       - name: Set up Python ${{matrix.py_ver}}
         uses: actions/setup-python@v5
         with:

--- a/RELEASE_MEMO.md
+++ b/RELEASE_MEMO.md
@@ -5,12 +5,6 @@
 | Branch | Purpose | Version |
 |--------|---------|---------|
 | `master` | Main development | 2.3.x |
-| `maint/2.0` | Maintenance releases | 2.0.x |
-
-For 2.0.x bugfixes:
-1. Commit to `maint/2.0`
-2. Tag and release as v2.0.x
-3. Cherry-pick to master if applicable
 
 ---
 
@@ -68,10 +62,11 @@ The release drafter uses PR labels to categorize changes:
 
 | Label | Category |
 |-------|----------|
-| `breaking` | BREAKING CHANGES |
-| `enhancement` | Added |
-| `bug` | Fixed |
-| `documentation` | (usually excluded) |
+| `breaking` | 💥 Breaking Changes |
+| `feature` | 🚀 Features |
+| `enhancement` | ⚡️ Enhancements |
+| `bug` | 🐛 Bug Fixes |
+| `documentation` | 📝 Documentation |
 
 Ensure PRs have appropriate labels before merging.
 

--- a/RELEASE_MEMO.md
+++ b/RELEASE_MEMO.md
@@ -210,6 +210,7 @@ After build completes:
 
 - @datajointbot
 - @dimitri-yatsenko
+- @MilagrosMarin
 - @ttngu207
 
 ## Links

--- a/RELEASE_MEMO.md
+++ b/RELEASE_MEMO.md
@@ -4,7 +4,7 @@
 
 | Branch | Purpose | Version |
 |--------|---------|---------|
-| `master` | Main development | 2.1.x |
+| `master` | Main development | 2.3.x |
 | `maint/2.0` | Maintenance releases | 2.0.x |
 
 For 2.0.x bugfixes:

--- a/src/datajoint/version.py
+++ b/src/datajoint/version.py
@@ -1,4 +1,4 @@
 # version bump auto managed by Github Actions:
-# label_prs.yaml(prep), release.yaml(bump), post_release.yaml(edit)
+# draft_release.yaml (draft), post_draft_release_published.yaml (bump + PR)
 # manually set this version will be eventually overwritten by the above actions
 __version__ = "2.3.1"


### PR DESCRIPTION
Addresses findings 2, 3, and 4 from #1503, plus follow-up items from Dimitri's review. Leaves finding 1 (version.py version-at-tag timing) open — that one needs a maintainer decision on approach (sed before tag / retag / hatch-vcs).

## Changes

**`src/datajoint/version.py`** — header comment listed three workflow files that don't exist (`label_prs.yaml`, `release.yaml`, `post_release.yaml`); updated to name the actual workflows (`draft_release.yaml`, `post_draft_release_published.yaml`).

**`RELEASE_MEMO.md`**
- **Branch Structure table**: `master` row was listed as `2.1.x` (stale by two minor versions); bumped to `2.3.x`. Removed the `maint/2.0` row and the "For 2.0.x bugfixes:" block — no longer supporting 2.0.x. Leaves the actual `maint/2.0` git branch alone; this is doc-only.
- **PR-labels table**: category names were "Keep a Changelog"-style (`BREAKING CHANGES`, `Added`, `Fixed`, `documentation | (usually excluded)`); updated to match `release_drafter.yaml` verbatim (`💥 Breaking Changes`, `⚡️ Enhancements`, `🐛 Bug Fixes`, `📝 Documentation`). Added the missing `feature` → `🚀 Features` row.
- **Maintainers**: added `@MilagrosMarin`.

**`.github/workflows/post_draft_release_published.yaml`** — removed the "Update README.md badge" step. Its two `sed` calls targeted `<a id="commit-since-release-link">` and `<img id="commit-since-release-img">` — both elements were removed from `README.md` in [`ff04914c`](https://github.com/datajoint/datajoint-python/commit/ff04914c) (2026-01-04, "docs: Update README with Relational Workflow Model and OAS"). Every release since has run empty `sed`s guarded by a `git-diff --cached --quiet || git commit` no-op check.

If you'd prefer to keep the README-badge step and restore the badge markup to README instead, happy to swap the approach.

Closes findings 2, 3, 4 in #1503.
