### PR TITLE
Remove process-wide sys.excepthook; harden log formatter (#1516)

### DIFF
--- a/src/datajoint/logging.py
+++ b/src/datajoint/logging.py
@@ -28,11 +28,22 @@ class LevelAwareFormatter(logging.Formatter):
     def format(self, record):
         timestamp = self.formatTime(record, "%Y-%m-%d %H:%M:%S")
         if record.levelno >= logging.WARNING:
-            return f"[{timestamp}][{record.levelname}]: {record.getMessage()}"
+            message = f"[{timestamp}][{record.levelname}]: {record.getMessage()}"
         elif record.levelno == JOBS:
-            return f"[{timestamp}][JOBS]: {record.getMessage()}"
+            message = f"[{timestamp}][JOBS]: {record.getMessage()}"
         else:
-            return f"[{timestamp}] {record.getMessage()}"
+            message = f"[{timestamp}] {record.getMessage()}"
+
+        # Render exception/stack info like the base logging.Formatter does, so
+        # that a logger.exception(...)/exc_info=... call never silently drops
+        # the traceback (see #1516).
+        if record.exc_info and not record.exc_text:
+            record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            message = f"{message}\n{record.exc_text}"
+        if record.stack_info:
+            message = f"{message}\n{self.formatStack(record.stack_info)}"
+        return message
 
 
 # Select output stream: stdout (default, no red highlighting) or stderr
@@ -44,13 +55,7 @@ stream_handler.setFormatter(LevelAwareFormatter())
 logger.setLevel(level=log_level)
 logger.handlers = [stream_handler]
 
-
-def excepthook(exc_type, exc_value, exc_traceback):
-    if issubclass(exc_type, KeyboardInterrupt):
-        sys.__excepthook__(exc_type, exc_value, exc_traceback)
-        return
-
-    logger.error("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
-
-
-sys.excepthook = excepthook
+# NOTE: DataJoint intentionally does NOT install a process-wide sys.excepthook.
+# Importing a library must not change how *unrelated* uncaught exceptions are
+# reported in the host process. Uncaught exceptions are left to Python's default
+# handler, which prints the full type/message/traceback to stderr. (See #1516.)

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,70 @@
+"""
+Tests for datajoint.logging.
+
+Regression coverage for #1516: importing datajoint must not install a
+process-wide sys.excepthook, and LevelAwareFormatter must not discard
+exc_info/stack_info.
+"""
+
+import logging
+import sys
+
+
+def test_import_does_not_replace_excepthook():
+    """Importing datajoint must leave sys.excepthook untouched (#1516)."""
+    original = sys.excepthook
+    try:
+        modules_to_remove = [key for key in sys.modules if key.startswith("datajoint")]
+        for mod in modules_to_remove:
+            del sys.modules[mod]
+
+        import datajoint  # noqa: F401
+
+        assert sys.excepthook is original, "importing datajoint replaced sys.excepthook"
+    finally:
+        sys.excepthook = original
+
+
+def test_formatter_renders_exception_info():
+    """LevelAwareFormatter must append the traceback when exc_info is set (#1516)."""
+    from datajoint.logging import LevelAwareFormatter
+
+    formatter = LevelAwareFormatter()
+    try:
+        raise ValueError("something specific and diagnosable went wrong")
+    except ValueError:
+        record = logging.LogRecord(
+            name="datajoint",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=0,
+            msg="Uncaught exception",
+            args=(),
+            exc_info=sys.exc_info(),
+        )
+
+    output = formatter.format(record)
+    assert "Uncaught exception" in output
+    assert "ValueError: something specific and diagnosable went wrong" in output
+    assert "Traceback (most recent call last)" in output
+
+
+def test_formatter_renders_stack_info():
+    """LevelAwareFormatter must append stack_info when present (#1516)."""
+    from datajoint.logging import LevelAwareFormatter
+
+    formatter = LevelAwareFormatter()
+    record = logging.LogRecord(
+        name="datajoint",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=0,
+        msg="with stack",
+        args=(),
+        exc_info=None,
+        sinfo="Stack (most recent call last):\n  fake stack frame",
+    )
+
+    output = formatter.format(record)
+    assert "with stack" in output
+    assert "fake stack frame" in output


### PR DESCRIPTION
Fixes #1516.

## Problem

Importing `datajoint` installed a **process-wide `sys.excepthook`** as an import side effect, routing *every* uncaught exception in the host process — DataJoint-related or not — through DataJoint's logger. Combined with `LevelAwareFormatter` overriding `format()` without rendering `exc_info`, every uncaught exception collapsed to a contentless line:

```
[2026-07-21 16:00:13][ERROR]: Uncaught exception
```

with no type, message, or traceback — strictly worse than Python's default handler, which would have printed the full traceback for free.

## History (this is a regression, not the original design)

The hook was originally non-lossy: it inlined the exception message (`Uncaught exception: {exc_value}`) and rendered a full traceback under `DJ_LOG_LEVEL=DEBUG` via the stdlib formatter. Two later changes compounded into the silent-discard behavior:

- `a9dee8d9` — simplified the excepthook to rely solely on `exc_info`, dropping the inline message.
- `41dad5d2` — introduced the custom `LevelAwareFormatter`, which overrides `format()` and never renders `exc_info`.

## Change

- **Remove the `sys.excepthook` installation.** A library must not change how unrelated exceptions surface in the importing process. Uncaught exceptions now fall through to Python's default handler (full traceback to stderr). Nothing in the codebase reads the hook, and no internal code path attaches `exc_info` to a log record, so removal is self-contained.
- **Harden `LevelAwareFormatter`** to append `exc_info`/`stack_info` like the base `logging.Formatter`, so any future `logger.exception(...)` / `exc_info=…` call never silently drops a traceback.
- **Add regression tests** (`tests/unit/test_logging.py`): import no longer replaces `sys.excepthook`; the formatter renders exception and stack info.

The centralized `datajoint` logger and its handler/level config are unchanged — only the process-global excepthook is removed.

## Compatibility

Behavior change worth a release note: fatal uncaught tracebacks now print to **stderr** (Python's default handler) rather than as a single line on stdout. This is the correct destination for a crash, and restores the full type/message/traceback that the previous hook discarded.
