### PR TITLE
fix(gc): don't act on partial storage listings

### DIFF
--- a/src/datajoint/gc.py
+++ b/src/datajoint/gc.py
@@ -209,7 +209,7 @@ class GarbageCollector:
                     if not _BASE32_HASH.match(filename):
                         continue
                     file_path = f"{root}/{filename}"
-                    relative_path = file_path[len(full_root):].lstrip("/")
+                    relative_path = file_path[len(full_root) :].lstrip("/")
                     try:
                         stored[relative_path] = self.backend.fs.size(file_path)
                     except Exception as e:
@@ -258,7 +258,7 @@ class GarbageCollector:
                     # reclaimed with it. _is_covered() keeps a live object's
                     # manifest out of the orphan set.
                     file_path = f"{root}/{filename}"
-                    relative_path = file_path[len(full_root):].lstrip("/")
+                    relative_path = file_path[len(full_root) :].lstrip("/")
                     try:
                         stored[relative_path] = self.backend.fs.size(file_path)
                     except Exception as e:

--- a/src/datajoint/gc.py
+++ b/src/datajoint/gc.py
@@ -121,6 +121,10 @@ class GarbageCollector:
         spec = self.config.get_store_spec(store)
         self._hash_prefix = spec["hash_prefix"].strip("/")  # settings applies the "_hash" default
         self._schema_prefix = spec["schema_prefix"].strip("/")  # ... "_schema" default
+        # Per-collect() scan errors (walk failures in list_*_paths). Non-empty
+        # blocks destructive deletion in collect(dry_run=False). Reset at the
+        # start of each collect() call.
+        self._scan_errors: list[str] = []
 
     # ------------------------------------------------------------------ #
     # References — extracted from database metadata (per-schema connection)
@@ -205,15 +209,17 @@ class GarbageCollector:
                     if not _BASE32_HASH.match(filename):
                         continue
                     file_path = f"{root}/{filename}"
+                    relative_path = file_path[len(full_root):].lstrip("/")
                     try:
-                        relative_path = file_path.replace(full_root, "").lstrip("/")
                         stored[relative_path] = self.backend.fs.size(file_path)
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.warning(f"Could not size {file_path}: {e}")
+                        stored[relative_path] = 0
         except FileNotFoundError:
             pass  # the hash section does not exist yet
         except Exception as e:
             logger.warning(f"Error listing stored hashes: {e}")
+            self._scan_errors.append(f"list_hash_paths({schema_name}): {e}")
         return stored
 
     def list_schema_paths(self, schema_name: str) -> dict[str, int]:
@@ -252,15 +258,17 @@ class GarbageCollector:
                     # reclaimed with it. _is_covered() keeps a live object's
                     # manifest out of the orphan set.
                     file_path = f"{root}/{filename}"
-                    relative_path = file_path.replace(full_root, "").lstrip("/")
+                    relative_path = file_path[len(full_root):].lstrip("/")
                     try:
                         stored[relative_path] = self.backend.fs.size(file_path)
-                    except Exception:
+                    except Exception as e:
+                        logger.warning(f"Could not size {file_path}: {e}")
                         stored[relative_path] = 0
         except FileNotFoundError:
             pass  # this schema's section does not exist yet
         except Exception as e:
             logger.warning(f"Error listing stored schemas: {e}")
+            self._scan_errors.append(f"list_schema_paths({schema_name}): {e}")
         return stored
 
     # ------------------------------------------------------------------ #
