### PR TITLE
chore: normalize stdlib copy imports to `import copy`

### DIFF
--- a/src/datajoint/diagram.py
+++ b/src/datajoint/diagram.py
@@ -15,7 +15,7 @@ pygraphviz. All other methods are always available.
 
 from __future__ import annotations
 
-import copy as copy_module
+import copy
 import functools
 import inspect
 import io
@@ -103,9 +103,9 @@ class Diagram(nx.DiGraph):  # noqa: C901
             self._expanded_nodes = set(source._expanded_nodes)
             self.context = source.context
             self._connection = source._connection
-            self._cascade_restrictions = copy_module.deepcopy(source._cascade_restrictions)
-            self._restrict_conditions = copy_module.deepcopy(source._restrict_conditions)
-            self._restriction_attrs = copy_module.deepcopy(source._restriction_attrs)
+            self._cascade_restrictions = copy.deepcopy(source._cascade_restrictions)
+            self._restrict_conditions = copy.deepcopy(source._restrict_conditions)
+            self._restriction_attrs = copy.deepcopy(source._restriction_attrs)
             super().__init__(source)
             return
 

--- a/src/datajoint/settings.py
+++ b/src/datajoint/settings.py
@@ -37,12 +37,12 @@ Project structure::
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
 import warnings
 from contextlib import contextmanager
-from copy import deepcopy
 from enum import Enum
 from pathlib import Path
 from typing import Any, Iterator, Literal
@@ -805,14 +805,14 @@ class Config(BaseSettings):
                 if len(key_parts) == 1:
                     key = key_parts[0]
                     if hasattr(self, key):
-                        backup[key_parts] = deepcopy(getattr(self, key))
+                        backup[key_parts] = copy.deepcopy(getattr(self, key))
                         setattr(self, key, value)
                 elif len(key_parts) == 2:
                     group, attr = key_parts
                     if hasattr(self, group):
                         group_obj = getattr(self, group)
                         if hasattr(group_obj, attr):
-                            backup[key_parts] = deepcopy(getattr(group_obj, attr))
+                            backup[key_parts] = copy.deepcopy(getattr(group_obj, attr))
                             setattr(group_obj, attr, value)
 
             yield self


### PR DESCRIPTION
Standardizes how the stdlib `copy` module is imported across the codebase. Three modules used three conventions:

- `diagram.py` — `import copy as copy_module` → `import copy` (the alias was unnecessary; `copy` only appears there as a keyword argument, which can't collide with the module name)
- `settings.py` — `from copy import deepcopy` → `import copy`, call-sites qualified as `copy.deepcopy`
- `expression.py` — already `import copy` (uses `copy.copy`); unchanged

Now uniform: `import copy` with qualified `copy.deepcopy` / `copy.copy`, so one import covers both shallow and deep copies. Pure rename — no behavior change (identifiers only; ruff/isort/mypy clean, imports verified). Split out of #1508.