### PR TITLE
docs(autopopulate): fix stale finally-comment; document upstream in class Attributes

### DIFF
--- a/src/datajoint/autopopulate.py
+++ b/src/datajoint/autopopulate.py
@@ -89,6 +89,11 @@ class AutoPopulate:
         Query yielding keys to be populated. Default is join of FK parents.
     jobs : Job
         Job table (``~~table_name``) for distributed processing.
+    upstream : Diagram
+        Pre-restricted ancestor view for the current ``make(self, key)`` call
+        (property). Available only inside ``make()``; built lazily on first
+        access and memoized for the call. See the property docstring for
+        details.
 
     Notes
     -----
@@ -736,9 +741,11 @@ class AutoPopulate:
             return True
         finally:
             self.__class__._allow_insert = False
-            # Clear the per-make() upstream view so subsequent attribute
-            # access raises a clear error rather than silently using a
-            # stale trace from the previous make() call.
+            # Clear the per-make() upstream state: `_upstream = None` invalidates
+            # the memoized Diagram; `_upstream_key = None` restores the "outside
+            # make()" state so subsequent `self.upstream` access raises a clear
+            # error via the property guard rather than silently returning a stale
+            # trace from the previous call.
             self._upstream = None
             self._upstream_key = None
 


### PR DESCRIPTION
Two post-#1499 documentation drift fixes on `src/datajoint/autopopulate.py`.

## Changes

**1. `_populate_one` finally-block comment** — the comment above the state cleanup attributed the "raises a clear error rather than silently using a stale trace" behavior to `self._upstream = None`, but after #1499 that line only invalidates the memoized `Diagram`. The actual guard is `self._upstream_key = None` (via the `upstream` property at `:135-140`, which raises when `_upstream_key is None`). Reworded so each line's role is correctly attributed:

- `_upstream = None` → invalidates the memoized Diagram
- `_upstream_key = None` → restores the "outside make()" state; enables the guard's clear-error behavior

A maintainer who trusted the old comment might remove `_upstream_key = None` on the assumption `_upstream = None` was sufficient — exactly the silent-stale-trace outcome the comment warns against.

**2. `AutoPopulate` class docstring** — the Attributes section listed `key_source` and `jobs` but omitted `upstream`, which is a public `@property` since #1473 (documented at `:103-141` as the "recommended pattern for the make() reproducibility contract"). Sphinx renders the class docstring at the top of the AutoPopulate reference page, so readers of the summary see a Table+jobs mixin and miss the primary public read surface until they scroll to the property. Added `upstream` alongside the others.

Docs-only, no behavior change.
