### PR TITLE
ci: add Windows unit-test job to catch OS-specific path bugs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,3 +68,32 @@ jobs:
 
       - name: Run unit tests
         run: pixi run -e test pytest tests/unit -v
+
+  # Windows unit tests: guard OS-specific behavior (path separators, etc.) that
+  # the Linux jobs above cannot catch — e.g. #1520, where file-protocol paths
+  # rendered with native backslashes broke garbage collection on Windows.
+  # pixi targets linux/osx only (see [tool.pixi] platforms), so this leg uses
+  # pip. Unit tests need no containers, so no Docker/DB is required on Windows.
+  unit-tests-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Exercise both ends of the supported range (requires-python >=3.10,<3.15).
+        python-version: ["3.10", "3.14"]
+    name: unit-tests-windows (py${{ matrix.python-version }})
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # hatch-vcs derives the version from git history/tags
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package with test extras
+        run: pip install -e ".[test]"
+
+      - name: Run unit tests
+        run: pytest tests/unit -v

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,6 +92,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # NOTE: pip resolves `[project.optional-dependencies].test`, which is a
+      # DIFFERENT set than the pixi Linux legs' `[dependency-groups].test`
+      # (e.g. it omits graphviz). A unit test importing a dep present in only
+      # one set would then pass on Linux but error on Windows (or vice versa) —
+      # a dep-set mismatch that reads like an OS bug. Keep the two `test` sets
+      # in sync when unit-test dependencies change.
       - name: Install package with test extras
         run: pip install -e ".[test]"
 


### PR DESCRIPTION
## Why

The CI matrix ran Linux-only, so OS-specific defects couldn't be caught. #1520 is the motivating case: `StorageBackend._full_path()` rendered file-protocol paths with native backslashes on Windows, which broke garbage collection (every live file looked orphaned; `collect()` could delete referenced files). #1521 fixes it, but nothing in CI exercises Windows, so the regression — and its whole class — would recur silently.

## What

Adds a `unit-tests-windows` job on `windows-latest` running the container-free unit suite (`tests/unit`) across both ends of the supported Python range (3.10, 3.14).

- **Scope: unit tests only.** The DB-backed `test` job needs Docker/Linux containers (testcontainers), which don't fit Windows runners. The unit suite needs no containers and is where the path-handling logic (incl. #1520) actually lives, so it's the right and sufficient surface for a Windows guard.
- **Installs via pip, not pixi.** pixi targets linux/osx only (`[tool.pixi] platforms` has no `win-64`, and the lock isn't solved for it), so this leg uses `actions/setup-python` + `pip install -e ".[test]"`. The `test` extra's deps all ship Windows wheels. The existing Linux `unit-tests` (pixi) job is unchanged.
- `fetch-depth: 0` so `hatch-vcs` can derive the version on the editable install.

## Notes

- Verifies against #1520: with the #1521 fix, this job would pass; on the pre-fix code, `test_storage_adapter.py::test_file_protocol_full_path_uses_forward_slashes` fails. (As noted in the #1521 review, an end-to-end GC integration test on Windows would strengthen this further — this PR provides the runner; the deeper test can follow.)
- Two Windows runners (3.10, 3.14) mirror the range ethos of the existing matrix; can be trimmed to one if CI minutes are a concern.
- Introduces a second install idiom (pip) alongside pixi, scoped to this one Windows leg — unavoidable until/unless `win-64` is added to the pixi platforms and the lock re-solved.
