### PR TITLE
fix(diagram): walk all FK paths in the part→master cascade walk

### DIFF
--- a/src/datajoint/diagram.py
+++ b/src/datajoint/diagram.py
@@ -887,9 +887,9 @@ class Diagram(nx.MultiDiGraph):  # noqa: C901
         by walking the full path (intermediate Parts get restricted too) and
         renamed FKs via the upward rules.
 
-        Alias nodes (integer-named graph nodes inserted for aliased edges)
-        are transparent — both half-edges carry the same `attr_map` props,
-        so we read props from one and skip the alias node when walking.
+        A renamed/aliased FK is a direct parallel edge in the MultiDiGraph
+        (keyed by the child-side attr tuple), carrying its own ``attr_map``;
+        the upward rules read that map directly — there is no alias-node hop.
 
         After the walk, the master's restriction is **materialized** to a
         literal value tuple via ``to_arrays()``. This is required for
@@ -912,14 +912,12 @@ class Diagram(nx.MultiDiGraph):  # noqa: C901
 
         Limitations
         -----------
-        - **Single FK path**: ``nx.shortest_path`` returns *one* path from
-          ``master_name`` to ``part_node``. If a Part is reachable from its
-          Master through multiple distinct FK chains (e.g. references two
-          different intermediate Parts), restrictions through the
-          non-shortest paths are not applied. This pattern is unusual; if a
-          schema hits it, the user is responsible for restricting the
-          additional paths explicitly via ``part_integrity="ignore"`` plus
-          manual ``delete()`` calls.
+        - **Multiple FK paths**: every simple FK path from ``master_name`` to
+          ``part_node`` is walked (``nx.all_simple_edge_paths`` also enumerates
+          parallel FK edges between the same table pair). A Part reachable from
+          its Master through several distinct FK chains contributes master rows
+          through each, combined with OR — a master row is affected if *any*
+          part-path taints it.
         - **Memory cost of materialization**: ``master_ft.proj().to_arrays()``
           pulls the matching master primary keys into Python memory. Cost is
           bounded by the count of *distinct* master rows referenced by the
@@ -927,41 +925,51 @@ class Diagram(nx.MultiDiGraph):  # noqa: C901
           grow with bulk cascades on tables with many master rows. Cascade
           *preview* (``Diagram.cascade(...).counts()``) pays the same cost.
         """
+        # Enumerate EVERY simple FK path master → part. Because the graph is a
+        # MultiDiGraph, `all_simple_edge_paths` also yields parallel FK edges
+        # between the same table pair, each as its own (parent, child, key)
+        # tuple — so a Part reachable through more than one FK chain is
+        # restricted through all of them, not just the shortest (see #1492,
+        # completing the multigraph migration). OR convergence (cascade
+        # semantics) combines the chains: a master row is affected if any
+        # part-path taints it.
         try:
-            path = nx.shortest_path(self, master_name, part_node)
+            edge_paths = list(nx.all_simple_edge_paths(self, master_name, part_node))
         except (nx.NetworkXNoPath, nx.NodeNotFound):
             return False
-
-        # The path is a sequence of real tables (no alias nodes exist anymore).
-        real_path = list(path)
-        if len(real_path) < 2 or real_path[-1] != part_node or real_path[0] != master_name:
+        if not edge_paths:
             return False
 
-        # Walk real_path in reverse (child → parent direction). For each
-        # adjacent (parent, child) pair, look up the FK edge props.
+        # Walk each path child → parent (reverse of the master → part order) so
+        # every parent accumulates from its already-restricted child. Dedup by
+        # (parent, child, key) across overlapping paths: re-applying an edge is
+        # wasteful and, for the non-idempotent proj rules, would double-append.
         any_propagated = False
-        for i in range(len(real_path) - 1, 0, -1):
-            child = real_path[i]
-            parent = real_path[i - 1]
-            edge_props = self._edge_props(parent, child)
-            if edge_props is None:
-                return any_propagated  # Path broken (shouldn't happen if shortest_path succeeded)
+        walked_edges = set()
+        for edge_path in edge_paths:
+            for parent, child, ekey in reversed(edge_path):
+                if (parent, child, ekey) in walked_edges:
+                    continue
+                walked_edges.add((parent, child, ekey))
+                edge_props = self.get_edge_data(parent, child, ekey)
+                if edge_props is None:
+                    continue  # Path broken (shouldn't happen for an enumerated edge)
 
-            attr_map = edge_props.get("attr_map", {})
-            aliased = edge_props.get("aliased", False)
-            child_ft = self._restricted_table(child)
-            child_attrs = self._restriction_attrs.get(child, set())
+                attr_map = edge_props.get("attr_map", {})
+                aliased = edge_props.get("aliased", False)
+                child_ft = self._restricted_table(child)
+                child_attrs = self._restriction_attrs.get(child, set())
 
-            self._apply_propagation_rule_upward(
-                child_ft,
-                child_attrs,
-                parent,
-                attr_map,
-                aliased,
-                mode,
-                restrictions,
-            )
-            any_propagated = True
+                self._apply_propagation_rule_upward(
+                    child_ft,
+                    child_attrs,
+                    parent,
+                    attr_map,
+                    aliased,
+                    mode,
+                    restrictions,
+                )
+                any_propagated = True
 
         # Materialize the master's restriction so subsequent forward cascade
         # doesn't produce self-referential subqueries. Replace the master's
@@ -988,18 +996,6 @@ class Diagram(nx.MultiDiGraph):  # noqa: C901
                 self._restriction_attrs.setdefault(master_name, set())
 
         return any_propagated
-
-    def _edge_props(self, parent, child):
-        """
-        Return the FK edge properties for a direct ``parent → child`` foreign
-        key, or ``None`` if there is no such edge. When multiple parallel FKs
-        exist between the pair, the first one is returned (consistent with the
-        single-FK-path limitation documented on ``_propagate_part_to_master``).
-        """
-        data = self.get_edge_data(parent, child)
-        if not data:
-            return None
-        return next(iter(data.values()))
 
     def counts(self):
         """

