### PR TITLE
fix(release): derive version from git tag via hatch-vcs (#1503)

### DIFF
--- a/.github/workflows/post_draft_release_published.yaml
+++ b/.github/workflows/post_draft_release_published.yaml
@@ -12,9 +12,8 @@ run-name: Post ${{ github.event.release.name }}
 jobs:
   pypi-release:
     permissions:
-      # write permission is required to update version.py
+      # write permission is required to upload build artifacts as release assets
       contents: write
-      pull-requests: write
     # Use the oldest supported version to build, just in case there are issues
     # for our case, this doesn't matter that much, since the build is for 3.x
     strategy:
@@ -33,20 +32,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      # new release needs the updated version.py
-      - name: Update version.py
-        run: |
-          VERSION=$(echo "${{ github.event.release.name }}" | grep -oP '\d+\.\d+\.\d+')
-          sed -i "s/^__version__ = .*/__version__ = \"$VERSION\"/" src/datajoint/version.py
-          cat src/datajoint/version.py
-          # Commit the changes
-          BRANCH_NAME="update-version-$VERSION"
-          git switch -c $BRANCH_NAME
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
-          git add src/datajoint/version.py
-          git commit -m "Update version.py to $VERSION"
-          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          # Full history + tags so hatch-vcs can derive the version from the
+          # release tag. The checked-out ref is the tag itself, so the build
+          # reports exactly X.Y.Z — no version.py bump or follow-up PR needed.
+          fetch-depth: 0
       - name: Set up Python ${{matrix.py_ver}}
         uses: actions/setup-python@v5
         with:
@@ -108,17 +97,6 @@ jobs:
           asset_path: ${{env.DJ_SDIST_PATH}}
           asset_name: pip-datajoint-${{ github.event.release.tag_name }}.tar.gz
           asset_content_type: application/gzip
-      - name: Create Pull Request
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git push origin ${{ env.BRANCH_NAME }}
-          gh pr create \
-            --title "[github-actions]Update version.py to ${{ github.event.release.name }}" \
-            --body "This PR updates \`version.py\` to match the latest release: ${{ github.event.release.name }}" \
-            --base master \
-            --head ${{ env.BRANCH_NAME }} \
-            --reviewer dimitri-yatsenko,drewyangdev,ttngu207
       - name: Post release notification to Slack
         if: ${{ env.TEST_PYPI == 'false' }}
         uses: slackapi/slack-github-action@v2.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# Version file generated at build time by hatch-vcs (see pyproject.toml)
+src/datajoint/_version.py
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/RELEASE_MEMO.md
+++ b/RELEASE_MEMO.md
@@ -82,20 +82,23 @@ Ensure PRs have appropriate labels before merging.
    - Set release name to `Release X.Y.Z`
    - Set tag to `vX.Y.Z`
    - Review and edit release notes
-4. **Publish the release**
+4. **Publish the release** — this creates the `vX.Y.Z` tag.
 5. Automation will:
-   - Update `version.py` to `X.Y.Z`
-   - Build and publish to PyPI
-   - Create PR to merge version update back to master
+   - Build from the tag and publish to PyPI
+   - Attach the wheel/sdist as release assets
 
 ### Version Note
 
-The release drafter computes version from the previous tag. You may need to **manually edit** the release name for major version changes.
+The release drafter computes the version from the previous tag. You may need to
+**manually edit** the release name/tag for major version changes.
 
-The regex in `post_draft_release_published.yaml` extracts version from the release name:
-```bash
-VERSION=$(echo "${{ github.event.release.name }}" | grep -oP '\d+\.\d+\.\d+')
-```
+The package version is **derived from the git tag** at build time by
+[hatch-vcs](https://github.com/ofek/hatch-vcs) (see `[tool.hatch.version]` in
+`pyproject.toml`) — the tag is the single source of truth. There is **no
+`version.py` value to bump** and **no follow-up version PR**: publishing the
+`vX.Y.Z` tag is what sets the version everywhere (`pip install`, `pip show`, and
+`datajoint.__version__`). Do not hand-edit `src/datajoint/version.py`; it only
+re-exports the build-generated `_version.py`.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -219,7 +219,14 @@ module = [
 ignore_errors = true
 
 [tool.hatch.version]
-path = "src/datajoint/version.py"
+# Version is derived from the git tag at build time (hatch-vcs), so the tag is
+# the single source of truth: `pip install git+...@vX.Y.Z` reports X.Y.Z. The
+# resolved version is written to the generated (git-ignored) src/datajoint/_version.py
+# by the build hook below; src/datajoint/version.py reads it back at runtime.
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/datajoint/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/datajoint"]

--- a/src/datajoint/version.py
+++ b/src/datajoint/version.py
@@ -1,4 +1,16 @@
-# version bump auto managed by Github Actions:
-# draft_release.yaml (draft), post_draft_release_published.yaml (bump + PR)
-# manually set this version will be eventually overwritten by the above actions
-__version__ = "2.3.1"
+# Version is derived from the git tag at build time by hatch-vcs (see
+# pyproject.toml). The build writes the resolved version to the generated,
+# git-ignored ``_version.py``; there is no version string to bump by hand.
+# This module re-exports it, falling back to installed package metadata so
+# ``datajoint.__version__`` also works when running from a source tree.
+try:
+    from ._version import __version__
+except ImportError:  # not built yet (e.g. a bare git checkout on sys.path)
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        __version__ = version("datajoint")
+    except PackageNotFoundError:
+        __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]


### PR DESCRIPTION
Resolves **finding 1** of #1503. (Findings 2–4 already landed in #1504.)

## Problem

The version bump PR lands *after* the release tag, so `src/datajoint/version.py` at each tag still reports the **previous** release (at the `v2.3.1` tag it reads `2.3.0`, and so on). PyPI wheels are unaffected — they're built from the sed'd tree in the same workflow run — but:

- `pip install git+https://github.com/datajoint/datajoint-python.git@v2.3.1` → wheel reporting `2.3.0`
- `pip show datajoint` on that install reports `2.3.0`
- version-gated code (`if datajoint.__version__ >= "2.3.1"`) silently takes the wrong branch

## Fix — make the git tag the single source of truth (hatch-vcs)

- **`pyproject.toml`**: `[tool.hatch.version] source = "vcs"` (+ `hatch-vcs` build dep) and a `[tool.hatch.build.hooks.vcs]` hook that writes the resolved version to the generated, git-ignored `src/datajoint/_version.py`.
- **`src/datajoint/version.py`**: re-exports the generated version, falling back to installed package metadata (`importlib.metadata`) for source-tree runs — so `datajoint.__version__` keeps working everywhere.
- **`.github/workflows/post_draft_release_published.yaml`**: drops the `version.py` sed/commit step and the follow-up bump PR entirely; checks out with `fetch-depth: 0` so the build resolves the tag. Publishing the `vX.Y.Z` tag is now the only version action.
- **`.gitignore`**: ignore the build-generated `_version.py`.
- **`RELEASE_MEMO.md`**: document the tag-driven flow (no manual bump, no bump PR).

## Verification

Built and installed locally against a throwaway `v9.9.9` tag:

- `hatchling version` at the clean tag → `9.9.9`; `python -m build` → `datajoint-9.9.9-py3-none-any.whl` and `datajoint-9.9.9.tar.gz` (the sdist→wheel path `pip install git+…@vX` uses).
- Installed wheel → `datajoint.__version__ == 9.9.9` and `importlib.metadata.version("datajoint") == 9.9.9`.
- A dirty/untagged tree correctly yields a `.devN+g<sha>` version; `_version.py` is git-ignored and never tracked.

## Notes

- No `version.py` value to bump by hand anymore; the tag sets the version for `pip install`, `pip show`, and `datajoint.__version__` alike.
- Opened as a draft — this touches the release path, so worth a careful look before it's live. The workflow change can only be fully exercised on the next real release.
- **Behavior change — bare source checkout without install.** Running from an uninstalled tree (`PYTHONPATH=./src python -c "import datajoint; print(datajoint.__version__)"`) now reports `0.0.0+unknown`, because both the build-generated `_version.py` and installed package metadata are absent. This differs from the previous hardcoded `__version__`. Anyone developing seriously will `pip install -e .` (which runs the hatch-vcs hook and generates `_version.py`), so this is minor — but flagged here so that seeing `0.0.0+unknown` after upgrading isn't mistaken for a regression; the fix is `pip install -e .`.