@@ -327,6 +335,7 @@ class GarbageCollector:
         - hash_paths_deleted / schema_paths_deleted / deleted / bytes_freed (0 when
           dry_run) / errors / dry_run
         """
+        self._scan_errors = []  # reset per-call; populated by list_*_paths below
         # References can be gathered across all schemas at once: because paths
         # embed the schema, a file under schema X is only ever covered by an X
         # reference, so combined coverage equals per-schema coverage.
@@ -350,6 +359,12 @@ class GarbageCollector:
         errors = 0
 
         if not dry_run:
+            if self._scan_errors:
+                raise DataJointError(
+                    f"Refusing to delete: {len(self._scan_errors)} scan error(s) — "
+                    f"partial listing risks classifying live files as orphaned. "
+                    f"Errors: {self._scan_errors}"
+                )
             # The size maps from the scan above are reused for the byte tally —
             # no second listing pass.
             for path in orphaned_hash_paths:
@@ -393,5 +408,6 @@ class GarbageCollector:
             "deleted": hash_paths_deleted + schema_paths_deleted,
             "bytes_freed": bytes_freed,
             "errors": errors,
+            "scan_errors": list(self._scan_errors),
             "dry_run": dry_run,
         }

--- a/tests/integration/test_gc.py
+++ b/tests/integration/test_gc.py
@@ -762,3 +762,84 @@ class TestPerSchemaScoping:
         assert set(collector.list_hash_paths(b.database)) == b_hashes_before
         assert set(collector.list_schema_paths(b.database)) == b_paths_before
         assert len(b_obj()) == 1  # b's row (and its object) untouched
+
+
+class TestScanErrorGuard:
+    """A walk failure during list_*_paths (anything other than FileNotFoundError,
+    which just means the section doesn't exist yet) leaves the stored listing
+    partial. Comparing partial listings against complete reference sets would
+    classify live files as orphaned — silent data loss under dry_run=False.
+    The scan-error guard captures such errors and refuses to delete."""
+
+    def test_scan_errors_reset_between_collect_calls(self):
+        """_scan_errors is reset at the start of each collect() call, so an
+        error from a prior collect() never carries over into the next report."""
+        with ExitStack() as es:
+            for p in TestCollect._patch_data(TestCollect):
+                es.enter_context(p)
+            es.enter_context(patch("datajoint.gc.delete_path"))
+            collector = _mock_collector()
+            # Simulate a leftover error from a previous run.
+            collector._scan_errors = ["stale error from previous call"]
+
+            stats = collector.collect()  # dry_run=True
+
+        assert stats["scan_errors"] == [], "scan_errors must be reset at the start of collect()"
+        assert collector._scan_errors == [], "the collector's _scan_errors must be cleared for the new run"
+
+    def test_dry_run_false_raises_when_scan_errors_present(self):
+        """collect(dry_run=False) must refuse to delete when list_*_paths hit a
+        non-FileNotFoundError walk failure — partial listing means live files
+        could be misclassified as orphans."""
+        # Real walk failure: mock fs.walk on list_hash_paths to raise a
+        # non-FileNotFoundError, exercising the outer except that records the
+        # scan error.
+        with ExitStack() as es:
+            es.enter_context(patch.object(gc.GarbageCollector, "hash_references", return_value=set()))
+            es.enter_context(patch.object(gc.GarbageCollector, "schema_references", return_value=set()))
+
+            # Real list_hash_paths runs and hits fs.walk failure; list_schema_paths
+            # is stubbed to a clean empty listing so only the hash walk errors.
+            es.enter_context(patch.object(gc.GarbageCollector, "list_schema_paths", return_value={}))
+
+            collector = _mock_collector()
+            collector.backend.fs.walk.side_effect = PermissionError("s3 access denied")
+            collector.backend._full_path.return_value = "/root"
+
+            mock_delete = es.enter_context(patch("datajoint.gc.delete_path"))
+            with pytest.raises(DataJointError, match="Refusing to delete"):
+                collector.collect(dry_run=False)
+
+            # And no deletion happened.
+            mock_delete.assert_not_called()
+
+    def test_scan_errors_in_stats_dict(self):
+        """The returned stats dict always includes a 'scan_errors' key: empty
+        list on a clean scan, list of "<method>(<schema>): <exception>" strings
+        when a walk failed."""
+        # Clean case — scan_errors is an empty list.
+        with ExitStack() as es:
+            for p in TestCollect._patch_data(TestCollect):
+                es.enter_context(p)
+            es.enter_context(patch("datajoint.gc.delete_path"))
+            stats = _mock_collector().collect()
+
+        assert "scan_errors" in stats
+        assert stats["scan_errors"] == []
+
+        # Error case — list of strings identifying which listing failed.
+        with ExitStack() as es:
+            es.enter_context(patch.object(gc.GarbageCollector, "hash_references", return_value=set()))
+            es.enter_context(patch.object(gc.GarbageCollector, "schema_references", return_value=set()))
+            es.enter_context(patch.object(gc.GarbageCollector, "list_schema_paths", return_value={}))
+
+            collector = _mock_collector()
+            collector.schemas[0].database = "s"
+            collector.backend.fs.walk.side_effect = PermissionError("s3 access denied")
+            collector.backend._full_path.return_value = "/root"
+
+            stats = collector.collect()  # dry_run=True → returns rather than raising
+
+        assert len(stats["scan_errors"]) == 1
+        assert stats["scan_errors"][0].startswith("list_hash_paths(s):")
+        assert "s3 access denied" in stats["scan_errors"][0]


### PR DESCRIPTION
Fixes three compounding completeness bugs in `GarbageCollector.list_hash_paths` and `list_schema_paths` that could cause `collect(dry_run=False)` to silently delete live external-store files. Follow-up to the completeness-layer discussion on #1478.

## Changes

**1. `str.replace(full_root, "")` corrupts paths when the root string recurs**

Both `list_*_paths` derived relative paths as `file_path.replace(full_root, "").lstrip("/")` (`gc.py:209, 256`). `str.replace` replaces *every* occurrence, so if `full_root` reappears later in `file_path` — e.g., S3 bucket "store" + schema "store" → `full_root="store/"` recurs in `"store/_hash/store/xxx"` — the middle occurrence gets stripped too. The resulting relative key doesn't match the reference-side shape, so a live file falls into the orphan set. Real live files aren't destroyed (the corrupted key fails `backend.exists()`), but real orphans in affected schemas never get reclaimed. Uses `file_path[len(full_root):]` (prefix slice) instead.

**2. `fs.size` handling diverged silently between the two functions**

`list_hash_paths` wrapped `stored[relative_path] = fs.size(file_path)` in `except Exception: pass` — dropping the file from `stored` entirely, so an orphan invisible to `collect()` and quietly retained forever. `list_schema_paths` used `except Exception: stored[relative_path] = 0` — keeping it visible but counting 0 bytes toward `bytes_freed`. Neither logged. Both now keep the entry at 0 and log a warning.

**3. `fs.walk` errors returned a partial listing with no signal to `collect()`**

An S3 permission drop, expired token, transient 5xx, NFS unmount, etc. all present to `collect()` as an empty (or partial) `stored` dict. `orphaned = stored - referenced` then computes to `set()`, and the stats dict reports `orphaned_hash_paths: 0` — indistinguishable from a genuinely clean store. A user running nightly GC would see "nothing to reclaim" while their listing was silently failing.

Adds a `_scan_errors: list[str]` instance attribute on `GarbageCollector`. `list_*_paths` append to it when a walk fails (in addition to the existing `logger.warning`). `collect()` resets it at the start and, before deleting, refuses with a clear `DataJointError` if it's non-empty. The stats dict now includes `scan_errors: list[str]` — empty on clean runs.

## Behavior changes

- **`collect(dry_run=False)` raises `DataJointError` when a listing walk failed.** Real-store tests unaffected; would only surface in tests that mock `fs.walk` to raise (none currently do).
- **`fs.size` errors on the hash side now keep the entry at 0 (was: drop).** More conservative for orphan detection.
- **New `scan_errors: list[str]` field in the returned stats dict.** Additive; existing tests that check specific keys still work.

## Verification

Applied and tested locally in an isolated worktree:
- **`tests/integration/test_gc.py`**: 39/39 pass unchanged → **42/42 pass with fix** + 3 new `TestScanErrorGuard` tests (reset-between-calls, refuse-to-delete-on-scan-error, scan_errors-in-stats).
- **Unit tests**: 319/319 pass.
- **Full integration**: 626 pass / identical to baseline (1 pre-existing failure in `test_tls.py`, 5 pre-existing errors in `test_university.py` — both unrelated to `gc.py`).

## Scope note

Findings #1 (`_references` swallows per-table exceptions) and #2 (`Codec.referenced_paths` silent `[]` on bad input) from #1478 are structurally similar but touch different code paths (`_references()` and the codec API surface). Kept out of this PR to keep the scope tight — they could adopt the same `_scan_errors` mechanism in a follow-up.