--- a/tests/integration/test_cascade_integrity.py
+++ b/tests/integration/test_cascade_integrity.py
@@ -155,3 +155,61 @@ def test_upward_u3_nonprimary_master_fk(schema_by_backend):
         f"only master 1 (via the secondary-FK part row) must be restricted; got {counts} — "
         "a bare proj() on the U3 arm would have restricted both masters."
     )
+
+
+def test_part_to_master_walks_all_fk_paths(schema_by_backend):
+    """A Part reachable from its Master through more than one FK chain must be
+    restricted through EVERY chain, not just the shortest (see #1492). `Master.P`
+    references both its Master directly (the implicit `-> master` edge) AND a
+    sibling Part `Master.Q`, so there are two simple FK paths Master -> Master.P
+    (`Master -> Master.P` and `Master -> Master.Q -> Master.P`). An external
+    `Ext` feeds a restriction into both parts, firing the part->master upward
+    walk along both chains. The pre-#1492 `nx.shortest_path` walk followed a
+    single chain; the all-paths walk (`nx.all_simple_edge_paths`) must exercise
+    both branches without over- or under-restricting the master's part-group."""
+
+    @schema_by_backend
+    class Ext(dj.Manual):
+        definition = """
+        ext_id : int32
+        """
+
+    @schema_by_backend
+    class Master(dj.Manual):
+        definition = """
+        master_id : int32
+        """
+
+        class Q(dj.Part):
+            definition = """
+            -> master
+            q_id : int32
+            ---
+            -> Ext
+            """
+
+        class P(dj.Part):
+            definition = """
+            -> master
+            p_id : int32
+            ---
+            -> master.Q
+            -> Ext
+            """
+
+    Ext.insert([(1,), (2,)])
+    Master.insert([(1,), (2,)])
+    # master 1: one Q and one P (P references that Q), both via ext 1.
+    # master 2: one Q and one P, both via ext 2 (must stay untouched).
+    Master.Q.insert([(1, 10, 1), (2, 20, 2)])
+    Master.P.insert([(1, 100, 10, 1), (2, 200, 20, 2)])
+
+    # Seed taints ext 1 only. Forward cascade restricts the Q and P rows that
+    # reference ext 1; the part->master walk then pulls master 1 up both chains.
+    counts = dj.Diagram.cascade(Ext & {"ext_id": 1}, part_integrity="cascade").counts()
+
+    # Only master 1 is pulled in, with its whole part-group (its Q and its P);
+    # master 2 and its parts are untouched.
+    assert counts.get(Master.full_table_name, 0) == 1, f"only master 1 must be restricted; got {counts}"
+    assert counts.get(Master.P.full_table_name, 0) == 1, f"master 1's P must be pulled in; got {counts}"
+    assert counts.get(Master.Q.full_table_name, 0) == 1, f"master 1's Q must be pulled in; got {counts}"


### PR DESCRIPTION
## Why

Completes the `nx.MultiDiGraph` migration (#1492) in the one place it hadn't reached: the part→master upward walk in `Diagram.cascade(..., part_integrity="cascade")`. `_propagate_part_to_master` used `nx.shortest_path`, which follows a **single** FK chain from master to part and silently drops any others. A Part reachable from its Master through more than one FK chain (or through parallel FK edges between the same table pair) was therefore restricted through only one of them.

## What

- Replace `nx.shortest_path` with `nx.all_simple_edge_paths`, walking **every** simple FK path master→part. Because the graph is a MultiDiGraph, this also enumerates parallel FK edges between the same pair. Contributions combine with OR (cascade semantics): a master row is affected if *any* part-path taints it. Edges are de-duplicated across overlapping paths.
- Remove the now-unused `_edge_props` helper (it returned only the first parallel edge — the old single-path assumption).
- Scrub residual **alias-node** language from the upward-walk docstrings: an aliased FK is a direct parallel edge in the MultiDiGraph, not a transparent alias-node hop.

## Tests

Adds `test_part_to_master_walks_all_fk_paths` (a two-chain part-of-part shape fed by an external table) exercising the all-paths walk. Verified green on **both MySQL 8.0 and PostgreSQL 15**, along with the existing cascade/trace/ERD suites (78 tests) — no regressions.

## Scope

Targets the **2.3.3** bug-fix line. This is the safe, self-contained completion of the MultiDiGraph work; it is independent of the broader `expand`/`restrict` traversal redesign (design under review in #1524), into which the compositional-integrity items (#1496/#1501/#1481) fold.

Draft pending review.