### PR TITLE
fix(#1512): index foreign-key columns on PostgreSQL (coverage-aware)

### DIFF
--- a/src/datajoint/adapters/base.py
+++ b/src/datajoint/adapters/base.py
@@ -617,6 +617,22 @@ class DatabaseAdapter(ABC):
         """
         return True  # Default for MySQL, override in PostgreSQL
 
+    @property
+    def auto_indexes_foreign_keys(self) -> bool:
+        """
+        Whether this backend implicitly indexes a foreign key's referencing
+        (child) columns as part of enforcing the constraint.
+
+        MySQL/InnoDB does; PostgreSQL does not (and offers no server setting to
+        make it), so DataJoint must emit an explicit index on that backend.
+
+        Returns
+        -------
+        bool
+            True for MySQL, False for PostgreSQL.
+        """
+        return True  # Default for MySQL, override in PostgreSQL
+
     def create_index_ddl(
         self,
         full_table_name: str,

--- a/src/datajoint/adapters/postgres.py
+++ b/src/datajoint/adapters/postgres.py
@@ -720,6 +720,14 @@ class PostgreSQLAdapter(DatabaseAdapter):
         """
         return False
 
+    @property
+    def auto_indexes_foreign_keys(self) -> bool:
+        """
+        PostgreSQL never indexes a foreign key's referencing columns
+        automatically, so DataJoint emits an explicit (coverage-aware) index.
+        """
+        return False
+
     # =========================================================================
     # Introspection
     # =========================================================================

--- a/src/datajoint/declare.py
+++ b/src/datajoint/declare.py
@@ -190,6 +190,7 @@ def compile_foreign_key(
     index_sql: list[str],
     adapter,
     fk_attribute_map: dict[str, tuple[str, str]] | None = None,
+    fk_index_candidates: list[list[str]] | None = None,
 ) -> None:
     """
     Parse a foreign key line and update declaration components.
@@ -215,6 +216,11 @@ def compile_foreign_key(
         Database adapter for backend-specific SQL generation.
     fk_attribute_map : dict, optional
         Mapping of ``child_attr -> (parent_table, parent_attr)``. Updated in place.
+    fk_index_candidates : list, optional
+        PostgreSQL only. Collects each non-unique foreign key's columns as a
+        candidate supporting index; the redundancy/coverage decision is made
+        post-parse (once the full primary key and index list are known).
+        Updated in place.
 
     Raises
     ------
@@ -301,27 +307,22 @@ def compile_foreign_key(
         f"FOREIGN KEY ({fk_cols}) REFERENCES {ref_table_name} ({pk_cols}) ON UPDATE CASCADE ON DELETE RESTRICT"
     )
 
-    # Declare a supporting index on the foreign-key columns.
+    # Supporting index on the foreign-key columns.
     #
-    # MySQL/InnoDB creates one implicitly for every foreign key, so we emit an
-    # explicit index only on the PostgreSQL path — Postgres never auto-indexes
-    # the referencing (child) columns and offers no server setting to make it
-    # (see #1512). The `unique` case keeps its UNIQUE INDEX on every backend.
-    #
-    # Coverage-aware: skip when the foreign-key columns are already a left-prefix
-    # of the child's primary key, since the primary-key index then already serves
-    # foreign-key lookups and cascades. That holds exactly for a *leading*
-    # primary foreign key; a secondary foreign key (`primary_key is None`) or a
-    # non-leading primary foreign key is not covered and needs its own index.
+    # The `unique` option is a uniqueness constraint, always emitted, on every
+    # backend. For the non-unique case: MySQL/InnoDB indexes every foreign key
+    # implicitly, but PostgreSQL never indexes the referencing (child) columns
+    # and offers no server setting to make it (see #1512), so DataJoint must.
+    # Whether that index is *redundant* (the columns are already a left-prefix of
+    # the primary key or of another declared index) can only be decided once the
+    # whole definition is parsed, so here we merely record the candidate; the
+    # coverage decision happens post-parse in `prepare_declare`.
     fk_attrs = list(ref.primary_key)
     if is_unique:
         index_cols = ", ".join(adapter.quote_identifier(attr) for attr in fk_attrs)
         index_sql.append(f"UNIQUE INDEX ({index_cols})")
-    elif adapter.backend == "postgresql":
-        covered_by_pk = primary_key is not None and list(primary_key[: len(fk_attrs)]) == fk_attrs
-        if not covered_by_pk:
-            index_cols = ", ".join(adapter.quote_identifier(attr) for attr in fk_attrs)
-            index_sql.append(f"INDEX ({index_cols})")
+    elif adapter.backend == "postgresql" and fk_index_candidates is not None:
+        fk_index_candidates.append(fk_attrs)
 
 
 def prepare_declare(
@@ -368,6 +369,7 @@ def prepare_declare(
     external_stores = []
     fk_attribute_map = {}  # child_attr -> (parent_table, parent_attr)
     column_comments = {}  # column_name -> comment (for PostgreSQL COMMENT ON)
+    fk_index_candidates = []  # PostgreSQL: FK column-lists that may need a support index (#1512)
 
     for line in definition:
         if not line or line.startswith("#"):  # ignore additional comments
@@ -385,6 +387,7 @@ def prepare_declare(
                 index_sql,
                 adapter,
                 fk_attribute_map,
+                fk_index_candidates,
             )
         elif re.match(r"^(unique\s+)?index\s*\(.*\)\s*(#.*)?$", line, re.I):  # index
             compile_index(re.sub(r"\s*#.*$", "", line), index_sql, adapter)
@@ -399,6 +402,33 @@ def prepare_declare(
                 attribute_sql.append(sql)
                 if comment:
                     column_comments[name] = comment
+
+    # Foreign-key support indexes (PostgreSQL; #1512). Now that the whole
+    # definition is parsed, emit an index on each candidate foreign key's columns
+    # UNLESS they are already a left-prefix of the primary key, of a declared
+    # index, or of a longer FK-support index already emitted — in which case that
+    # existing index already serves foreign-key lookups and cascades. Candidates
+    # are only collected on PostgreSQL (MySQL/InnoDB indexes FKs implicitly), so
+    # this loop is a no-op elsewhere.
+    if fk_index_candidates:
+
+        def _index_columns(index_def: str) -> list[str]:
+            match = re.match(r"(?:unique\s+)?index\s*\(([^)]+)\)", index_def, re.I)
+            return [col.strip().strip('`"') for col in match.group(1).split(",")] if match else []
+
+        # Existing prefixes an FK index could be redundant against: the primary
+        # key and every already-declared index. Grows as we accept FK indexes.
+        existing_prefixes = [list(primary_key)] + [_index_columns(s) for s in index_sql]
+
+        def _covered(candidate: list[str]) -> bool:
+            return any(prefix[: len(candidate)] == candidate for prefix in existing_prefixes)
+
+        # Longest first, so a shorter FK index left-covered by a longer one is skipped.
+        for candidate in sorted(fk_index_candidates, key=len, reverse=True):
+            if not _covered(candidate):
+                index_cols = ", ".join(adapter.quote_identifier(attr) for attr in candidate)
+                index_sql.append(f"INDEX ({index_cols})")
+                existing_prefixes.append(candidate)
 
     return (
         table_comment,

--- a/src/datajoint/declare.py
+++ b/src/datajoint/declare.py
@@ -301,10 +301,27 @@ def compile_foreign_key(
         f"FOREIGN KEY ({fk_cols}) REFERENCES {ref_table_name} ({pk_cols}) ON UPDATE CASCADE ON DELETE RESTRICT"
     )
 
-    # declare unique index
+    # Declare a supporting index on the foreign-key columns.
+    #
+    # MySQL/InnoDB creates one implicitly for every foreign key, so we emit an
+    # explicit index only on the PostgreSQL path — Postgres never auto-indexes
+    # the referencing (child) columns and offers no server setting to make it
+    # (see #1512). The `unique` case keeps its UNIQUE INDEX on every backend.
+    #
+    # Coverage-aware: skip when the foreign-key columns are already a left-prefix
+    # of the child's primary key, since the primary-key index then already serves
+    # foreign-key lookups and cascades. That holds exactly for a *leading*
+    # primary foreign key; a secondary foreign key (`primary_key is None`) or a
+    # non-leading primary foreign key is not covered and needs its own index.
+    fk_attrs = list(ref.primary_key)
     if is_unique:
-        index_cols = ", ".join(adapter.quote_identifier(attr) for attr in ref.primary_key)
+        index_cols = ", ".join(adapter.quote_identifier(attr) for attr in fk_attrs)
         index_sql.append(f"UNIQUE INDEX ({index_cols})")
+    elif adapter.backend == "postgresql":
+        covered_by_pk = primary_key is not None and list(primary_key[: len(fk_attrs)]) == fk_attrs
+        if not covered_by_pk:
+            index_cols = ", ".join(adapter.quote_identifier(attr) for attr in fk_attrs)
+            index_sql.append(f"INDEX ({index_cols})")
 
 
 def prepare_declare(

--- a/src/datajoint/declare.py
+++ b/src/datajoint/declare.py
@@ -321,7 +321,7 @@ def compile_foreign_key(
     if is_unique:
         index_cols = ", ".join(adapter.quote_identifier(attr) for attr in fk_attrs)
         index_sql.append(f"UNIQUE INDEX ({index_cols})")
-    elif adapter.backend == "postgresql" and fk_index_candidates is not None:
+    elif not adapter.auto_indexes_foreign_keys and fk_index_candidates is not None:
         fk_index_candidates.append(fk_attrs)
 
 

--- a/tests/integration/test_fk_index.py
+++ b/tests/integration/test_fk_index.py
@@ -1,0 +1,139 @@
+"""
+Tests for foreign-key supporting indexes on the PostgreSQL backend (#1512).
+
+MySQL/InnoDB auto-creates an index on every foreign key's referencing columns;
+PostgreSQL does not. DataJoint therefore emits an explicit, coverage-aware index
+on the Postgres path: one is created when the FK columns are NOT already a
+left-prefix of the child's primary key (secondary FKs, and FKs in a non-leading
+position of a composite PK), and skipped when they are (a leading primary FK,
+already served by the PK index).
+
+These tests are PostgreSQL-specific: on MySQL the equivalent index is created
+implicitly by InnoDB, not by DataJoint's DDL, so there is nothing of ours to
+assert.
+"""
+
+import time
+
+import pytest
+
+import datajoint as dj
+
+
+@pytest.fixture(scope="function")
+def schema_by_backend(connection_by_backend, db_creds_by_backend):
+    """Create a fresh schema per test, parameterized across backends."""
+    backend = db_creds_by_backend["backend"]
+    test_id = str(int(time.time() * 1000))[-8:]
+    schema_name = f"djtest_fkidx_{backend}_{test_id}"[:64]
+
+    if connection_by_backend.is_connected:
+        try:
+            connection_by_backend.query(
+                f"DROP DATABASE IF EXISTS {connection_by_backend.adapter.quote_identifier(schema_name)}"
+            )
+        except Exception:
+            pass
+
+    schema = dj.Schema(schema_name, connection=connection_by_backend)
+    yield schema
+
+    if connection_by_backend.is_connected:
+        try:
+            connection_by_backend.query(
+                f"DROP DATABASE IF EXISTS {connection_by_backend.adapter.quote_identifier(schema_name)}"
+            )
+        except Exception:
+            pass
+
+
+def _fk_support_indexes(conn, schema_name, table_name):
+    """Names of the DataJoint-created FK-support indexes (idx_*) on a table."""
+    rows = conn.query(
+        "SELECT indexname FROM pg_indexes "
+        f"WHERE schemaname = '{schema_name}' AND tablename = '{table_name}' "
+        "AND indexname LIKE 'idx%%'"
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def _indexes_covering(conn, schema_name, table_name, column):
+    """idx_* indexes on a table whose definition references `column`."""
+    rows = conn.query(
+        "SELECT indexname, indexdef FROM pg_indexes "
+        f"WHERE schemaname = '{schema_name}' AND tablename = '{table_name}' "
+        "AND indexname LIKE 'idx%%'"
+    ).fetchall()
+    return {name for name, defn in rows if column in defn}
+
+
+def test_secondary_fk_gets_index(schema_by_backend, db_creds_by_backend, connection_by_backend):
+    """A secondary foreign key (below the ---) is not in the child PK, so its
+    columns are unindexed by the PK; DataJoint must emit a supporting index."""
+    if db_creds_by_backend["backend"] != "postgresql":
+        pytest.skip("PostgreSQL-specific: MySQL/InnoDB indexes FK columns implicitly")
+
+    @schema_by_backend
+    class Master(dj.Manual):
+        definition = """
+        master_id : int32
+        """
+
+    @schema_by_backend
+    class Child(dj.Manual):
+        definition = """
+        child_id : int32
+        ---
+        -> Master
+        """
+
+    covering = _indexes_covering(connection_by_backend, schema_by_backend.database, Child.table_name, "master_id")
+    assert covering, "secondary FK column `master_id` must have a supporting index on PostgreSQL"
+
+
+def test_nonleading_primary_fk_gets_index(schema_by_backend, db_creds_by_backend, connection_by_backend):
+    """A primary FK in a non-leading position of a composite PK (PK = (b_id,
+    a_id), a_id from the FK) is not a left-prefix of the PK index, so it needs
+    its own index."""
+    if db_creds_by_backend["backend"] != "postgresql":
+        pytest.skip("PostgreSQL-specific")
+
+    @schema_by_backend
+    class A(dj.Manual):
+        definition = """
+        a_id : int32
+        """
+
+    @schema_by_backend
+    class B(dj.Manual):
+        definition = """
+        b_id : int32
+        -> A
+        """
+
+    covering = _indexes_covering(connection_by_backend, schema_by_backend.database, B.table_name, "a_id")
+    assert covering, "non-leading primary FK column `a_id` must have a supporting index on PostgreSQL"
+
+
+def test_leading_primary_fk_no_redundant_index(schema_by_backend, db_creds_by_backend, connection_by_backend):
+    """A leading primary FK (PK = (p_id, q_id), p_id from the FK) is a left-prefix
+    of the PK index, which already serves FK lookups; no extra index is created."""
+    if db_creds_by_backend["backend"] != "postgresql":
+        pytest.skip("PostgreSQL-specific")
+
+    @schema_by_backend
+    class P(dj.Manual):
+        definition = """
+        p_id : int32
+        """
+
+    @schema_by_backend
+    class Q(dj.Manual):
+        definition = """
+        -> P
+        q_id : int32
+        """
+
+    assert not _fk_support_indexes(
+        connection_by_backend, schema_by_backend.database, Q.table_name
+    ), "a leading primary FK is covered by the PK index; no redundant FK-support index should be created"

--- a/tests/integration/test_fk_index.py
+++ b/tests/integration/test_fk_index.py
@@ -137,3 +137,34 @@ def test_leading_primary_fk_no_redundant_index(schema_by_backend, db_creds_by_ba
     assert not _fk_support_indexes(
         connection_by_backend, schema_by_backend.database, Q.table_name
     ), "a leading primary FK is covered by the PK index; no redundant FK-support index should be created"
+
+
+def test_secondary_fk_covered_by_declared_index(schema_by_backend, db_creds_by_backend, connection_by_backend):
+    """A secondary FK whose columns are a left-prefix of a user-declared index
+    needs no separate FK-support index (post-parse coverage vs declared indexes)."""
+    if db_creds_by_backend["backend"] != "postgresql":
+        pytest.skip("PostgreSQL-specific")
+
+    @schema_by_backend
+    class Master(dj.Manual):
+        definition = """
+        master_id : int32
+        """
+
+    @schema_by_backend
+    class Child(dj.Manual):
+        definition = """
+        child_id : int32
+        ---
+        -> Master
+        note : varchar(16)
+        index (master_id, note)
+        """
+
+    # The declared index (master_id, note) already left-covers master_id, so no
+    # standalone FK-support index on master_id should be created.
+    names = _fk_support_indexes(connection_by_backend, schema_by_backend.database, Child.table_name)
+    assert (
+        f"idx_{Child.table_name}_master_id" not in names
+    ), f"a secondary FK covered by a declared index must not get a redundant FK-support index; got {names}"
+    assert f"idx_{Child.table_name}_master_id_note" in names, "the declared composite index should still exist"


### PR DESCRIPTION
Closes #1512.

## Why

PostgreSQL never auto-indexes a foreign key's **referencing** (child) columns and offers no server setting to change it — only MySQL/InnoDB does, implicitly. So on Postgres a non-unique FK was left with no supporting index, a performance cliff for cascade deletes, joins on the FK, and parent-existence checks on large child tables — and an asymmetry with MySQL.

## What

`declare.py`'s `compile_foreign_key()` now emits an explicit index on the FK columns **on the PostgreSQL DDL path only**, **coverage-aware**:

- **Skip** when the FK columns are already a **left-prefix of the child's primary key** — a *leading* primary FK, whose lookups the PK index already serves.
- **Emit** otherwise — a **secondary** FK (not in the PK) or a **non-leading** primary FK (e.g. PK `(b_id, a_id)` with `a_id` from the FK), neither covered by the PK index.

The coverage test is exactly `primary_key[:len(fk_attrs)] == fk_attrs`. MySQL continues to rely on InnoDB's implicit index (nothing emitted); the `unique` FK case keeps its `UNIQUE INDEX` on both backends. The existing Postgres DDL path already converts `INDEX (...)` entries to `CREATE INDEX` statements, so no new plumbing.

Per the issue decision: **index creation only** — the index *lifecycle* on FK drop / `.alter()` is deferred to the schema-changes design.

## Tests

`tests/integration/test_fk_index.py` (PostgreSQL-specific; MySQL cases skip since the index is InnoDB's, not ours):
- secondary FK → supporting index present;
- non-leading primary FK → supporting index present;
- leading primary FK → **no** redundant index.

Verified **failing without the fix** (negative control: the two positive tests fail) and passing with it; full `test_declare.py` + `test_cascade_delete.py` green on MySQL 8.0 and PostgreSQL 15 (52 passed, no regressions).

## Follow-up (not in this PR)

datajoint-docs #227 currently advises users to declare an explicit `index(...)` on Postgres; once this lands, that guidance flips back to "the database indexes FK columns." I'll pair the docs update with the spec reshape.

Draft pending review.