### PR TITLE
ci(release): upload to PyPI without the docker rebuild

### DIFF
--- a/.github/workflows/post_draft_release_published.yaml
+++ b/.github/workflows/post_draft_release_published.yaml
@@ -50,34 +50,24 @@ jobs:
           python -m build .
           echo "DJ_WHEEL_PATH=$(ls dist/datajoint-*.whl)" >> $GITHUB_ENV
           echo "DJ_SDIST_PATH=$(ls dist/datajoint-*.tar.gz)" >> $GITHUB_ENV
-          echo "NEW_VERSION=${{github.event.release.resolved_version}}" >> $GITHUB_ENV
       - name: Publish package
         id: publish
         env:
           RELEASE_NAME: ${{ github.event.release.name }}
         run: |
-          export HOST_UID=$(id -u)
+          python -m pip install --upgrade twine
           if [[ "$RELEASE_NAME" =~ ^Test ]]; then
-            LATEST_PYPI=$(curl -s https://test.pypi.org/pypi/datajoint/json | jq -r '.info.version')
             echo "TEST_PYPI=true" >> $GITHUB_ENV
             export TWINE_REPOSITORY="testpypi"
             export TWINE_USERNAME=${TWINE_TEST_USERNAME}
             export TWINE_PASSWORD=${TWINE_TEST_PASSWORD}
           else
-            LATEST_PYPI=$(curl -s https://pypi.org/pypi/datajoint/json | jq -r '.info.version')
             echo "TEST_PYPI=false" >> $GITHUB_ENV
             export TWINE_REPOSITORY="pypi"
           fi
-          # Check if the new version is different from the latest on PyPI, avoid re-uploading error
-          if [ "$NEW_VERSION" != "$LATEST_PYPI" ]; then
-            docker compose run --build --quiet-pull \
-            -e TWINE_USERNAME=${TWINE_USERNAME} \
-            -e TWINE_PASSWORD=${TWINE_PASSWORD} \
-            -e TWINE_REPOSITORY=${TWINE_REPOSITORY} \
-            app sh -c "pip install twine && python -m twine upload dist/*"
-          else
-            echo "::warning::Latest version $LATEST_PYPI on $TWINE_REPOSITORY is the new version $NEW_VERSION"
-          fi
+          # Upload the artifacts built in the previous step. --skip-existing
+          # keeps re-runs idempotent (no error if the version already exists).
+          python -m twine upload --skip-existing dist/*
       # Upload package as release assets
       - name: Upload pip wheel asset to release
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Fixes the v2.3.2 release publish failure. The Publish step wrapped twine in `docker compose run --build`, reinstalling the package in a container without the git tag → hatch-vcs `metadata-generation-failed` (first release using hatch-vcs, #1503). Now uploads the already-built `dist/*` directly with `twine upload --skip-existing`; drops the empty `resolved_version` guard. No package code changes.