### PR TITLE
docs(codecs): fix stale storage-path and hash-algorithm docstrings

### DIFF
--- a/src/datajoint/builtin_codecs/hash.py
+++ b/src/datajoint/builtin_codecs/hash.py
@@ -1,5 +1,5 @@
 """
-Hash-addressed storage codec with SHA256 deduplication.
+Hash-addressed storage codec with MD5-based deduplication.
 """
 
 from __future__ import annotations
@@ -12,11 +12,13 @@ from ..errors import DataJointError
 
 class HashCodec(Codec):
     """
-    Hash-addressed storage with SHA256 deduplication.
+    Hash-addressed storage with content-addressed deduplication.
 
     The ``<hash@>`` codec stores raw bytes using hash-addressed storage.
-    Data is identified by its SHA256 hash and stored in a hierarchical directory:
-    ``_hash/{hash[:2]}/{hash[2:4]}/{hash}``
+    Data is identified by a 26-character Base32-encoded MD5 digest of the
+    content, and stored at ``{hash_prefix}/{schema}/{hash}`` (``hash_prefix``
+    defaults to ``_hash``). Stores with subfolding configured insert
+    additional path segments: ``{hash_prefix}/{schema}/{fold1}/{fold2}/{hash}``.
 
     The database column stores JSON metadata: ``{hash, store, size}``.
     Duplicate content is automatically deduplicated across all tables.

--- a/src/datajoint/builtin_codecs/npy.py
+++ b/src/datajoint/builtin_codecs/npy.py
@@ -226,7 +226,9 @@ class NpyCodec(SchemaCodec):
     Schema-addressed storage for numpy arrays as .npy files.
 
     The ``<npy@>`` codec stores numpy arrays as standard ``.npy`` files
-    using schema-addressed paths: ``{schema}/{table}/{pk}/{attribute}.npy``.
+    using schema-addressed paths: ``{schema_prefix}/{schema}/{table}/{pk}/{attribute}_{token}.npy``
+    (``schema_prefix`` defaults to ``_schema``; ``{token}`` is a random
+    per-write suffix).
     Arrays are fetched lazily via ``NpyRef``, which provides metadata access
     without I/O and transparent numpy integration via ``__array__``.
 
@@ -269,7 +271,7 @@ class NpyCodec(SchemaCodec):
 
     Storage Details:
         - File format: NumPy .npy (version 1.0 or 2.0)
-        - Path: ``{schema}/{table}/{pk}/{attribute}.npy``
+        - Path: ``{schema_prefix}/{schema}/{table}/{pk}/{attribute}_{token}.npy``
         - Database column: JSON with ``{path, store, dtype, shape}``
 
     Deletion: Requires garbage collection via ``dj.gc.GarbageCollector``.

--- a/src/datajoint/builtin_codecs/object.py
+++ b/src/datajoint/builtin_codecs/object.py
@@ -15,7 +15,9 @@ class ObjectCodec(SchemaCodec):
     Schema-addressed storage for files and folders.
 
     The ``<object@>`` codec provides managed file/folder storage using
-    schema-addressed paths: ``{schema}/{table}/{pk}/{field}/``. This creates
+    schema-addressed paths: ``{schema_prefix}/{schema}/{table}/{pk}/{field}_{token}/``
+    (``schema_prefix`` defaults to ``_schema``; ``{token}`` is a random
+    per-write suffix). This creates
     a browsable organization in object storage that mirrors the database schema.
 
     Unlike hash-addressed storage (``<hash@>``), each row has its own unique path
@@ -51,7 +53,7 @@ class ObjectCodec(SchemaCodec):
     Storage Structure:
         Objects are stored at::
 
-            {store_root}/{schema}/{table}/{pk}/{field}/
+            {store_root}/{schema_prefix}/{schema}/{table}/{pk}/{field}_{token}/
 
     Deletion: Requires garbage collection via ``dj.gc.GarbageCollector``.
 


### PR DESCRIPTION
Three built-in codec class docstrings still describe pre-2.3.1 storage layouts, and `HashCodec` additionally names the wrong hash algorithm. Every one of these docstrings had its "Deletion:" line touched in v2.3.1 (`dj.gc.collect()` → `dj.gc.GarbageCollector`), but the surrounding path claims were left stale — so a reader sees a locally-updated block and assumes it's current.

## Changes

**`src/datajoint/builtin_codecs/hash.py`** (module docstring + class summary + storage description)
- "SHA256 deduplication" → "MD5-based deduplication" / "content-addressed deduplication". The actual algorithm is `md5(data)` + `base32encode`, then lowercased and stripped of `=` padding (`hash_registry.py:65-67`).
- Layout `_hash/{hash[:2]}/{hash[2:4]}/{hash}` → `{hash_prefix}/{schema}/{hash}` (with `hash_prefix` defaulting to `_hash`; stores with subfolding get additional segments). No `[:2]/[:4]` character split exists in the code.

**`src/datajoint/builtin_codecs/npy.py`** (class summary + Storage Details)
- Path `{schema}/{table}/{pk}/{attribute}.npy` → `{schema_prefix}/{schema}/{table}/{pk}/{attribute}_{token}.npy`. The `schema_prefix` section and `_{token}` suffix are what `build_object_path` now writes (`storage.py:191-278`) after #1479's prefix-configuration work.

**`src/datajoint/builtin_codecs/object.py`** (class summary + Storage Structure)
- Same drift as NpyCodec, as a directory rather than a file.

## Sibling docstrings already correct

`src/datajoint/hash_registry.py:8-14` and `src/datajoint/gc.py:8-24` module docstrings already document the current layout — these three codec class docstrings are the outliers.

Docs-only.
