### PR TITLE
Fix jobs table generation for uuid FK-derived primary keys (#1515)

### DIFF
--- a/src/datajoint/jobs.py
+++ b/src/datajoint/jobs.py
@@ -206,9 +206,14 @@ class Job(Table):
         fk_attrs = []
         for name in target_pk:
             if name in fk_derived_attrs:
-                # FK-derived: comes from a primary FK parent
+                # FK-derived: comes from a primary FK parent.
+                # Use original_type (the DataJoint-level alias, e.g. "uuid") when
+                # present, falling back to the resolved SQL type. attr.type holds
+                # the backend-resolved type (e.g. "binary(16)" for uuid), which is
+                # not valid DataJoint definition syntax and fails to re-parse when
+                # the jobs table is declared. Mirrors heading.py's own fallback.
                 attr = heading[name]
-                fk_attrs.append((name, attr.type))
+                fk_attrs.append((name, attr.original_type or attr.type))
             else:
                 # Native PK attribute - not from FK
                 logger.warning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -863,6 +863,7 @@ def schema_uuid(connection_test, prefix):
         connection=connection_test,
     )
     schema(schema_uuid_module.Basic)
+    schema(schema_uuid_module.BasicComputed)
     schema(schema_uuid_module.Topic)
     schema(schema_uuid_module.Item)
     yield schema

--- a/tests/integration/test_jobs.py
+++ b/tests/integration/test_jobs.py
@@ -7,6 +7,7 @@ import datajoint as dj
 from datajoint.jobs import ERROR_MESSAGE_LENGTH, TRUNCATION_APPENDIX
 
 from tests import schema
+from tests.schema_uuid import BasicComputed
 
 
 def test_reserve_job(clean_jobs, subject, experiment):
@@ -206,3 +207,26 @@ def test_jobs_refresh_with_keep_completed(clean_jobs, subject, experiment):
 
         # Calling refresh again should not raise semantic matching error
         experiment.jobs.refresh()  # This was failing before the fix
+
+
+def test_jobs_table_uuid_fk_derived_pk(schema_uuid):
+    """Jobs table generation must handle uuid-typed FK-derived primary keys (#1515).
+
+    The auto-generated jobs table definition previously leaked the resolved SQL
+    type (binary(16)) for a uuid PK attribute instead of the DataJoint alias
+    (uuid), so declaring the ~~table raised
+    "Unsupported attribute type binary(16)" on first .jobs access.
+    """
+    # Definition must carry the DataJoint alias, not the resolved SQL type.
+    definition = BasicComputed.jobs.definition
+    assert "uuid" in definition
+    assert "binary(16)" not in definition
+
+    # First .jobs access declares the ~~table; this is where the bug fired.
+    BasicComputed.jobs.refresh()
+    assert BasicComputed.jobs.is_declared
+
+    # The declared PK attribute round-trips back to uuid / binary(16).
+    pk = BasicComputed.jobs.heading.primary_key
+    assert "item" in pk
+    assert BasicComputed.jobs.heading["item"].original_type == "uuid"

--- a/tests/schema_uuid.py
+++ b/tests/schema_uuid.py
@@ -14,6 +14,18 @@ class Basic(dj.Manual):
     """
 
 
+class BasicComputed(dj.Computed):
+    definition = """
+    # Computed table whose primary key is FK-derived from a uuid attribute
+    -> Basic
+    ---
+    value : int32
+    """
+
+    def make(self, key):
+        self.insert1(dict(key, value=1))
+
+
 class Topic(dj.Manual):
     definition = """
     # A topic for items


### PR DESCRIPTION
Fixes #1515.

## Problem

Accessing `.jobs` on a `Computed`/`Imported` table whose primary key is FK-derived from a `uuid` attribute crashed with:

```
DataJointError: Unsupported attribute type binary(16)
```

This fires on the first `.jobs` access for such a table — including the implicit access inside `populate(reserve_jobs=True)` — and never recovers, since the `~~jobs` table stays undeclared. It disables `reserve_jobs=True` entirely for the common, recommended pattern of using `uuid` root keys with downstream computed tables.

## Root cause

`Job._generate_definition()` builds the `~~jobs` table's DataJoint definition string from the target's FK-derived primary key. For each attribute it emitted `attr.type` — the **backend-resolved SQL type** (`binary(16)` for a `uuid`) — rather than the DataJoint-level alias the user wrote (`uuid`). `binary(16)` is not valid DataJoint definition syntax, so when `Job.declare()` re-parsed the generated string, `match_type("binary(16)")` matched no pattern and raised.

## Fix

Use `attr.original_type or attr.type` in `_get_fk_derived_pk_attrs`, mirroring the fallback DataJoint already uses in `heading.py` (`original_type = attr["original_type"] or attr["type"]`). `original_type` holds the DataJoint alias for core types (`uuid`, `float32`, …) and is `None` otherwise, so:

- `uuid` PK → definition line `item : uuid` (re-parses correctly; DataJoint resolves it back to `binary(16)` internally).
- any other core-type alias in an FK-derived PK is fixed the same way, not just `uuid`.
- non-alias types are unaffected (fall back to `attr.type` as before).

## Test

Adds `test_jobs_table_uuid_fk_derived_pk` (plus a `BasicComputed` table in the uuid test schema: a `Computed` table whose PK is FK-derived from a `uuid` parent). It asserts the generated definition carries `uuid` (not `binary(16)`), that `.jobs.refresh()` declares the table, and that the PK attribute round-trips to `original_type == "uuid"`.
