### PR TITLE
docs: post-2.3.1 stale-text sweep (3 small drift fixes)

### DIFF
--- a/RELEASE_MEMO.md
+++ b/RELEASE_MEMO.md
@@ -150,11 +150,16 @@ If the bot doesn't create a PR, manually update the feedstock:
      run:
        - python >={{ python_min }}
        - numpy
+       - pymysql >=0.7.2
+       - deepdiff
+       - pyparsing
        - pandas
-       - pymysql >=1.0
-       - minio
+       - tqdm
+       - networkx
+       - pydot
+       - fsspec >=2023.1.0
+       - pydantic-settings >=2.0.0
        - packaging
-       # ... etc
    ```
 
 5. **Submit PR** to the feedstock

--- a/src/datajoint/builtin_codecs/filepath.py
+++ b/src/datajoint/builtin_codecs/filepath.py
@@ -22,8 +22,10 @@ class FilepathCodec(Codec):
 
     This codec gives users maximum freedom in organizing their files while
     reusing DataJoint's store configuration. Files can be placed anywhere
-    in the store EXCEPT the reserved ``_hash/`` and ``_schema/`` sections
-    which are managed by DataJoint.
+    in the store EXCEPT the reserved sections managed by DataJoint (the
+    hash-addressed and schema-addressed sections — from each store's
+    ``hash_prefix`` and ``schema_prefix`` settings, defaults ``_hash`` and
+    ``_schema``).
 
     This is useful when:
     - Files are managed externally (e.g., by acquisition software)
@@ -54,7 +56,8 @@ class FilepathCodec(Codec):
         JSON metadata: ``{path, store, size, timestamp}``
 
     Reserved Sections:
-        Paths cannot start with ``_hash/`` or ``_schema/`` - these are managed by DataJoint.
+        Paths cannot start with the store's reserved ``hash_prefix`` or
+        ``schema_prefix`` sections (defaults ``_hash/`` and ``_schema/``).
 
     Warning:
         The file must exist in the store at the specified path.
@@ -78,7 +81,8 @@ class FilepathCodec(Codec):
         Parameters
         ----------
         value : str
-            Relative path within the store. Cannot use reserved sections (_hash/, _schema/).
+            Relative path within the store. Cannot use the store's reserved
+            hash/schema sections.
         key : dict, optional
             Primary key values (unused).
         store_name : str, optional
@@ -92,7 +96,7 @@ class FilepathCodec(Codec):
         Raises
         ------
         ValueError
-            If path uses reserved sections (_hash/ or _schema/).
+            If path uses the store's reserved hash/schema sections.
         FileNotFoundError
             If file does not exist in the store.
         """

--- a/tests/integration/test_trace.py
+++ b/tests/integration/test_trace.py
@@ -400,7 +400,7 @@ def test_trace_stops_at_master_no_part_down_collection(schema_by_backend):
 
     This corrects the design comment on datajoint/datajoint-python discussion
     1232, which described a Master->Parts down-collection that was never
-    implemented; the spec (provenance.md, Allowed table set) matches this
+    implemented; the spec (trace.md §Allowed table set) matches this
     test. If down-collection is ever added deliberately, this test must be
     revised alongside the spec — it exists so the semantics cannot drift
     silently."""


### PR DESCRIPTION
Three small drift items from a post-2.3.1 sweep, bundled since each is a one-line-ish fix but they touch unrelated files.

## Changes

**1. `tests/integration/test_trace.py:403`** — docstring cited `provenance.md, Allowed table set` as the spec anchor for the merge-table pin. That spec file was deleted when `strict_provenance` was retired; the section moved to [`trace.md §Allowed table set`](https://github.com/datajoint/datajoint-docs/blob/main/src/reference/specs/trace.md). Updated the pointer. The `autopopulate.py` docstring's own `:doc:` reference was already swept in the retirement commit — this test docstring was missed.

**2. `src/datajoint/builtin_codecs/filepath.py` (4 sites)** — docstring hardcoded `_hash/`/`_schema/` as the reserved sections, but `encode()` (`:118-134`) actually reads each store's configured `hash_prefix` and `schema_prefix` (defaults `_hash`/`_schema`). Reworded to name the settings with defaults, so users who override either prefix aren't misled by literal `_hash/` in the docs. Existing test `test_filepath_reservation_follows_hash_prefix_override` (in `tests/unit/test_codecs.py`) already covers the dynamic behavior.

**3. `RELEASE_MEMO.md` conda-forge example** — the "Check dependencies match `pyproject.toml`" template listed only 5 deps (missing 7 runtime deps: `deepdiff`, `pyparsing`, `tqdm`, `networkx`, `pydot`, `fsspec`, `pydantic-settings`), included spurious `minio` (only in test extras via `testcontainers[minio]`), and pinned `pymysql >=1.0` (actual `>=0.7.2`). Since the section explicitly instructs the reader to match `pyproject.toml`, replaced with the complete 11-dep run list from current `pyproject.toml`.

Docs-only. No behavior change.

